### PR TITLE
reduce SMS-triggered agent costs by trimming conversation history

### DIFF
--- a/api/src/sernia_ai/config.py
+++ b/api/src/sernia_ai/config.py
@@ -95,6 +95,12 @@ SMS_MAX_LENGTH = 1000
 # AI SMS conversation: max messages to fetch from OpenPhone for initial bootstrap
 SMS_CONVERSATION_MAX_MESSAGES = 20
 
+# AI SMS history trimming — reduce context size for SMS-triggered runs.
+# Default window: last N days OR last N user messages, whichever goes further back.
+# The agent is told history was trimmed and can use tools to load more.
+SMS_HISTORY_MIN_DAYS = 3
+SMS_HISTORY_MIN_MESSAGES = 3
+
 # ClickUp — Maintenance list for task creation from SMS triggers
 CLICKUP_MAINTENANCE_LIST_ID = "901312027371"
 

--- a/api/src/sernia_ai/instructions.py
+++ b/api/src/sernia_ai/instructions.py
@@ -124,9 +124,13 @@ to get the correct field_id and option orderindex values.
 - **google_read_email_thread**: Read all messages in an email thread (chronological). Use to understand full back-and-forth conversations.
 - **google_list_calendar_events**: See upcoming Google Calendar events.
 - **db_search_conversations**: Search past agent conversation history by keyword.
+- **db_get_contact_sms_history**: Get chronological SMS history for a contact \
+without needing a keyword. Use this when you need more context beyond the \
+default trimmed window — for example, to review earlier conversations before \
+replying. Supports days_back (default 30) and max_messages (default 50).
 - **db_search_sms_history**: Search SMS messages by keyword across all contacts, \
 with optional contact and date filters. Use for keyword search — for individual \
-thread history, use quo_get_thread_messages instead.
+thread history, use db_get_contact_sms_history or quo_get_thread_messages instead.
 
 ### Google Drive — prefix: `google_`
 - **google_search_drive**: Search Google Drive for files by name or content.
