### PR TITLE
Clarify knowledge-repo error boundaries and fix skills injection

### DIFF
--- a/api/src/sernia_ai/PLAN.md
+++ b/api/src/sernia_ai/PLAN.md
@@ -311,7 +311,19 @@ The frontend uses `trigger_source` and `trigger_contact_name` to render icons (P
 | Filetree | Entire `.workspace/` | Yes (every turn) | Agent knows what files exist |
 | Daily Notes | `/workspace/daily_notes/YYYY-MM-DD_<desc>.md` | On demand | Activity logs, events |
 | Areas | `/workspace/areas/<topic>.md` | On demand | Deep topic knowledge |
-| Skills | `/workspace/skills/<name>/SKILL.md` | On demand | SOPs (deferred) |
+| Skills | `/workspace/skills/<name>/SKILL.md` | Yes (every turn) | Playbooks, SOPs — auto-injected via `SkillsToolset` |
+
+### Server-Side vs Knowledge-Repo Error Boundary
+
+All workspace content (memory, areas, skills) lives in the `sernia-knowledge` git repo and is editable at runtime by the agent and humans. Server-side code (`api/src/sernia_ai/`) is developer-maintained Python.
+
+**Key principle**: Knowledge-repo content must **never** crash the server. A malformed `SKILL.md`, corrupt `MEMORY.md`, or missing file must degrade gracefully (log + skip), not take down agent runs.
+
+This is enforced by:
+- `reload_skills()` — per-directory try/except, broken skill directories are skipped
+- `refresh_skills_before_run` decorator — wraps reload in try/except, agent runs with stale skills on failure
+- `inject_memory` / `inject_filetree` — capped reads with fallback to empty string
+- `ErrorLoggingToolset` — workspace tool errors return error strings, never raise
 
 ### Git-Backed Sync
 

--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -46,4 +46,22 @@ Git-backed persistent workspace at `/workspace/`:
 - `MEMORY.md` — Long-term memory (injected into every conversation)
 - `daily_notes/` — Date-stamped notes per topic
 - `areas/` — Deep knowledge by domain (properties, tenants, etc.)
+- `skills/` — Playbooks and procedures (auto-injected via `SkillsToolset`)
+
+### Server-Side vs Knowledge-Repo Content
+
+The agent's behavior comes from two sources with different error boundaries:
+
+| Source | Location | Edited by | Error handling |
+|--------|----------|-----------|----------------|
+| **Server-side** | `api/src/sernia_ai/` (Python) | Developers (code deploys) | Bugs crash the app — standard software quality applies |
+| **Knowledge repo** | `.workspace/` (`sernia-knowledge` git repo) | Agent + humans at runtime | Must **never** crash the server — all reads are error-wrapped |
+
+This distinction matters most for **skills** (`/workspace/skills/<name>/SKILL.md`). Skills are runtime-editable YAML+markdown files that the agent itself can create and modify via `workspace_edit`. A malformed SKILL.md (bad YAML frontmatter, broken encoding, etc.) must degrade gracefully:
+
+- **Reload** (`reload_skills()` in `agent.py`): Per-directory try/except — a broken skill directory is skipped and logged, other skills still load.
+- **Injection** (`SkillsToolset.get_instructions()`): Operates on already-loaded `_skills` dict, so it only sees successfully parsed skills.
+- **Decorator** (`refresh_skills_before_run`): Wraps the reload in try/except — if the entire reload fails, the agent runs with stale skills rather than crashing.
+
+The same principle applies to all knowledge-repo content: `MEMORY.md` reads are capped and wrapped, filetree generation catches `OSError`, and workspace file tools return error strings rather than raising.
 

--- a/api/src/sernia_ai/agent.py
+++ b/api/src/sernia_ai/agent.py
@@ -65,14 +65,14 @@ filesystem_toolset = FileSystemToolset(_sandbox)
 # Skills toolset — loads SKILL.md files from .workspace/skills/
 # Note: initial discovery may find nothing if workspace hasn't been git-synced yet.
 # Call reload_skills() after workspace init in lifespan to pick up synced skills.
-skills_toolset = SkillsToolset(directories=[WORKSPACE_PATH / "skills"], auto_reload=True)
+skills_toolset = SkillsToolset(directories=[WORKSPACE_PATH / "skills"])
 
 
 def reload_skills() -> None:
     """Re-discover skills from disk with per-directory error handling.
 
-    Called during lifespan startup after workspace git-sync.
-    Runtime re-discovery is handled by auto_reload=True on the SkillsToolset.
+    Called during lifespan startup and before every agent run (via decorator).
+    Per-directory try/except ensures a broken SKILL.md never crashes the agent.
     """
     skills_toolset._skills.clear()
     for skill_dir in skills_toolset._skill_directories:
@@ -111,6 +111,20 @@ sernia_agent = Agent(
     instrument=True,
     name=AGENT_NAME,
 )
+
+
+@sernia_agent.instructions
+async def refresh_skills_before_run(ctx: RunContext[SerniaDeps]) -> None:
+    """Re-discover skills from disk before every agent run.
+
+    Only reloads — does NOT return instructions (the toolset's own
+    get_instructions() handles that, avoiding the old duplicate injection).
+    Errors are swallowed so a broken SKILL.md never crashes the agent.
+    """
+    try:
+        reload_skills()
+    except Exception:
+        logfire.exception("refresh_skills_before_run failed — agent will run with stale skills")
 
 
 @sernia_agent.tool

--- a/api/src/sernia_ai/agent.py
+++ b/api/src/sernia_ai/agent.py
@@ -65,13 +65,14 @@ filesystem_toolset = FileSystemToolset(_sandbox)
 # Skills toolset — loads SKILL.md files from .workspace/skills/
 # Note: initial discovery may find nothing if workspace hasn't been git-synced yet.
 # Call reload_skills() after workspace init in lifespan to pick up synced skills.
-skills_toolset = SkillsToolset(directories=[WORKSPACE_PATH / "skills"])
+skills_toolset = SkillsToolset(directories=[WORKSPACE_PATH / "skills"], auto_reload=True)
 
 
 def reload_skills() -> None:
-    """Re-discover skills from disk. Called every agent run so edits take effect immediately.
+    """Re-discover skills from disk with per-directory error handling.
 
-    Catches errors per-directory so a broken skill file doesn't kill the entire agent run.
+    Called during lifespan startup after workspace git-sync.
+    Runtime re-discovery is handled by auto_reload=True on the SkillsToolset.
     """
     skills_toolset._skills.clear()
     for skill_dir in skills_toolset._skill_directories:
@@ -110,25 +111,6 @@ sernia_agent = Agent(
     instrument=True,
     name=AGENT_NAME,
 )
-
-
-@sernia_agent.instructions
-async def inject_skills_instructions(ctx: RunContext[SerniaDeps]) -> str | None:
-    """Re-discover skills from disk and inject descriptions.
-
-    Runs at the start of every agent run, so skill edits (by the agent or
-    manually) take effect without restarting the server.
-
-    Workspace skills are runtime-editable and must never block an agent run.
-    Errors are logged as exceptions (triggers Logfire alerts) but swallowed
-    so the agent continues without skills.
-    """
-    try:
-        reload_skills()
-        return await skills_toolset.get_instructions(ctx)
-    except Exception:
-        logfire.exception("inject_skills_instructions failed — agent will run without skills")
-        return None
 
 
 @sernia_agent.tool

--- a/api/src/sernia_ai/agent.py
+++ b/api/src/sernia_ai/agent.py
@@ -63,7 +63,9 @@ _sandbox = Sandbox(SandboxConfig(mounts=[
 filesystem_toolset = FileSystemToolset(_sandbox)
 
 # Skills toolset — loads SKILL.md files from .workspace/skills/
-# Note: initial discovery may find nothing if workspace hasn't been git-synced yet.
+# These are knowledge-repo content (sernia-knowledge git repo), not server-side code.
+# A broken SKILL.md must never crash the server — all loading is error-wrapped.
+# Initial discovery may find nothing if workspace hasn't been git-synced yet.
 # Call reload_skills() after workspace init in lifespan to pick up synced skills.
 skills_toolset = SkillsToolset(directories=[WORKSPACE_PATH / "skills"])
 


### PR DESCRIPTION
## Description

This PR clarifies the architectural distinction between server-side code and runtime-editable knowledge-repo content, and fixes a bug in skills injection that was causing duplicate skill descriptions.

### Changes

**1. Fixed skills injection bug** (`agent.py`)
- Renamed `inject_skills_instructions()` → `refresh_skills_before_run()` to clarify intent
- Changed from returning skill instructions to only reloading skills
- Removed duplicate injection: `SkillsToolset.get_instructions()` already handles injection, so the decorator should only reload
- This prevents skills from being injected twice in the same run

**2. Improved error handling documentation** (`agent.py`)
- Enhanced docstrings for `reload_skills()` and `refresh_skills_before_run()` to explain per-directory error wrapping
- Clarified that broken SKILL.md files are logged but never crash the agent
- Updated error message to reflect stale-skills fallback behavior

**3. Documented error boundary principle** (`README.md` and `PLAN.md`)
- Added new section explaining the distinction between server-side code (developer-maintained, crashes are bugs) and knowledge-repo content (runtime-editable, must degrade gracefully)
- Documented that all workspace content (skills, memory, areas) is error-wrapped to prevent crashes
- Added table showing error handling strategy for each content type

### Why This Matters

Skills are runtime-editable YAML+markdown files that the agent itself can create and modify. A malformed SKILL.md (bad YAML, broken encoding, etc.) must never crash the server. This PR:
- Fixes the duplicate injection bug that could cause confusing behavior
- Establishes clear error boundaries so future changes respect the principle that knowledge-repo content failures degrade gracefully, never crash
- Documents the architectural pattern for other developers

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

https://claude.ai/code/session_012UbKM92KfpyViqpuyKncgQ