### PR TITLE
feat: configurable scheduled check schedule via settings UI

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -158,7 +158,7 @@ async def _apscheduler_startup_async() -> None:
             register_clickup_apscheduler_jobs()
             # Legacy Zillow jobs disabled — replaced by Sernia AI triggers below
             # register_zillow_apscheduler_jobs()
-            register_scheduled_triggers()
+            await register_scheduled_triggers()
 
         # Start the scheduler AFTER the span closes and with a clean OTel context.
         # APScheduler's internal event loop inherits the current trace context —

--- a/api/src/google/pubsub/routes.py
+++ b/api/src/google/pubsub/routes.py
@@ -203,12 +203,14 @@ async def process_gmail_notification(pubsub_notification_data: dict):
 
                     # Fire Zillow trigger only for new arrivals (added_message_ids),
                     # not label changes / read-unread / archiving.
+                    # Uses debounced queue: first email starts a 10-min window,
+                    # additional emails are batched, agent fires once at the end.
                     from_addr = processed_email_message.get("from_address", "")
                     is_new = email_message_id in added_message_ids
                     if is_new and from_addr and ("@zillow.com" in from_addr.lower() or ".zillow.com" in from_addr.lower()):
-                        from api.src.sernia_ai.triggers.zillow_email_event_trigger import handle_zillow_email_event
+                        from api.src.sernia_ai.triggers.zillow_email_event_trigger import queue_zillow_email_event
                         asyncio.create_task(
-                            handle_zillow_email_event(
+                            queue_zillow_email_event(
                                 thread_id=processed_email_message.get("thread_id", ""),
                                 message_id=processed_email_message.get("message_id", ""),
                                 subject=processed_email_message.get("subject", ""),

--- a/api/src/google/pubsub/routes.py
+++ b/api/src/google/pubsub/routes.py
@@ -207,7 +207,20 @@ async def process_gmail_notification(pubsub_notification_data: dict):
                     # additional emails are batched, agent fires once at the end.
                     from_addr = processed_email_message.get("from_address", "")
                     is_new = email_message_id in added_message_ids
-                    if is_new and from_addr and ("@zillow.com" in from_addr.lower() or ".zillow.com" in from_addr.lower()):
+                    is_zillow = bool(
+                        from_addr
+                        and ("@zillow.com" in from_addr.lower() or ".zillow.com" in from_addr.lower())
+                    )
+                    logfire.info(
+                        "zillow_trigger_gate",
+                        email_message_id=email_message_id,
+                        from_address=from_addr,
+                        is_new=is_new,
+                        is_zillow=is_zillow,
+                        added_message_ids=list(added_message_ids),
+                        subject=processed_email_message.get("subject", ""),
+                    )
+                    if is_new and is_zillow:
                         from api.src.sernia_ai.triggers.zillow_email_event_trigger import queue_zillow_email_event
                         asyncio.create_task(
                             queue_zillow_email_event(

--- a/api/src/sernia_ai/config.py
+++ b/api/src/sernia_ai/config.py
@@ -60,8 +60,9 @@ TRIGGER_BOT_NAME = "Sernia AI (Trigger)"
 # Google API delegation requires impersonating a real Google Workspace user.
 GOOGLE_DELEGATION_EMAIL = "emilio@serniacapital.com"
 
-# Scheduled check interval — runs during business hours (8am-5pm ET).
-SCHEDULED_CHECK_INTERVAL_HOURS = 3
+# Scheduled check defaults — overridable via DB-backed schedule_config setting.
+DEFAULT_SCHEDULE_DAYS_OF_WEEK = [0, 1, 2, 3, 4]  # Mon–Fri (APScheduler convention)
+DEFAULT_SCHEDULE_HOURS = [8, 11, 14, 17]  # 8am, 11am, 2pm, 5pm ET
 
 # Shared team contact ID in OpenPhone (Quo).
 # Phone number is looked up at runtime via the API — not hardcoded.

--- a/api/src/sernia_ai/routes.py
+++ b/api/src/sernia_ai/routes.py
@@ -709,18 +709,28 @@ async def get_admin_settings(
     user: SerniaUser = Depends(_get_sernia_user),
     session: DBSession = None,
 ):
-    """Return current app settings."""
+    """Return current app settings including schedule config."""
+    from api.src.sernia_ai.triggers.scheduled_triggers import get_schedule_config
+
     result = await session.execute(
         select(AppSetting).where(AppSetting.key == "triggers_enabled")
     )
     row = result.scalar_one_or_none()
+    schedule_config = await get_schedule_config()
     return {
         "triggers_enabled": row.value if row else _IS_PRODUCTION,
+        "schedule_config": schedule_config,
     }
+
+
+class _ScheduleConfigPayload(BaseModel):
+    days_of_week: list[int]  # 0=Mon … 6=Sun
+    hours: list[int]  # 0–23, ET
 
 
 class _SettingsUpdateRequest(BaseModel):
     triggers_enabled: bool | None = None
+    schedule_config: _ScheduleConfigPayload | None = None
 
 
 @router.patch("/admin/settings")
@@ -729,7 +739,7 @@ async def update_admin_settings(
     user: SerniaUser = Depends(_get_sernia_user),
     session: DBSession = None,
 ):
-    """Update app settings (upsert)."""
+    """Update app settings (upsert). Re-registers the scheduled job when schedule changes."""
     updated = {}
     if body.triggers_enabled is not None:
         stmt = pg_insert(AppSetting).values(
@@ -742,6 +752,35 @@ async def update_admin_settings(
         await session.execute(stmt)
         await session.commit()
         updated["triggers_enabled"] = body.triggers_enabled
+
+    if body.schedule_config is not None:
+        # Validate ranges
+        for d in body.schedule_config.days_of_week:
+            if d < 0 or d > 6:
+                raise HTTPException(status_code=422, detail=f"Invalid day_of_week: {d}")
+        for h in body.schedule_config.hours:
+            if h < 0 or h > 23:
+                raise HTTPException(status_code=422, detail=f"Invalid hour: {h}")
+        if not body.schedule_config.hours:
+            raise HTTPException(status_code=422, detail="At least one hour is required")
+        if not body.schedule_config.days_of_week:
+            raise HTTPException(status_code=422, detail="At least one day is required")
+
+        config_dict = body.schedule_config.model_dump()
+        stmt = pg_insert(AppSetting).values(
+            key="schedule_config",
+            value=config_dict,
+        ).on_conflict_do_update(
+            index_elements=["key"],
+            set_={"value": config_dict},
+        )
+        await session.execute(stmt)
+        await session.commit()
+        updated["schedule_config"] = config_dict
+
+        # Re-register the APScheduler job with the new config
+        from api.src.sernia_ai.triggers.scheduled_triggers import apply_schedule_from_db
+        await apply_schedule_from_db()
 
     return {"updated": updated}
 

--- a/api/src/sernia_ai/triggers/README.md
+++ b/api/src/sernia_ai/triggers/README.md
@@ -97,7 +97,7 @@ sequenceDiagram
 
 ## Zillow Email Event Trigger Flow
 
-Real-time Zillow lead processing. When a new email arrives via Gmail Pub/Sub and is from `zillow.com`, the trigger fires immediately (not on a schedule).
+Debounced Zillow lead processing. When a new email from `zillow.com` arrives via Gmail Pub/Sub, it is **queued** rather than processed immediately. The first email starts a 10-minute debounce window; any additional Zillow emails within that window are accumulated. After the window closes, the agent fires **once** and sees all batched emails — this lets it assess multiple leads or thread updates in a single run.
 
 **Phase 1 (Training):** Agent drafts a reply but does NOT send it. Emilio receives a targeted push notification to review the draft in web chat. The detailed guide lives in `.workspace/areas/zillow_auto_reply.md` — editable without code deploys.
 
@@ -108,17 +108,22 @@ flowchart TD
     PUBSUB["google/pubsub/routes.py<br/>handle_gmail_notifications()"] --> SAVE["save_email_message()"]
     SAVE --> CHECK{"is_zillow_email()<br/>(from_address)"}
     CHECK -->|No| DONE["Normal email processing"]
-    CHECK -->|Yes| FIRE["asyncio.create_task()<br/>handle_zillow_email_event()"]
+    CHECK -->|Yes| QUEUE["queue_zillow_email_event()<br/>(accumulate in pending list)"]
+
+    QUEUE --> PENDING{"Debounce timer<br/>already running?"}
+    PENDING -->|Yes| BATCH["Add to batch,<br/>wait for timer"]
+    PENDING -->|No| TIMER["Start 10-min<br/>debounce timer"]
+
+    TIMER --> SLEEP["asyncio.sleep(600)"]
+    SLEEP --> FIRE["_fire_batched_trigger()<br/>(all accumulated emails)"]
 
     FIRE --> RUNNER["background_agent_runner.<br/>run_agent_for_trigger()"]
     RUNNER --> ENABLED{"Triggers<br/>enabled?"}
     ENABLED -->|No| SKIP["Skip (disabled)"]
-    ENABLED -->|Yes| RATE{"Rate limited?<br/>(2 min per thread_id)"}
-    RATE -->|Yes| SKIP2["Skip"]
-    RATE -->|No| AGENT["Run sernia_agent<br/>with trigger prompt"]
+    ENABLED -->|Yes| AGENT["Run sernia_agent<br/>with batch prompt"]
 
     AGENT --> GUIDE["Agent reads<br/>areas/zillow_auto_reply.md"]
-    GUIDE --> THREAD["Agent reads full<br/>email thread via search_emails"]
+    GUIDE --> THREAD["Agent reads each email<br/>via search_emails"]
     THREAD --> DECIDE{"Reply<br/>warranted?"}
     DECIDE -->|No| NOACTION["NoAction + reason"]
     DECIDE -->|Yes| DRAFT["Draft reply in<br/>conversation output"]
@@ -128,10 +133,10 @@ flowchart TD
 
 ### Key design choices
 
+- **10-minute debounce** — First email starts a fixed window; subsequent emails are accumulated. The agent fires once at the end with the full batch, so it can see all new leads at once. This prevents N agent runs for N emails arriving in quick succession.
 - **Trigger instructions stay lean** — point to `areas/zillow_auto_reply.md` for detailed guidance (qualification criteria, availability schedule, response tone). This allows iterating on AI behavior without code deploys.
 - **Emilio-only notifications** — looks up Emilio's `clerk_user_id` from DB via contact slug `"emilio"` (cached at module level), then uses `notify_clerk_user_id` parameter in `run_agent_for_trigger()` to send push only to Emilio's subscriptions via `notify_user_push()`.
-- **Rate limiting** — keyed by `thread:{thread_id}` so the same thread doesn't fire multiple triggers within 2 minutes.
-- **Coexists with scheduled check** — `run_scheduled_checks()` still runs every 3 hours as a safety net, catching anything the event trigger misses (e.g., server downtime).
+- **Coexists with scheduled check** — `run_scheduled_checks()` still runs as a safety net, catching anything the event trigger misses (e.g., server downtime).
 
 ## Scheduled Trigger Flow
 

--- a/api/src/sernia_ai/triggers/README.md
+++ b/api/src/sernia_ai/triggers/README.md
@@ -139,9 +139,11 @@ A single scheduled job via APScheduler in `scheduled_triggers.py`:
 
 | Job | Interval | Scope |
 |-----|----------|-------|
-| `run_scheduled_checks()` | 3 hours (8am-5pm ET) | All inbox checks — agent follows the `scheduled-checks` skill |
+| `run_scheduled_checks()` | Configurable (default: Mon–Fri at 8am, 11am, 2pm, 5pm ET) | All inbox checks — agent follows the `scheduled-checks` skill |
 
-The trigger is a thin function that provides a lookback window and points the agent to the `scheduled-checks` workspace skill. All domain logic (what to check, how to assess, output rules) lives in `skills/scheduled-checks/SKILL.md`, not in trigger code.
+The schedule is configurable via the Settings page (`/sernia-settings`) or the `schedule_config` key in `app_settings`. The DB-backed config stores `days_of_week` (0=Mon … 6=Sun) and `hours` (ET, 24-hour). Changes take effect immediately — the APScheduler job is re-registered on save.
+
+The trigger is a thin function that points the agent to the `scheduled-checks` workspace skill. All domain logic (what to check, how to assess, output rules) lives in `skills/scheduled-checks/SKILL.md`, not in trigger code.
 
 Uses `background_agent_runner.run_agent_for_trigger()` with the silent/alert pattern. When the agent uses the `NoAction` structured output, the runner persists the conversation but skips push notifications.
 
@@ -199,5 +201,6 @@ Separate sliding-window rate limiter in `ai_sms_event_trigger.py`:
 | `QUO_SERNIA_AI_PHONE_ID` | AI's phone line (used for SMS replies and team notifications) |
 | `QUO_INTERNAL_COMPANY` | `"Sernia Capital LLC"` — gate for AI SMS contact verification |
 | `SMS_CONVERSATION_MAX_MESSAGES` | Max messages to fetch from OpenPhone for SMS conversation bootstrap (20) |
-| `SCHEDULED_CHECK_INTERVAL_HOURS` | Scheduled check frequency (3 hours, business hours only) |
+| `DEFAULT_SCHEDULE_DAYS_OF_WEEK` | Default days (Mon–Fri) — overridden by `schedule_config` DB setting |
+| `DEFAULT_SCHEDULE_HOURS` | Default hours (`[8,11,14,17]` ET) — overridden by `schedule_config` DB setting |
 | `EMILIO_CONTACT_SLUG` | `"emilio"` — contact slug used to look up Emilio's `clerk_user_id` from DB (contacts → users join) |

--- a/api/src/sernia_ai/triggers/scheduled_triggers.py
+++ b/api/src/sernia_ai/triggers/scheduled_triggers.py
@@ -3,12 +3,31 @@ Scheduled triggers for the Sernia AI agent.
 
 One job wakes the agent up periodically. All instructions live in the
 scheduled-checks workspace skill.
+
+Schedule is configurable via the ``schedule_config`` AppSetting (JSONB):
+    {
+        "days_of_week": [0, 1, 2, 3, 4],   # 0=Mon … 6=Sun
+        "hours": [8, 11, 14, 17]             # ET hours (24-h)
+    }
+
+Falls back to DEFAULT_SCHEDULE_* constants in config.py when no DB row exists.
 """
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
 import logfire
+from sqlalchemy import select
 
 from api.src.apscheduler_service.service import get_scheduler, upsert_job
-from api.src.sernia_ai.config import SCHEDULED_CHECK_INTERVAL_HOURS
+from api.src.sernia_ai.config import (
+    DEFAULT_SCHEDULE_DAYS_OF_WEEK,
+    DEFAULT_SCHEDULE_HOURS,
+)
 from api.src.sernia_ai.triggers.background_agent_runner import run_agent_for_trigger
+
+JOB_ID = "sernia_scheduled_checks"
+ET = ZoneInfo("America/New_York")
 
 
 async def run_scheduled_checks() -> None:
@@ -21,22 +40,69 @@ async def run_scheduled_checks() -> None:
     )
 
 
-def register_scheduled_triggers() -> None:
-    """Register Sernia AI scheduled trigger with APScheduler."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _apply_schedule(days_of_week: list[int], hours: list[int]) -> None:
+    """Register (or re-register) the APScheduler cron job with the given config."""
     scheduler = get_scheduler()
+    day_expr = ",".join(str(d) for d in sorted(days_of_week)) if days_of_week else "0-6"
+    hour_expr = ",".join(str(h) for h in sorted(hours)) if hours else "8"
 
-    from zoneinfo import ZoneInfo
-
-    # Business hours: 8am-5pm ET
     upsert_job(
         scheduler,
         func=run_scheduled_checks,
         trigger="cron",
-        hour=f"8-17/{SCHEDULED_CHECK_INTERVAL_HOURS}",
+        day_of_week=day_expr,
+        hour=hour_expr,
         minute=0,
-        timezone=ZoneInfo("America/New_York"),
-        id="sernia_scheduled_checks",
+        timezone=ET,
+        id=JOB_ID,
         name="Sernia AI: Scheduled Checks",
     )
+    logfire.info(
+        "Sernia AI scheduled trigger registered",
+        days_of_week=day_expr,
+        hours=hour_expr,
+    )
 
-    logfire.info("Sernia AI scheduled triggers registered")
+
+async def get_schedule_config() -> dict:
+    """Read schedule_config from DB, returning defaults if not set."""
+    from api.src.database.database import AsyncSessionFactory
+    from api.src.sernia_ai.models import AppSetting
+
+    defaults = {
+        "days_of_week": DEFAULT_SCHEDULE_DAYS_OF_WEEK,
+        "hours": DEFAULT_SCHEDULE_HOURS,
+    }
+    try:
+        async with AsyncSessionFactory() as session:
+            result = await session.execute(
+                select(AppSetting.value).where(AppSetting.key == "schedule_config")
+            )
+            row = result.scalar_one_or_none()
+            if row is not None and isinstance(row, dict):
+                return {
+                    "days_of_week": row.get("days_of_week", defaults["days_of_week"]),
+                    "hours": row.get("hours", defaults["hours"]),
+                }
+    except Exception:
+        logfire.warn("Failed to read schedule_config from DB, using defaults")
+    return defaults
+
+
+async def apply_schedule_from_db() -> None:
+    """Read config from DB and (re-)register the scheduled job."""
+    config = await get_schedule_config()
+    _apply_schedule(config["days_of_week"], config["hours"])
+
+
+# ---------------------------------------------------------------------------
+# Startup
+# ---------------------------------------------------------------------------
+
+async def register_scheduled_triggers() -> None:
+    """Register Sernia AI scheduled trigger with APScheduler (reads config from DB)."""
+    await apply_schedule_from_db()

--- a/api/src/sernia_ai/triggers/zillow_email_event_trigger.py
+++ b/api/src/sernia_ai/triggers/zillow_email_event_trigger.py
@@ -1,13 +1,16 @@
 """
 Zillow email event trigger for the Sernia AI agent.
 
-Fires in real-time when a new Zillow email arrives via Gmail Pub/Sub.
-The agent drafts a response (Phase 1: no email sent) and sends a push
-notification to Emilio for review.
+Fires when new Zillow emails arrive via Gmail Pub/Sub, but **debounced**:
+the first email starts a 10-minute window; any additional Zillow emails
+during that window are accumulated.  The agent fires once at the end of
+the window so it can assess all accumulated emails in a single run.
 
 Naming convention: all public symbols use the ``zillow_email_event`` root.
 """
+from __future__ import annotations
 
+import asyncio
 import uuid
 from textwrap import dedent
 
@@ -15,6 +18,17 @@ import logfire
 
 from api.src.sernia_ai.config import EMILIO_CONTACT_SLUG, FRONTEND_BASE_URL
 from api.src.sernia_ai.triggers.background_agent_runner import run_agent_for_trigger
+
+# ---------------------------------------------------------------------------
+# Debounce configuration
+# ---------------------------------------------------------------------------
+DEBOUNCE_SECONDS = 600  # 10 minutes
+
+# Module-level state for the debounce window.
+# _pending_emails accumulates email info dicts; _pending_task is the asyncio
+# task that sleeps for DEBOUNCE_SECONDS and then fires the trigger.
+_pending_emails: list[dict] = []
+_pending_task: asyncio.Task | None = None
 
 # Module-level cache for Emilio's clerk_user_id (looked up once from DB).
 _emilio_clerk_user_id: str | None = None
@@ -48,64 +62,131 @@ def is_zillow_email(from_address: str) -> bool:
     return addr.endswith("@zillow.com") or "@" in addr and addr.split("@", 1)[1].endswith(".zillow.com")
 
 
-async def handle_zillow_email_event(
+# ---------------------------------------------------------------------------
+# Public API — called from pubsub webhook
+# ---------------------------------------------------------------------------
+
+async def queue_zillow_email_event(
     *,
     thread_id: str,
     message_id: str = "",
     subject: str,
     from_address: str,
     body_text: str | None,
-) -> str | None:
+) -> None:
     """
-    Process a newly arrived Zillow email in real-time.
+    Queue a Zillow email for debounced processing.
 
-    Called from the Gmail Pub/Sub webhook after the email is saved to the DB.
-    The agent reads the full thread via its email tools, drafts a reply,
-    and we push-notify Emilio with the result.
-
-    Returns the conversation_id if a draft was created, None otherwise.
+    The first email in a quiet period starts a 10-minute timer.  All
+    subsequent emails within that window are accumulated.  When the timer
+    fires, the agent runs once and sees every email in the batch.
     """
+    global _pending_task
+
+    email_info = {
+        "thread_id": thread_id,
+        "message_id": message_id,
+        "subject": subject,
+        "from_address": from_address,
+        "body_text": body_text,
+    }
+    _pending_emails.append(email_info)
+
+    if _pending_task is not None and not _pending_task.done():
+        logfire.info(
+            "zillow_email_event: batched with pending trigger",
+            pending_count=len(_pending_emails),
+            subject=subject,
+        )
+        return
+
     logfire.info(
-        "zillow_email_event: handling",
-        thread_id=thread_id,
-        message_id=message_id,
+        "zillow_email_event: starting debounce window",
+        debounce_seconds=DEBOUNCE_SECONDS,
         subject=subject,
-        from_address=from_address,
+    )
+    _pending_task = asyncio.create_task(_debounced_fire())
+
+
+async def _debounced_fire() -> None:
+    """Sleep for the debounce window, then fire the trigger with all accumulated emails."""
+    await asyncio.sleep(DEBOUNCE_SECONDS)
+
+    # Snapshot and clear the pending list atomically
+    emails = _pending_emails.copy()
+    _pending_emails.clear()
+
+    if not emails:
+        return
+
+    logfire.info(
+        "zillow_email_event: debounce window closed, firing trigger",
+        email_count=len(emails),
     )
 
-    # Pre-generate conversation ID so we can embed a deeplink in the prompt
+    try:
+        await _fire_batched_trigger(emails)
+    except Exception:
+        logfire.exception("zillow_email_event: batched trigger failed")
+
+
+# ---------------------------------------------------------------------------
+# Trigger execution
+# ---------------------------------------------------------------------------
+
+async def _fire_batched_trigger(emails: list[dict]) -> str | None:
+    """Run the agent once for a batch of Zillow emails."""
     conv_id = str(uuid.uuid4())
     deeplink = f"{FRONTEND_BASE_URL}/sernia-chat?id={conv_id}"
 
-    # Build a snippet of the email body for the trigger prompt
-    body_snippet = ""
-    if body_text:
-        body_snippet = body_text[:500].strip()
-        if len(body_text) > 500:
-            body_snippet += "..."
+    # Build a summary of all emails in the batch
+    if len(emails) == 1:
+        email = emails[0]
+        body_snippet = ""
+        if email.get("body_text"):
+            body_snippet = email["body_text"][:500].strip()
+            if len(email["body_text"]) > 500:
+                body_snippet += "..."
+        email_details = dedent(f"""\
+            **Email details:**
+            - Gmail Message ID (all@ account): {email['message_id']}
+            - Thread ID (Gmail): {email['thread_id']}
+            - Subject: {email['subject']}
+            - From: {email['from_address']}
+            - Body preview: {body_snippet}""")
+        reply_hint = f'When replying, pass reply_to_message_id="{email["message_id"]}" to thread correctly.'
+    else:
+        lines = []
+        for i, email in enumerate(emails, 1):
+            lines.append(
+                f"{i}. Subject: {email['subject']} | From: {email['from_address']} "
+                f"| Message ID: {email['message_id']} | Thread ID: {email['thread_id']}"
+            )
+        email_details = "**Emails received (oldest first):**\n" + "\n".join(lines)
+        reply_hint = (
+            "For each email that needs a reply, pass the corresponding reply_to_message_id to thread correctly."
+        )
+
+    subjects_preview = ", ".join(e["subject"][:50] for e in emails[:3])
+    if len(emails) > 3:
+        subjects_preview += f" (+{len(emails) - 3} more)"
 
     trigger_prompt = dedent(f"""\
-        New Zillow email arrived. Load the zillow-auto-reply skill and follow it.
+        {len(emails)} new Zillow email(s) arrived. Load the zillow-auto-reply skill and follow it.
 
-        **Email details:**
-        - Gmail Message ID (all@ account): {message_id}
-        - Thread ID (Gmail): {thread_id}
-        - Subject: {subject}
-        - From: {from_address}
-        - Body preview: {body_snippet}
+        {email_details}
         - Conversation deeplink: {deeplink}
 
-        Read the email using the Message ID above, then draft or NoAction.
-        When replying, pass reply_to_message_id="{message_id}" to thread correctly.
+        Read each email using its Message ID, then draft replies or NoAction per email.
+        {reply_hint}
         Always search/read from all@serniacapital.com (use user_email_account="all@serniacapital.com").""")
 
     trigger_metadata = {
         "trigger_source": "zillow_email_event",
         "trigger_type": "email_event",
-        "thread_id": thread_id,
-        "message_id": message_id,
-        "subject": subject,
-        "from_address": from_address,
+        "email_count": len(emails),
+        "subjects": [e["subject"] for e in emails],
+        "thread_ids": list({e["thread_id"] for e in emails}),
     }
 
     emilio_clerk_id = await _get_emilio_clerk_user_id()
@@ -114,20 +195,18 @@ async def handle_zillow_email_event(
         trigger_source="zillow_email_event",
         trigger_prompt=trigger_prompt,
         trigger_metadata=trigger_metadata,
-        notification_title="Zillow Draft Ready",
-        notification_body=f"Re: {subject[:80]}",
-        rate_limit_key=f"thread:{thread_id}",
+        notification_title=f"Zillow Draft Ready ({len(emails)} email{'s' if len(emails) != 1 else ''})",
+        notification_body=f"Re: {subjects_preview}",
+        rate_limit_key="zillow_batch",
         notify_clerk_user_id=emilio_clerk_id,
         conversation_id=conv_id,
     )
 
     logfire.info(
-        "zillow_email_event: completed",
-        thread_id=thread_id,
-        subject=subject,
+        "zillow_email_event: batched trigger completed",
+        email_count=len(emails),
         conversation_id=conversation_id,
         draft_created=conversation_id is not None,
-        notify_target=emilio_clerk_id or "none (fallback to broadcast)",
     )
 
     return conversation_id

--- a/api/src/tests/test_triggers.py
+++ b/api/src/tests/test_triggers.py
@@ -93,11 +93,13 @@ class TestSmoke:
     def test_zillow_email_event_trigger_imports(self):
         from api.src.sernia_ai.triggers.zillow_email_event_trigger import (
             is_zillow_email,
-            handle_zillow_email_event,
+            queue_zillow_email_event,
+            _fire_batched_trigger,
             _get_emilio_clerk_user_id,
         )
         assert callable(is_zillow_email)
-        assert callable(handle_zillow_email_event)
+        assert callable(queue_zillow_email_event)
+        assert callable(_fire_batched_trigger)
         assert callable(_get_emilio_clerk_user_id)
 
     def test_notify_user_push_imports(self):
@@ -1081,12 +1083,12 @@ class TestGetEmilioClerkUserId:
             assert result is None
 
 
-class TestHandleZillowEmailEvent:
-    """Test the main handle_zillow_email_event handler."""
+class TestZillowEmailBatchedTrigger:
+    """Test _fire_batched_trigger (the core trigger logic after debounce)."""
 
     @pytest.mark.asyncio
-    async def test_calls_runner_with_zillow_email_event_source(self):
-        """Should call run_agent_for_trigger with correct source and metadata."""
+    async def test_single_email_calls_runner_with_correct_source(self):
+        """Single-email batch should call run_agent_for_trigger with correct source and metadata."""
         with (
             patch("api.src.sernia_ai.triggers.zillow_email_event_trigger.run_agent_for_trigger") as mock_run,
             patch("api.src.sernia_ai.triggers.zillow_email_event_trigger._get_emilio_clerk_user_id",
@@ -1094,35 +1096,33 @@ class TestHandleZillowEmailEvent:
         ):
             mock_run.return_value = "conv-zillow-1"
 
-            from api.src.sernia_ai.triggers.zillow_email_event_trigger import handle_zillow_email_event
+            from api.src.sernia_ai.triggers.zillow_email_event_trigger import _fire_batched_trigger
 
-            result = await handle_zillow_email_event(
-                thread_id="thread_abc123",
-                subject="Rental Inquiry - 320 S Mathilda",
-                from_address="noreply@zillow.com",
-                body_text="Hi, I'm interested in the 1BR unit.",
-            )
+            emails = [{
+                "thread_id": "thread_abc123",
+                "message_id": "msg_1",
+                "subject": "Rental Inquiry - 320 S Mathilda",
+                "from_address": "noreply@zillow.com",
+                "body_text": "Hi, I'm interested in the 1BR unit.",
+            }]
+
+            result = await _fire_batched_trigger(emails)
 
             assert result == "conv-zillow-1"
             mock_run.assert_called_once()
             call_kwargs = mock_run.call_args[1]
             assert call_kwargs["trigger_source"] == "zillow_email_event"
-            assert call_kwargs["notification_title"] == "Zillow Draft Ready"
             assert "320 S Mathilda" in call_kwargs["notification_body"]
-            assert call_kwargs["rate_limit_key"] == "thread:thread_abc123"
             assert call_kwargs["notify_clerk_user_id"] == "user_emilio_123"
 
-            # Metadata should include thread context
             meta = call_kwargs["trigger_metadata"]
             assert meta["trigger_source"] == "zillow_email_event"
             assert meta["trigger_type"] == "email_event"
-            assert meta["thread_id"] == "thread_abc123"
-            assert meta["subject"] == "Rental Inquiry - 320 S Mathilda"
-            assert meta["from_address"] == "noreply@zillow.com"
+            assert meta["email_count"] == 1
 
     @pytest.mark.asyncio
     async def test_includes_body_snippet_in_prompt(self):
-        """Trigger prompt should include a preview of the email body."""
+        """Single-email trigger prompt should include a preview of the email body."""
         with (
             patch("api.src.sernia_ai.triggers.zillow_email_event_trigger.run_agent_for_trigger") as mock_run,
             patch("api.src.sernia_ai.triggers.zillow_email_event_trigger._get_emilio_clerk_user_id",
@@ -1130,14 +1130,15 @@ class TestHandleZillowEmailEvent:
         ):
             mock_run.return_value = None
 
-            from api.src.sernia_ai.triggers.zillow_email_event_trigger import handle_zillow_email_event
+            from api.src.sernia_ai.triggers.zillow_email_event_trigger import _fire_batched_trigger
 
-            await handle_zillow_email_event(
-                thread_id="thread_xyz",
-                subject="Inquiry",
-                from_address="noreply@zillow.com",
-                body_text="I have great credit and want to move in July.",
-            )
+            await _fire_batched_trigger([{
+                "thread_id": "thread_xyz",
+                "message_id": "msg_2",
+                "subject": "Inquiry",
+                "from_address": "noreply@zillow.com",
+                "body_text": "I have great credit and want to move in July.",
+            }])
 
             call_kwargs = mock_run.call_args[1]
             assert "great credit" in call_kwargs["trigger_prompt"]
@@ -1152,14 +1153,15 @@ class TestHandleZillowEmailEvent:
         ):
             mock_run.return_value = None
 
-            from api.src.sernia_ai.triggers.zillow_email_event_trigger import handle_zillow_email_event
+            from api.src.sernia_ai.triggers.zillow_email_event_trigger import _fire_batched_trigger
 
-            await handle_zillow_email_event(
-                thread_id="thread_null",
-                subject="Test",
-                from_address="noreply@zillow.com",
-                body_text=None,
-            )
+            await _fire_batched_trigger([{
+                "thread_id": "thread_null",
+                "message_id": "msg_3",
+                "subject": "Test",
+                "from_address": "noreply@zillow.com",
+                "body_text": None,
+            }])
 
             mock_run.assert_called_once()
 
@@ -1173,14 +1175,15 @@ class TestHandleZillowEmailEvent:
         ):
             mock_run.return_value = None
 
-            from api.src.sernia_ai.triggers.zillow_email_event_trigger import handle_zillow_email_event
+            from api.src.sernia_ai.triggers.zillow_email_event_trigger import _fire_batched_trigger
 
-            result = await handle_zillow_email_event(
-                thread_id="thread_cold",
-                subject="Re: Tour - 320 S Mathilda",
-                from_address="noreply@zillow.com",
-                body_text="Thanks, we'll let you know.",
-            )
+            result = await _fire_batched_trigger([{
+                "thread_id": "thread_cold",
+                "message_id": "msg_4",
+                "subject": "Re: Tour - 320 S Mathilda",
+                "from_address": "noreply@zillow.com",
+                "body_text": "Thanks, we'll let you know.",
+            }])
 
             assert result is None
 
@@ -1194,14 +1197,15 @@ class TestHandleZillowEmailEvent:
         ):
             mock_run.return_value = "conv-fallback"
 
-            from api.src.sernia_ai.triggers.zillow_email_event_trigger import handle_zillow_email_event
+            from api.src.sernia_ai.triggers.zillow_email_event_trigger import _fire_batched_trigger
 
-            await handle_zillow_email_event(
-                thread_id="thread_fb",
-                subject="Inquiry",
-                from_address="noreply@zillow.com",
-                body_text="Hello",
-            )
+            await _fire_batched_trigger([{
+                "thread_id": "thread_fb",
+                "message_id": "msg_5",
+                "subject": "Inquiry",
+                "from_address": "noreply@zillow.com",
+                "body_text": "Hello",
+            }])
 
             call_kwargs = mock_run.call_args[1]
             assert call_kwargs["notify_clerk_user_id"] is None
@@ -1216,21 +1220,49 @@ class TestHandleZillowEmailEvent:
         ):
             mock_run.return_value = None
 
-            from api.src.sernia_ai.triggers.zillow_email_event_trigger import handle_zillow_email_event
+            from api.src.sernia_ai.triggers.zillow_email_event_trigger import _fire_batched_trigger
 
-            await handle_zillow_email_event(
-                thread_id="t1",
-                subject="Test",
-                from_address="noreply@zillow.com",
-                body_text="Test body",
-            )
+            await _fire_batched_trigger([{
+                "thread_id": "t1",
+                "message_id": "msg_6",
+                "subject": "Test",
+                "from_address": "noreply@zillow.com",
+                "body_text": "Test body",
+            }])
 
             call_kwargs = mock_run.call_args[1]
             prompt = call_kwargs["trigger_prompt"]
             assert "zillow-auto-reply" in prompt  # references the skill
             assert "sernia-chat?id=" in prompt  # deeplink embedded
-            assert "trigger_instructions" not in call_kwargs  # guardrails live in skill now
             assert call_kwargs["conversation_id"] is not None
+
+    @pytest.mark.asyncio
+    async def test_multi_email_batch_prompt(self):
+        """Multi-email batch should list all emails in the prompt."""
+        with (
+            patch("api.src.sernia_ai.triggers.zillow_email_event_trigger.run_agent_for_trigger") as mock_run,
+            patch("api.src.sernia_ai.triggers.zillow_email_event_trigger._get_emilio_clerk_user_id",
+                  new_callable=AsyncMock, return_value=None),
+        ):
+            mock_run.return_value = "conv-batch"
+
+            from api.src.sernia_ai.triggers.zillow_email_event_trigger import _fire_batched_trigger
+
+            emails = [
+                {"thread_id": "t1", "message_id": "m1", "subject": "Inquiry A", "from_address": "a@zillow.com", "body_text": "A"},
+                {"thread_id": "t2", "message_id": "m2", "subject": "Inquiry B", "from_address": "b@zillow.com", "body_text": "B"},
+            ]
+
+            result = await _fire_batched_trigger(emails)
+
+            assert result == "conv-batch"
+            call_kwargs = mock_run.call_args[1]
+            prompt = call_kwargs["trigger_prompt"]
+            assert "2 new Zillow email(s)" in prompt
+            assert "Inquiry A" in prompt
+            assert "Inquiry B" in prompt
+            assert call_kwargs["trigger_metadata"]["email_count"] == 2
+            assert "2 email" in call_kwargs["notification_title"]
 
 
 class TestBackgroundRunnerTargetedPush:

--- a/apps/web-react-router/app/routes/sernia-admin.tsx
+++ b/apps/web-react-router/app/routes/sernia-admin.tsx
@@ -73,6 +73,7 @@ import {
   ArrowUpDown,
   ArrowDown,
   ArrowUp,
+  Settings,
 } from "lucide-react";
 
 const API_BASE = "/api/sernia-ai";
@@ -591,6 +592,15 @@ export default function SerniaAdminPage() {
           <div className="flex-1 min-w-0">
             <h1 className="text-lg font-semibold">Conversations</h1>
           </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => navigate("/sernia-settings")}
+            title="Schedule & trigger settings"
+          >
+            <Settings className="w-4 h-4" />
+          </Button>
           <Button
             variant="outline"
             size="sm"

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -1152,6 +1152,15 @@ export default function SerniaChatPage() {
                 >
                   <LayoutList className="w-4 h-4" />
                 </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => navigate("/sernia-settings")}
+                  title="Schedule & trigger settings"
+                >
+                  <Settings className="w-4 h-4" />
+                </Button>
               </>
             )}
           </div>

--- a/apps/web-react-router/app/routes/sernia-settings.tsx
+++ b/apps/web-react-router/app/routes/sernia-settings.tsx
@@ -1,0 +1,367 @@
+import type { Route } from "./+types/sernia-settings";
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router";
+import { useAuth } from "@clerk/react-router";
+import { AuthGuard } from "~/components/auth-guard";
+import { Button } from "~/components/ui/button";
+import { Switch } from "~/components/ui/switch";
+import { Label } from "~/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "~/components/ui/card";
+import { Badge } from "~/components/ui/badge";
+import { cn } from "~/lib/utils";
+import {
+  Building,
+  Loader2,
+  ArrowLeft,
+  Save,
+  RotateCcw,
+} from "lucide-react";
+
+const API_BASE = "/api/sernia-ai";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Sernia Settings" },
+    { name: "description", content: "Configure Sernia AI triggers and schedule." },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DAYS = [
+  { value: 0, label: "Mon" },
+  { value: 1, label: "Tue" },
+  { value: 2, label: "Wed" },
+  { value: 3, label: "Thu" },
+  { value: 4, label: "Fri" },
+  { value: 5, label: "Sat" },
+  { value: 6, label: "Sun" },
+] as const;
+
+function formatHour(h: number) {
+  if (h === 0) return "12am";
+  if (h < 12) return `${h}am`;
+  if (h === 12) return "12pm";
+  return `${h - 12}pm`;
+}
+
+// Business-hour range for the grid (5am–11pm covers realistic use)
+const HOUR_OPTIONS = Array.from({ length: 19 }, (_, i) => i + 5); // 5..23
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface ScheduleConfig {
+  days_of_week: number[];
+  hours: number[];
+}
+
+interface Settings {
+  triggers_enabled: boolean;
+  schedule_config: ScheduleConfig;
+}
+
+export default function SerniaSettingsPage() {
+  const { getToken } = useAuth();
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Settings state
+  const [triggersEnabled, setTriggersEnabled] = useState(false);
+  const [days, setDays] = useState<number[]>([0, 1, 2, 3, 4]);
+  const [hours, setHours] = useState<number[]>([8, 11, 14, 17]);
+
+  // Snapshot of last-saved values to detect dirty state
+  const [saved, setSaved] = useState<Settings | null>(null);
+
+  const isDirty =
+    saved !== null &&
+    (triggersEnabled !== saved.triggers_enabled ||
+      JSON.stringify([...days].sort()) !== JSON.stringify([...saved.schedule_config.days_of_week].sort()) ||
+      JSON.stringify([...hours].sort()) !== JSON.stringify([...saved.schedule_config.hours].sort()));
+
+  // Fetch settings
+  const fetchSettings = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      const res = await fetch(`${API_BASE}/admin/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const data: Settings = await res.json();
+      setTriggersEnabled(data.triggers_enabled);
+      setDays(data.schedule_config.days_of_week);
+      setHours(data.schedule_config.hours);
+      setSaved(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load settings");
+    } finally {
+      setLoading(false);
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    fetchSettings();
+  }, [fetchSettings]);
+
+  // Save
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      const token = await getToken();
+      const res = await fetch(`${API_BASE}/admin/settings`, {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          triggers_enabled: triggersEnabled,
+          schedule_config: {
+            days_of_week: [...days].sort(),
+            hours: [...hours].sort(),
+          },
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.detail || `${res.status} ${res.statusText}`);
+      }
+      const snapshot: Settings = {
+        triggers_enabled: triggersEnabled,
+        schedule_config: {
+          days_of_week: [...days].sort(),
+          hours: [...hours].sort(),
+        },
+      };
+      setSaved(snapshot);
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Reset to last saved
+  const handleReset = () => {
+    if (!saved) return;
+    setTriggersEnabled(saved.triggers_enabled);
+    setDays(saved.schedule_config.days_of_week);
+    setHours(saved.schedule_config.hours);
+  };
+
+  // Toggle helpers
+  const toggleDay = (d: number) =>
+    setDays((prev) =>
+      prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]
+    );
+
+  const toggleHour = (h: number) =>
+    setHours((prev) =>
+      prev.includes(h) ? prev.filter((x) => x !== h) : [...prev, h]
+    );
+
+  return (
+    <AuthGuard
+      requireDomain="serniacapital.com"
+      message="Admin access required"
+      icon={<Building className="w-16 h-16 text-muted-foreground" />}
+    >
+      <div className="flex flex-col h-[calc(100dvh-52px)] bg-background">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onClick={() => navigate("/sernia-chat")}
+          >
+            <ArrowLeft className="w-4 h-4" />
+          </Button>
+          <div className="flex-1 min-w-0">
+            <h1 className="text-lg font-semibold">Settings</h1>
+          </div>
+          <div className="flex items-center gap-2">
+            {isDirty && (
+              <Button variant="outline" size="sm" className="gap-1.5" onClick={handleReset}>
+                <RotateCcw className="w-3.5 h-3.5" />
+                Reset
+              </Button>
+            )}
+            <Button
+              size="sm"
+              className="gap-1.5"
+              disabled={saving || !isDirty}
+              onClick={handleSave}
+            >
+              {saving ? (
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              ) : (
+                <Save className="w-3.5 h-3.5" />
+              )}
+              Save
+            </Button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto">
+          {loading ? (
+            <div className="flex justify-center py-16">
+              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <div className="max-w-2xl mx-auto p-4 space-y-6">
+              {/* Status messages */}
+              {error && (
+                <div className="rounded-lg border border-red-300 bg-red-50 dark:bg-red-950/20 p-3 text-sm text-red-700 dark:text-red-400">
+                  {error}
+                </div>
+              )}
+              {success && (
+                <div className="rounded-lg border border-green-300 bg-green-50 dark:bg-green-950/20 p-3 text-sm text-green-700 dark:text-green-400">
+                  Settings saved. Schedule updated.
+                </div>
+              )}
+
+              {/* Triggers enabled */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Triggers</CardTitle>
+                  <CardDescription>
+                    Universal kill switch for all automated agent runs (scheduled checks, SMS, email triggers).
+                    Web chat and approvals are not affected.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      id="triggers-enabled"
+                      checked={triggersEnabled}
+                      onCheckedChange={setTriggersEnabled}
+                    />
+                    <Label htmlFor="triggers-enabled" className="cursor-pointer">
+                      {triggersEnabled ? "Enabled" : "Disabled"}
+                    </Label>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Schedule config */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Scheduled Checks</CardTitle>
+                  <CardDescription>
+                    Controls when the AI agent wakes up to check the inbox and perform routine tasks.
+                    All times are in Eastern Time (ET).
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  {/* Days of week */}
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Days of Week</Label>
+                    <div className="flex flex-wrap gap-2">
+                      {DAYS.map(({ value, label }) => {
+                        const active = days.includes(value);
+                        return (
+                          <button
+                            key={value}
+                            type="button"
+                            onClick={() => toggleDay(value)}
+                            className={cn(
+                              "inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors border",
+                              active
+                                ? "bg-primary text-primary-foreground border-primary"
+                                : "bg-background text-muted-foreground border-input hover:bg-accent hover:text-accent-foreground"
+                            )}
+                          >
+                            {label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {days.length === 0 && (
+                      <p className="text-xs text-destructive">At least one day must be selected.</p>
+                    )}
+                  </div>
+
+                  {/* Hours */}
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Run Times (ET)</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Select which hours the scheduled check should run at.
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {HOUR_OPTIONS.map((h) => {
+                        const active = hours.includes(h);
+                        return (
+                          <button
+                            key={h}
+                            type="button"
+                            onClick={() => toggleHour(h)}
+                            className={cn(
+                              "inline-flex items-center justify-center rounded-md px-2 py-1 text-xs font-medium transition-colors border min-w-[52px]",
+                              active
+                                ? "bg-primary text-primary-foreground border-primary"
+                                : "bg-background text-muted-foreground border-input hover:bg-accent hover:text-accent-foreground"
+                            )}
+                          >
+                            {formatHour(h)}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {hours.length === 0 && (
+                      <p className="text-xs text-destructive">At least one time must be selected.</p>
+                    )}
+                  </div>
+
+                  {/* Summary */}
+                  {days.length > 0 && hours.length > 0 && (
+                    <div className="rounded-lg bg-muted/50 p-3 space-y-1">
+                      <p className="text-xs font-medium text-muted-foreground">Schedule preview</p>
+                      <p className="text-sm">
+                        Runs{" "}
+                        <span className="font-medium">
+                          {[...days]
+                            .sort()
+                            .map((d) => DAYS.find((x) => x.value === d)!.label)
+                            .join(", ")}
+                        </span>{" "}
+                        at{" "}
+                        <span className="font-medium">
+                          {[...hours]
+                            .sort()
+                            .map(formatHour)
+                            .join(", ")}
+                        </span>{" "}
+                        ET
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {hours.length} check{hours.length !== 1 && "s"} per day,{" "}
+                        {days.length} day{days.length !== 1 && "s"} per week ({hours.length * days.length} total/week)
+                      </p>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          )}
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}


### PR DESCRIPTION
Replace hardcoded 3-hour interval with DB-backed schedule config
(days of week + specific hours in ET). New /sernia-settings page
lets admins configure when scheduled checks run and toggle triggers.
Changes apply immediately by re-registering the APScheduler job.

https://claude.ai/code/session_01NeCUL6UqX1uoVU2f18BAHf