@@ -258,7 +262,10 @@ def inject_modality_guidance(ctx: RunContext[SerniaDeps]) -> str:
     guidance = {
         "sms": (
             "You are communicating via SMS. Keep responses SHORT (1-3 sentences). "
-            "No markdown formatting. Be direct and casual."
+            "No markdown formatting. Be direct and casual. "
+            "NOTE: Your conversation history may be trimmed to only recent messages "
+            "(last 3 days or last 3 exchanges). If you need earlier context, use "
+            "`db_get_contact_sms_history` or `db_search_sms_history`."
         ),
         "email": (
             "You are communicating via email. Use a professional, slightly formal tone. "

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -91,6 +91,6 @@ One-time scheduled SMS and email delivery via APScheduler date trigger.
 |--------|-------------|
 | `google_tools.py` | Gmail (search, read, send), Calendar (list, create), Drive (search, read docs/sheets/PDFs). Core email routing (`EmailRouting`, `resolve_email_routing`) exported for scheduling. |
 | `clickup_tools.py` | Task management (list, search, create, update, delete) |
-| `db_search_tools.py` | Search past agent conversations and SMS history |
+| `db_search_tools.py` | Search past agent conversations and SMS history; chronological contact SMS history |
 | `code_tools.py` | Python sandbox (pydantic-monty) for math, formatting, data manipulation |
 | `_logging.py` | Shared error logging wrapper for tool failures |

--- a/api/src/sernia_ai/tools/db_search_tools.py
+++ b/api/src/sernia_ai/tools/db_search_tools.py
@@ -220,6 +220,65 @@ def _extract_snippet(messages: list[dict], query: str, max_len: int = 200) -> st
 
 
 # ---------------------------------------------------------------------------
+# Tool: get_contact_sms_history (chronological thread, no keyword required)
+# ---------------------------------------------------------------------------
+
+
+@db_search_toolset.tool
+async def get_contact_sms_history(
+    ctx: RunContext[SerniaDeps],
+    contact_name: str,
+    days_back: int = 30,
+    max_messages: int = 50,
+) -> str:
+    """Get chronological SMS history for a contact — no keyword needed.
+
+    Returns all messages to/from a contact in chronological order.
+    Use this when you need more conversation context beyond the default
+    trimmed window (e.g. to understand prior discussions before replying).
+    For keyword-based search, use search_sms_history instead.
+
+    Args:
+        contact_name: Contact name (fuzzy matched) or phone number.
+        days_back: How far back to look (default 30 days).
+        max_messages: Maximum messages to return (default 50).
+    """
+    try:
+        display_name, phones = await _resolve_contact_phones(contact_name)
+    except ValueError as e:
+        return str(e)
+
+    after_dt = datetime.now() - timedelta(days=days_back)
+
+    filters = [
+        OpenPhoneEvent.event_type.like("message.%"),
+        OpenPhoneEvent.message_text.isnot(None),
+        _build_phone_filter(phones),
+        OpenPhoneEvent.event_timestamp >= after_dt,
+    ]
+
+    async with AsyncSessionFactory() as session:
+        stmt = (
+            select(OpenPhoneEvent)
+            .where(and_(*filters))
+            .order_by(OpenPhoneEvent.event_timestamp.asc())
+            .limit(max_messages)
+        )
+        result = await session.execute(stmt)
+        events = result.scalars().all()
+
+    if not events:
+        return f"No SMS messages found for '{display_name}' in the last {days_back} days."
+
+    contact_map = await _get_contact_map()
+    lines = [f"SMS history with {display_name} — {len(events)} messages (last {days_back} days)\n"]
+    for evt in events:
+        lines.append(_format_sms_event(evt, contact_map))
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Tool: search_sms_history
 # ---------------------------------------------------------------------------
 

--- a/api/src/sernia_ai/triggers/README.md
+++ b/api/src/sernia_ai/triggers/README.md
@@ -43,7 +43,7 @@ The trigger always fetches from **both** sources and merges them:
 1. **DB history** — `get_conversation_messages()` preserves full tool call context from prior agent runs
 2. **Quo SMS thread** — `_fetch_sms_thread()` via `GET /v1/messages` captures messages sent from any conversation (e.g. web chat tool calls, context-seeded messages)
 
-`_merge_sms_into_history()` deduplicates by text content — any SMS messages whose text is missing from DB history are prepended. This ensures the agent sees the full picture even when messages were sent outside the AI SMS conversation (e.g. via `send_internal_sms` from web chat). If both sources return empty (e.g. Quo API hasn't indexed recent messages yet), a hint is injected telling the agent to use `get_contact_sms_history`.
+`_merge_sms_into_history()` deduplicates by text content — any SMS messages whose text is missing from DB history are prepended. After merging, `_trim_sms_history()` reduces the history to the last `SMS_HISTORY_MIN_DAYS` days or last `SMS_HISTORY_MIN_MESSAGES` user exchanges, whichever window goes further back. This significantly reduces token usage for long-running SMS conversations. When history is trimmed, a system hint tells the agent how many messages were omitted and which tools to use for earlier context (`db_get_contact_sms_history`, `db_search_sms_history`). If both sources return empty (e.g. Quo API hasn't indexed recent messages yet), a hint is injected telling the agent to use `db_get_contact_sms_history`.
 
 ```mermaid
 flowchart TD
@@ -65,7 +65,8 @@ flowchart TD
     DB --> MERGE["_merge_sms_into_history()<br/>(dedup by text content)"]
     QUO --> MERGE
 
-    MERGE --> AGENT["Run sernia_agent<br/>modality=sms"]
+    MERGE --> TRIM["_trim_sms_history()<br/>(last 3 days or last 3 exchanges)"]
+    TRIM --> AGENT["Run sernia_agent<br/>modality=sms"]
 
     AGENT --> SAVE["models.save_agent_conversation()<br/>(modality=sms, upsert)"]
     SAVE --> RESULT{"Pending<br/>approvals?"}
@@ -206,6 +207,8 @@ Separate sliding-window rate limiter in `ai_sms_event_trigger.py`:
 | `QUO_SERNIA_AI_PHONE_ID` | AI's phone line (used for SMS replies and team notifications) |
 | `QUO_INTERNAL_COMPANY` | `"Sernia Capital LLC"` — gate for AI SMS contact verification |
 | `SMS_CONVERSATION_MAX_MESSAGES` | Max messages to fetch from OpenPhone for SMS conversation bootstrap (20) |
+| `SMS_HISTORY_MIN_DAYS` | History trimming: minimum days of history to keep (3) |
+| `SMS_HISTORY_MIN_MESSAGES` | History trimming: minimum user-message turns to keep (3) |
 | `DEFAULT_SCHEDULE_DAYS_OF_WEEK` | Default days (Mon–Fri) — overridden by `schedule_config` DB setting |
 | `DEFAULT_SCHEDULE_HOURS` | Default hours (`[8,11,14,17]` ET) — overridden by `schedule_config` DB setting |
 | `EMILIO_CONTACT_SLUG` | `"emilio"` — contact slug used to look up Emilio's `clerk_user_id` from DB (contacts → users join) |

--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -22,6 +22,7 @@ import os
 import re
 import time
 from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import logfire
@@ -30,6 +31,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     TextPart,
+    ToolReturnPart,
     UserPromptPart,
 )
 
@@ -42,6 +44,8 @@ from api.src.sernia_ai.config import (
     QUO_INTERNAL_COMPANY,
     QUO_SERNIA_AI_PHONE_ID,
     SMS_CONVERSATION_MAX_MESSAGES,
+    SMS_HISTORY_MIN_DAYS,
+    SMS_HISTORY_MIN_MESSAGES,
     TRIGGER_BOT_ID,
     TRIGGER_BOT_NAME,
     WORKSPACE_PATH,
@@ -164,12 +168,25 @@ async def _fetch_sms_thread(
         return []
 
 
+def _parse_timestamp(raw: str | None) -> datetime | None:
+    """Parse an ISO 8601 timestamp from the Quo API, returning None on failure."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
 def _sms_to_model_messages(messages: list[dict]) -> list[ModelMessage]:
     """Convert Quo message dicts to PydanticAI ModelMessage list.
 
     Quo returns newest-first; we reverse for chronological order.
     Incoming (direction="incoming") → ModelRequest with UserPromptPart
     Outgoing (direction="outgoing") → ModelResponse with TextPart
+
+    Preserves original ``createdAt`` timestamps so history trimming can
+    accurately determine message age.
     """
     result: list[ModelMessage] = []
 
@@ -179,14 +196,19 @@ def _sms_to_model_messages(messages: list[dict]) -> list[ModelMessage]:
         if not body.strip():
             continue
 
+        ts = _parse_timestamp(msg.get("createdAt"))
         direction = msg.get("direction", "")
+        kwargs: dict = {}
+        if ts is not None:
+            kwargs["timestamp"] = ts
+
         if direction == "incoming":
             result.append(
-                ModelRequest(parts=[UserPromptPart(content=body)])
+                ModelRequest(parts=[UserPromptPart(content=body)], **kwargs)
             )
         elif direction == "outgoing":
             result.append(
-                ModelResponse(parts=[TextPart(content=body)])
+                ModelResponse(parts=[TextPart(content=body)], **kwargs)
             )
 
     return result
@@ -247,6 +269,64 @@ def _merge_sms_into_history(
 
     # Prepend missing SMS messages before DB history
     return missing + db_history
+
+
+def _trim_sms_history(
+    messages: list[ModelMessage],
+    min_days: int = SMS_HISTORY_MIN_DAYS,
+    min_messages: int = SMS_HISTORY_MIN_MESSAGES,
+) -> tuple[list[ModelMessage], int]:
+    """Trim conversation history to reduce token usage on SMS-triggered runs.
+
+    Keeps the **larger** of two windows (whichever goes further back):
+    - All messages from the last ``min_days`` days
+    - The last ``min_messages`` user-message turns (with all associated
+      agent responses and tool calls between them)
+
+    Returns:
+        (trimmed_messages, number_of_messages_removed)
+    """
+    if not messages or len(messages) <= min_messages:
+        return messages, 0
+
+    now = datetime.now(timezone.utc)
+    time_cutoff = now - timedelta(days=min_days)
+
+    # --- Time-based cutoff ---
+    # Find the first message (from the start) whose timestamp is within the window.
+    time_keep_from = len(messages)  # default: nothing qualifies on time alone
+    for i, msg in enumerate(messages):
+        ts = getattr(msg, "timestamp", None)
+        if ts is not None:
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            if ts >= time_cutoff:
+                time_keep_from = i
+                break
+
+    # --- Message-count cutoff ---
+    # Identify indices of user-turn starts (ModelRequest with a UserPromptPart
+    # that isn't purely tool-return plumbing).
+    user_turn_indices: list[int] = []
+    for i, msg in enumerate(messages):
+        if isinstance(msg, ModelRequest):
+            has_user_prompt = any(isinstance(p, UserPromptPart) for p in msg.parts)
+            is_pure_tool_return = all(isinstance(p, ToolReturnPart) for p in msg.parts)
+            if has_user_prompt and not is_pure_tool_return:
+                user_turn_indices.append(i)
+
+    if len(user_turn_indices) <= min_messages:
+        msg_keep_from = 0  # not enough turns to trim
+    else:
+        msg_keep_from = user_turn_indices[-min_messages]
+
+    # Whichever window goes further back (smaller index = more history kept)
+    keep_from = min(time_keep_from, msg_keep_from)
+
+    if keep_from <= 0:
+        return messages, 0
+
+    return messages[keep_from:], keep_from
 
 
 async def _send_sms_reply(to_phone: str, message: str) -> None:
@@ -333,24 +413,36 @@ async def handle_ai_sms_event(event_data: dict) -> None:
         )
         sms_thread = await _fetch_sms_thread(from_number)
 
-        history = _merge_sms_into_history(db_history, sms_thread)
+        merged = _merge_sms_into_history(db_history, sms_thread)
+        history, trimmed_count = _trim_sms_history(merged)
         logfire.info(
             "ai_sms_event: history loaded",
             from_number=from_number,
             db_messages=len(db_history),
             sms_messages=len(sms_thread),
-            merged_messages=len(history),
+            merged_messages=len(merged),
+            after_trim=len(history),
+            trimmed=trimmed_count,
         )
 
-        # If still no history, the Quo API may not have indexed recent
-        # messages yet. Hint the agent to look up SMS history.
+        # Build context hints for the agent
         sms_context_hint = ""
         if len(history) <= 1:
+            # Quo API may not have indexed recent messages yet
             sms_context_hint = (
                 " [System: No prior conversation history found. This person may "
                 "be replying to a message you sent from another conversation. "
-                "Use `get_contact_sms_history` to check recent SMS thread before "
-                "replying.]"
+                "Use `db_get_contact_sms_history` to check recent SMS thread "
+                "before replying.]"
+            )
+        elif trimmed_count > 0:
+            sms_context_hint = (
+                f" [System: Conversation history trimmed to reduce context — "
+                f"{trimmed_count} older message(s) omitted. You are seeing the "
+                f"last {SMS_HISTORY_MIN_DAYS} days or last "
+                f"{SMS_HISTORY_MIN_MESSAGES} exchanges (whichever is more). "
+                f"If you need earlier context, use `db_get_contact_sms_history` "
+                f"or `db_search_sms_history`.]"
             )
 
         deps = SerniaDeps(

--- a/api/src/tests/test_sms_search_tools.py
+++ b/api/src/tests/test_sms_search_tools.py
@@ -13,6 +13,7 @@ from pydantic_ai import RunContext
 
 from api.src.open_phone.models import OpenPhoneEvent
 from api.src.sernia_ai.tools.db_search_tools import (
+    get_contact_sms_history,
     search_sms_history,
     _resolve_contact_phones,
     _build_contact_map,
@@ -381,6 +382,78 @@ class TestSearchSmsHistory:
         with pytest.raises(RuntimeError, match="DB connection lost"):
             with patch(_SESSION_FACTORY_PATCH, side_effect=lambda: _mock_factory(session)):
                 await search_sms_history(ctx, query="test")
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_contact_sms_history
+# ---------------------------------------------------------------------------
+
+
+class TestGetContactSmsHistory:
+    """Test the chronological SMS history tool (no keyword needed)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_chronological_history(self):
+        ctx = _make_ctx()
+        session_mock = AsyncMock()
+        _mock_execute_returns(session_mock, FAKE_THREAD[:3])
+
+        @asynccontextmanager
+        async def mock_factory():
+            yield session_mock
+
+        with (
+            patch(_SESSION_FACTORY_PATCH, mock_factory),
+            patch(
+                "api.src.sernia_ai.tools.db_search_tools._resolve_contact_phones",
+                new_callable=AsyncMock,
+                return_value=("John Doe", ["+14155550100"]),
+            ),
+            patch(
+                "api.src.sernia_ai.tools.db_search_tools._get_contact_map",
+                new_callable=AsyncMock,
+                return_value={"+14155550100": "John Doe", "+14155559999": "Sernia Capital"},
+            ),
+        ):
+            result = await get_contact_sms_history(ctx, contact_name="John", days_back=30)
+
+        assert "John Doe" in result
+        assert "3 messages" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_not_found_when_no_messages(self):
+        ctx = _make_ctx()
+        session_mock = AsyncMock()
+        _mock_execute_returns(session_mock, [])
+
+        @asynccontextmanager
+        async def mock_factory():
+            yield session_mock
+
+        with (
+            patch(_SESSION_FACTORY_PATCH, mock_factory),
+            patch(
+                "api.src.sernia_ai.tools.db_search_tools._resolve_contact_phones",
+                new_callable=AsyncMock,
+                return_value=("John Doe", ["+14155550100"]),
+            ),
+        ):
+            result = await get_contact_sms_history(ctx, contact_name="John", days_back=7)
+
+        assert "No SMS messages found" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_error_for_unknown_contact(self):
+        ctx = _make_ctx()
+
+        with patch(
+            "api.src.sernia_ai.tools.db_search_tools._resolve_contact_phones",
+            new_callable=AsyncMock,
+            side_effect=ValueError("No contact found matching 'Nobody'"),
+        ):
+            result = await get_contact_sms_history(ctx, contact_name="Nobody")
+
+        assert "No contact found" in result
 
 
 # ---------------------------------------------------------------------------

--- a/api/src/tests/test_triggers.py
+++ b/api/src/tests/test_triggers.py
@@ -605,6 +605,7 @@ class TestAiSmsEventTriggerSmoke:
             _verify_internal_contact,
             _fetch_sms_thread,
             _sms_to_model_messages,
+            _trim_sms_history,
             _send_sms_reply,
             _is_ai_sms_rate_limited,
             AI_SMS_RATE_LIMIT_MAX_CALLS,
@@ -614,6 +615,7 @@ class TestAiSmsEventTriggerSmoke:
         assert callable(_verify_internal_contact)
         assert callable(_fetch_sms_thread)
         assert callable(_sms_to_model_messages)
+        assert callable(_trim_sms_history)
         assert callable(_send_sms_reply)
         assert callable(_is_ai_sms_rate_limited)
         assert AI_SMS_RATE_LIMIT_MAX_CALLS == 10
@@ -623,6 +625,13 @@ class TestAiSmsEventTriggerSmoke:
         from api.src.sernia_ai.config import SMS_CONVERSATION_MAX_MESSAGES
         assert isinstance(SMS_CONVERSATION_MAX_MESSAGES, int)
         assert SMS_CONVERSATION_MAX_MESSAGES > 0
+
+    def test_config_has_sms_history_trimming_constants(self):
+        from api.src.sernia_ai.config import SMS_HISTORY_MIN_DAYS, SMS_HISTORY_MIN_MESSAGES
+        assert isinstance(SMS_HISTORY_MIN_DAYS, int)
+        assert SMS_HISTORY_MIN_DAYS > 0
+        assert isinstance(SMS_HISTORY_MIN_MESSAGES, int)
+        assert SMS_HISTORY_MIN_MESSAGES > 0
 
     def test_ai_sms_event_trigger_wired_in_webhook(self):
         """handle_ai_sms_event should be imported in open_phone routes."""
@@ -716,6 +725,119 @@ class TestSmsToModelMessages:
 
         assert len(result) == 1
         assert result[0].parts[0].content == "from text"
+
+
+class TestSmsTimestampPreservation:
+    """Test that _sms_to_model_messages preserves original timestamps."""
+
+    def test_preserves_created_at_timestamp(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _sms_to_model_messages
+
+        messages = [
+            {"body": "Hello", "direction": "incoming", "createdAt": "2025-06-15T10:30:00Z"},
+        ]
+        result = _sms_to_model_messages(messages)
+
+        assert len(result) == 1
+        assert result[0].timestamp.year == 2025
+        assert result[0].timestamp.month == 6
+        assert result[0].timestamp.day == 15
+
+    def test_handles_missing_created_at(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _sms_to_model_messages
+
+        messages = [{"body": "Hello", "direction": "incoming"}]
+        result = _sms_to_model_messages(messages)
+
+        # Should still produce a message (with auto-generated timestamp)
+        assert len(result) == 1
+        assert result[0].parts[0].content == "Hello"
+
+
+class TestTrimSmsHistory:
+    """Test _trim_sms_history reduces conversation history to recent window."""
+
+    def _make_user_msg(self, text: str, days_ago: int = 0) -> ModelRequest:
+        from datetime import datetime, timedelta, timezone
+        ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        return ModelRequest(parts=[UserPromptPart(content=text)], timestamp=ts)
+
+    def _make_assistant_msg(self, text: str, days_ago: int = 0) -> ModelResponse:
+        from datetime import datetime, timedelta, timezone
+        ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        return ModelResponse(parts=[TextPart(content=text)], timestamp=ts)
+
+    def test_no_trim_when_few_messages(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _trim_sms_history
+
+        messages = [
+            self._make_user_msg("Hi", days_ago=1),
+            self._make_assistant_msg("Hello!", days_ago=1),
+        ]
+        result, removed = _trim_sms_history(messages, min_days=3, min_messages=3)
+        assert removed == 0
+        assert len(result) == 2
+
+    def test_trims_old_messages_beyond_both_windows(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _trim_sms_history
+
+        # 10 user turns: days 20, 18, 16, 14, 12, 10, 8, 6, 2, 0
+        messages = []
+        for i, days in enumerate([20, 18, 16, 14, 12, 10, 8, 6, 2, 0]):
+            messages.append(self._make_user_msg(f"msg-{i}", days_ago=days))
+            messages.append(self._make_assistant_msg(f"reply-{i}", days_ago=days))
+
+        result, removed = _trim_sms_history(messages, min_days=3, min_messages=3)
+
+        # Last 3 messages are at days 6, 2, 0 — last 3 days covers 2, 0
+        # "Whichever goes further" → 3 messages wins (goes back to day 6)
+        # So we keep messages from index 14 onward (3 user turns * 2 msgs each = 6 messages)
+        assert removed > 0
+        assert len(result) == 6  # last 3 user + assistant pairs
+
+    def test_time_window_wins_when_more_messages_in_period(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _trim_sms_history
+
+        # Many messages in last 3 days, plus old ones
+        messages = [
+            self._make_user_msg("old-1", days_ago=30),
+            self._make_assistant_msg("old-reply-1", days_ago=30),
+            self._make_user_msg("old-2", days_ago=20),
+            self._make_assistant_msg("old-reply-2", days_ago=20),
+        ]
+        # Add 5 turns within last 3 days
+        for i in range(5):
+            messages.append(self._make_user_msg(f"recent-{i}", days_ago=2))
+            messages.append(self._make_assistant_msg(f"recent-reply-{i}", days_ago=2))
+
+        result, removed = _trim_sms_history(messages, min_days=3, min_messages=3)
+
+        # 3-day window has 5 turns (10 msgs) — more than 3-message window
+        # Time window goes further back, so it wins
+        assert removed == 4  # the 4 old messages trimmed
+        assert len(result) == 10  # 5 recent turns
+
+    def test_empty_history_returns_empty(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _trim_sms_history
+
+        result, removed = _trim_sms_history([], min_days=3, min_messages=3)
+        assert result == []
+        assert removed == 0
+
+    def test_all_messages_within_window_no_trim(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _trim_sms_history
+
+        messages = [
+            self._make_user_msg("msg-1", days_ago=2),
+            self._make_assistant_msg("reply-1", days_ago=2),
+            self._make_user_msg("msg-2", days_ago=1),
+            self._make_assistant_msg("reply-2", days_ago=1),
+            self._make_user_msg("msg-3", days_ago=0),
+            self._make_assistant_msg("reply-3", days_ago=0),
+        ]
+        result, removed = _trim_sms_history(messages, min_days=3, min_messages=3)
+        assert removed == 0
+        assert len(result) == 6
 
 
 class TestVerifyInternalContact:


### PR DESCRIPTION
Default to including only last 3 days or last 3 SMS exchanges (whichever
goes further back) in the message_history passed to the agent. The agent
is told history was trimmed and can use tools to load more context:

- Add _trim_sms_history() to trim merged history after loading
- Preserve original timestamps in _sms_to_model_messages() for accurate trimming
- Add db_get_contact_sms_history tool (chronological thread, no keyword needed)
- Update agent instructions and SMS modality guidance about trimmed history
- System hint tells agent exactly how many messages were omitted and which tools to use

https://claude.ai/code/session_01EtEB2jjJozYWfTNEVzCQWT