### PR TITLE
fix: preserve draft messages and avoid loading spinner on app resume

### DIFF
--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -125,7 +125,7 @@ function ChatView({
   const [isProcessingApproval] = useState(false);
   const draftKey = `sernia-draft-${conversationId}`;
   const [input, setInput] = useState(
-    () => sessionStorage.getItem(draftKey) || ""
+    () => (typeof window !== "undefined" && sessionStorage.getItem(draftKey)) || ""
   );
   // Persist draft to sessionStorage so it survives component remounts
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Silent refresh on visibility change**: The `visibilitychange` handler now uses `silent: true` when calling `loadConversation()`, so returning to the app refreshes messages in the background without showing the "Loading conversation..." spinner or unmounting `ChatView`
- **Draft persistence via sessionStorage**: Text input state is backed by `sessionStorage` (keyed per conversation) so drafts survive component remounts. Cleared automatically on send.
- **SSR guard**: `sessionStorage` access is guarded with `typeof window !== "undefined"` to prevent crashes during server-side rendering

## Test plan

- [ ] Open Sernia AI chat on mobile, type a draft message, switch to another app, switch back — draft should be preserved
- [ ] Returning to the app should NOT show "Loading conversation..." flash
- [ ] Sending a message should clear the draft (no stale text after send)
- [ ] SSR: page should render without errors on initial load (no "Oops!" screen)
- [ ] Loading a conversation from history still shows proper loading state (non-silent path)

https://claude.ai/code/session_01GFfFhqSRKRTe6Ww9bcjJqi