### PR TITLE
Fix run_python tool: remove external_functions from Monty constructor

### DIFF
--- a/api/src/sernia_ai/tools/code_tools.py
+++ b/api/src/sernia_ai/tools/code_tools.py
@@ -109,8 +109,6 @@ _EXTERNAL_FUNCTIONS: dict[str, callable] = {
     "math_fn": _math_fn,
 }
 
-_EXT_FN_NAMES = list(_EXTERNAL_FUNCTIONS.keys())
-
 
 @code_toolset.tool
 async def run_python(
@@ -158,10 +156,7 @@ async def run_python(
         code: Python code to execute. The return value of the last expression is captured.
     """
     try:
-        m = pydantic_monty.Monty(
-            code,
-            external_functions=_EXT_FN_NAMES,
-        )
+        m = pydantic_monty.Monty(code)
 
         printed: list[str] = []
 


### PR DESCRIPTION
pydantic-monty 0.0.9 removed the external_functions parameter from
Monty(). External functions are now only passed to run_monty_async(),
which was already correct. This caused all run_python calls to fail
with "Monty.__new__() got an unexpected keyword argument 'external_functions'".

https://claude.ai/code/session_01EkmoTRysRcS2KMQoK3T2kn