### PR TITLE
Fix markdown and chat layout overflow issues

### DIFF
--- a/apps/web-react-router/app/components/markdown.tsx
+++ b/apps/web-react-router/app/components/markdown.tsx
@@ -11,17 +11,24 @@ const NonMemoizedMarkdown = ({ children }: { children: string }) => {
         // @ts-expect-error
         <pre
           {...props}
-          className={`${className} text-sm max-w-full overflow-x-auto bg-zinc-100 p-3 rounded-lg mt-2 dark:bg-zinc-800`}
+          className={`${className} text-sm w-full overflow-x-auto bg-zinc-100 p-3 rounded-lg mt-2 dark:bg-zinc-800`}
         >
           <code className={match[1]}>{children}</code>
         </pre>
       ) : (
         <code
-          className={`${className} text-sm bg-zinc-100 dark:bg-zinc-800 py-0.5 px-1 rounded-md`}
+          className={`${className} text-sm bg-zinc-100 dark:bg-zinc-800 py-0.5 px-1 rounded-md break-all`}
           {...props}
         >
           {children}
         </code>
+      );
+    },
+    table: ({ node, children, ...props }) => {
+      return (
+        <div className="overflow-x-auto -mx-1">
+          <table {...props}>{children}</table>
+        </div>
       );
     },
     ol: ({ node, children, ...props }) => {

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -326,7 +326,7 @@ function ChatView({
       {/* Messages */}
       <div
         ref={messagesContainerRef}
-        className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll overscroll-none pt-4 relative"
+        className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll overflow-x-hidden overscroll-none pt-4 relative"
         {...attachment.dropTargetProps}
       >
         {attachment.isDragging && (
@@ -378,7 +378,7 @@ function ChatView({
 
                   <div
                     className={cn(
-                      "flex flex-col gap-2 max-w-[85%] min-w-0",
+                      "flex flex-col gap-2 max-w-[85%] min-w-0 overflow-hidden",
                       message.role === "user" && "items-end"
                     )}
                   >


### PR DESCRIPTION
## Description

This PR addresses several layout and overflow issues in the markdown renderer and chat view:

### Changes:
1. **Markdown code blocks**: Changed `max-w-full` to `w-full` to ensure code blocks properly fill their container width
2. **Inline code**: Added `break-all` class to allow inline code to wrap text properly instead of overflowing
3. **Markdown tables**: Added a new table renderer that wraps tables in a scrollable container with `overflow-x-auto` to handle wide tables gracefully
4. **Chat messages container**: Added `overflow-x-hidden` to prevent horizontal scrolling in the messages area
5. **Message content wrapper**: Added `overflow-hidden` to the message flex container to ensure content respects the max-width constraint and doesn't overflow

These changes improve the responsive behavior and prevent content from breaking the layout on smaller screens or with long content.

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

https://claude.ai/code/session_01DcPo1yJELqoCgJd75Y6n4f