### PR TITLE
fix: read timestamps from correct PydanticAI message fields

### DIFF
--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -186,7 +186,10 @@ def _sms_to_model_messages(messages: list[dict]) -> list[ModelMessage]:
     Outgoing (direction="outgoing") → ModelResponse with TextPart
 
     Preserves original ``createdAt`` timestamps so history trimming can
-    accurately determine message age.
+    accurately determine message age.  Timestamps are set on
+    ``UserPromptPart.timestamp`` (for requests) and
+    ``ModelResponse.timestamp`` (for responses) — the two places
+    PydanticAI actually persists them through serialization.
     """
     result: list[ModelMessage] = []
 
@@ -198,17 +201,20 @@ def _sms_to_model_messages(messages: list[dict]) -> list[ModelMessage]:
 
         ts = _parse_timestamp(msg.get("createdAt"))
         direction = msg.get("direction", "")
-        kwargs: dict = {}
-        if ts is not None:
-            kwargs["timestamp"] = ts
 
         if direction == "incoming":
+            part_kwargs: dict = {}
+            if ts is not None:
+                part_kwargs["timestamp"] = ts
             result.append(
-                ModelRequest(parts=[UserPromptPart(content=body)], **kwargs)
+                ModelRequest(parts=[UserPromptPart(content=body, **part_kwargs)])
             )
         elif direction == "outgoing":
+            resp_kwargs: dict = {}
+            if ts is not None:
+                resp_kwargs["timestamp"] = ts
             result.append(
-                ModelResponse(parts=[TextPart(content=body)], **kwargs)
+                ModelResponse(parts=[TextPart(content=body)], **resp_kwargs)
             )
 
     return result
@@ -271,6 +277,23 @@ def _merge_sms_into_history(
     return missing + db_history
 
 
+def _get_message_timestamp(msg: ModelMessage) -> datetime | None:
+    """Extract the effective timestamp from a PydanticAI message.
+
+    PydanticAI stores timestamps in different places depending on message type:
+    - ``ModelRequest``: ``ModelRequest.timestamp`` is always ``None`` after
+      serialization.  The real timestamp lives on ``UserPromptPart.timestamp``.
+    - ``ModelResponse``: ``ModelResponse.timestamp`` is preserved correctly.
+    """
+    if isinstance(msg, ModelResponse):
+        return msg.timestamp
+    if isinstance(msg, ModelRequest):
+        for part in msg.parts:
+            if isinstance(part, UserPromptPart):
+                return getattr(part, "timestamp", None)
+    return None
+
+
 def _trim_sms_history(
     messages: list[ModelMessage],
     min_days: int = SMS_HISTORY_MIN_DAYS,
@@ -296,7 +319,7 @@ def _trim_sms_history(
     # Find the first message (from the start) whose timestamp is within the window.
     time_keep_from = len(messages)  # default: nothing qualifies on time alone
     for i, msg in enumerate(messages):
-        ts = getattr(msg, "timestamp", None)
+        ts = _get_message_timestamp(msg)
         if ts is not None:
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)

--- a/api/src/tests/test_triggers.py
+++ b/api/src/tests/test_triggers.py
@@ -730,11 +730,29 @@ class TestSmsToModelMessages:
 class TestSmsTimestampPreservation:
     """Test that _sms_to_model_messages preserves original timestamps."""
 
-    def test_preserves_created_at_timestamp(self):
+    def test_preserves_created_at_timestamp_on_incoming(self):
+        """Incoming SMS: timestamp preserved on UserPromptPart (not ModelRequest, which is always None)."""
         from api.src.sernia_ai.triggers.ai_sms_event_trigger import _sms_to_model_messages
 
         messages = [
             {"body": "Hello", "direction": "incoming", "createdAt": "2025-06-15T10:30:00Z"},
+        ]
+        result = _sms_to_model_messages(messages)
+
+        assert len(result) == 1
+        # ModelRequest.timestamp is always None after serialization;
+        # the real timestamp lives on UserPromptPart.timestamp.
+        part = result[0].parts[0]
+        assert part.timestamp.year == 2025
+        assert part.timestamp.month == 6
+        assert part.timestamp.day == 15
+
+    def test_preserves_created_at_timestamp_on_outgoing(self):
+        """Outgoing SMS: timestamp preserved on ModelResponse.timestamp."""
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _sms_to_model_messages
+
+        messages = [
+            {"body": "Hi back", "direction": "outgoing", "createdAt": "2025-06-15T10:31:00Z"},
         ]
         result = _sms_to_model_messages(messages)
 
@@ -760,7 +778,8 @@ class TestTrimSmsHistory:
     def _make_user_msg(self, text: str, days_ago: int = 0) -> ModelRequest:
         from datetime import datetime, timedelta, timezone
         ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
-        return ModelRequest(parts=[UserPromptPart(content=text)], timestamp=ts)
+        # Timestamp must be on UserPromptPart (ModelRequest.timestamp is always None after ser/deser)
+        return ModelRequest(parts=[UserPromptPart(content=text, timestamp=ts)])
 
     def _make_assistant_msg(self, text: str, days_ago: int = 0) -> ModelResponse:
         from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
ModelRequest.timestamp is always None after serialization — the real timestamp lives on UserPromptPart.timestamp. ModelResponse.timestamp works correctly. Added _get_message_timestamp() helper and also fixed _sms_to_model_messages to set timestamps on UserPromptPart (part level) instead of ModelRequest (message level, always null).

https://claude.ai/code/session_01EtEB2jjJozYWfTNEVzCQWT

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed. 