### PR TITLE
Remove HITL approval requirement from create_contact

### DIFF
--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -36,7 +36,7 @@ The agent operates in three modalities, each with distinct behavior:
 
 - **Internal/external SMS separation** — Internal phone numbers never appear in external threads
 - **Unit isolation** — Cross-unit tenant group texts blocked (see [`tools/README.md`](tools/README.md))
-- **HITL approval** — External SMS, emails, task/contact/calendar writes require human approval
+- **HITL approval** — External SMS, emails, task deletion, contact updates/deletes, and calendar writes require human approval
 - **Universal kill switch** — DB-backed toggle disables all automated triggers
 - **Rate limiting** — Per-source cooldowns prevent runaway trigger loops
 

--- a/api/src/sernia_ai/instructions.py
+++ b/api/src/sernia_ai/instructions.py
@@ -179,8 +179,7 @@ filtering, aggregation, or joining across multiple datasets.
 ## Approval-Gated Actions
 Some tools require human approval before executing: external SMS, external emails, \
 scheduled messages to external contacts, mass texts, calendar events with external \
-attendees, calendar deletion, contact writes (create/update/delete), and task \
-deletion. When you use one of these tools, the system will pause and ask the user \
+attendees, calendar deletion, contact updates and deletes, and task deletion. When you use one of these tools, the system will pause and ask the user \
 to approve or deny. Do NOT ask the user for confirmation before calling the tool — \
 the approval system handles that automatically. Just call the tool naturally. \
 Tools automatically detect internal vs external recipients — internal-only \

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -64,7 +64,8 @@ The `_get_contact_unit()` helper extracts this as a `(property, unit)` tuple, re
 
 - **search_contacts** — Fuzzy search by name, phone, or company against a TTL-cached (5 min) contact list.
 - **update_contact** — Safe read-merge-write contact update. Fetches the full contact first, merges only the provided fields, then sends the complete payload to Quo. Works around Quo's PATCH bug that clears omitted fields. Requires HITL approval.
-- **MCP-bridged tools** — `createContact_v1`, `deleteContact_v1`, `getContactCustomFields_v1`, `listCalls_v1`, `getCallById_v1`, `getCallSummary_v1`, `getCallTranscript_v1`. Contact writes require HITL approval.
+- **create_contact** — Create a new Quo contact. No approval required.
+- **MCP-bridged tools** — `deleteContact_v1`, `getContactCustomFields_v1`, `listCalls_v1`, `getCallById_v1`, `getCallSummary_v1`, `getCallTranscript_v1`. Contact deletes require HITL approval.
 
 ## Scheduling (`scheduling_tools.py`)
 

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -1145,7 +1145,7 @@ def _build_quo_toolset():
         tags: list[str] | None = None,
         custom_fields: list[CustomField] | None = None,
     ) -> str:
-        """Create a new Quo contact. Requires approval.
+        """Create a new Quo contact.
 
         Args:
             first_name: Contact's first name.
@@ -1158,8 +1158,6 @@ def _build_quo_toolset():
             custom_fields: Additional custom fields as [{key, value}] objects.
                 Use getContactCustomFields_v1 to look up field keys.
         """
-        if not ctx.tool_call_approved:
-            raise ApprovalRequired()
 
         payload = _build_contact_payload(
             first_name=first_name,


### PR DESCRIPTION
Contact creation is a low-risk operation that doesn't warrant blocking
on human approval. Update/delete still require approval.

https://claude.ai/code/session_01YAf3YuQriejz8LB99bTahj