### PR TITLE
Fix root cause of mobile horizontal scroll

### DIFF
--- a/apps/web-react-router/app/root.tsx
+++ b/apps/web-react-router/app/root.tsx
@@ -82,7 +82,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
         <Toaster />
         <SidebarProvider>
           <AppSidebar />
-          <SidebarInset>
+          <SidebarInset className="min-w-0 overflow-x-hidden">
             <Navbar />
             <EnvBanner />
             <Outlet />


### PR DESCRIPTION
## Summary
- Add `min-w-0` and `overflow-x-hidden` to `SidebarInset` in `root.tsx` — the root cause of mobile horizontal scroll
- The `SidebarInset` (`<main>`) uses `flex-1` without `min-w-0`, so in flexbox its minimum width defaults to `auto` (content's intrinsic width). Wide content in the chat (tool cards, code blocks, long text) propagates upward through the flex chain, pushing the entire page wider — including the navbar.

## Test plan
- [ ] Open sernia-chat on mobile (or narrow browser window)
- [ ] Send a message and receive AI response with tool calls
- [ ] Verify no horizontal scrolling occurs on the page
- [ ] Verify navbar stays within viewport width

https://claude.ai/code/session_01DcPo1yJELqoCgJd75Y6n4f