### PR TITLE
feat: redesign Sernia AI conversation sidebar

### DIFF
--- a/apps/web-react-router/app/components/sernia/conversation-sidebar.tsx
+++ b/apps/web-react-router/app/components/sernia/conversation-sidebar.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
+import { useAuth, useUser } from "@clerk/react-router";
+import { cn } from "~/lib/utils";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Badge } from "~/components/ui/badge";
+import { ScrollArea } from "~/components/ui/scroll-area";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  useSidebar,
+} from "~/components/ui/sidebar";
+import {
+  Plus,
+  Search,
+  Phone,
+  Mail,
+  MessageSquare,
+  Clock,
+  Trash2,
+  Loader2,
+  Home,
+  Settings,
+  LayoutList,
+  Building,
+  X,
+  Menu,
+} from "lucide-react";
+
+const API_BASE = "/api/sernia-ai";
+
+export interface ConversationSummary {
+  conversation_id: string;
+  modality: string;
+  preview: string;
+  has_pending: boolean;
+  trigger_source: string | null;
+  trigger_contact_name: string | null;
+  participant?: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+type SourceFilter = "all" | "web_chat" | "sms" | "email";
+
+const SOURCE_FILTERS: { value: SourceFilter; label: string; icon: React.ReactNode }[] = [
+  { value: "all", label: "All", icon: null },
+  { value: "web_chat", label: "Chat", icon: <MessageSquare className="w-3 h-3" /> },
+  { value: "sms", label: "SMS", icon: <Phone className="w-3 h-3" /> },
+  { value: "email", label: "Email", icon: <Mail className="w-3 h-3" /> },
+];
+
+function modalityIcon(conv: ConversationSummary) {
+  if (conv.trigger_source === "sms" || conv.modality === "sms") {
+    return <Phone className="w-3.5 h-3.5 text-muted-foreground" />;
+  }
+  if (
+    conv.trigger_source === "email" ||
+    conv.trigger_source === "zillow_email" ||
+    conv.modality === "email"
+  ) {
+    return (
+      <Mail
+        className={cn(
+          "w-3.5 h-3.5 text-muted-foreground",
+          conv.trigger_source === "zillow_email" && "text-blue-500"
+        )}
+      />
+    );
+  }
+  return <MessageSquare className="w-3.5 h-3.5 text-muted-foreground" />;
+}
+
+function formatRelativeTime(dateString: string | null) {
+  if (!dateString) return "";
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return "now";
+  if (diffMins < 60) return `${diffMins}m`;
+  if (diffHours < 24) return `${diffHours}h`;
+  if (diffDays < 7) return `${diffDays}d`;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// ---- Cache for page 1 ----
+let cachedConversations: ConversationSummary[] | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL = 30_000; // 30 seconds
+
+function getCachedConversations(): ConversationSummary[] | null {
+  if (cachedConversations && Date.now() - cacheTimestamp < CACHE_TTL) {
+    return cachedConversations;
+  }
+  return null;
+}
+
+function setCachedConversations(convos: ConversationSummary[]) {
+  cachedConversations = convos;
+  cacheTimestamp = Date.now();
+}
+
+// ---- Prefetch function (call early, outside component) ----
+let prefetchPromise: Promise<ConversationSummary[]> | null = null;
+
+export function prefetchConversations(getToken: () => Promise<string | null>) {
+  if (getCachedConversations()) return;
+  if (prefetchPromise) return;
+
+  prefetchPromise = (async () => {
+    try {
+      const token = await getToken();
+      const res = await fetch(`${API_BASE}/conversations/history?limit=30`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const convos = data.conversations || [];
+        setCachedConversations(convos);
+        return convos;
+      }
+    } catch {
+      // silent fail for prefetch
+    } finally {
+      prefetchPromise = null;
+    }
+    return [];
+  })();
+}
+
+// ---- Main component ----
+
+interface ConversationSidebarProps {
+  activeConversationId?: string;
+  onSelectConversation: (convId: string, modality?: string) => void;
+  onNewConversation: () => void;
+  onDeleteConversation?: (convId: string) => void;
+}
+
+export function ConversationSidebar({
+  activeConversationId,
+  onSelectConversation,
+  onNewConversation,
+  onDeleteConversation,
+}: ConversationSidebarProps) {
+  const { isSignedIn, getToken } = useAuth();
+  const { user } = useUser();
+  const navigate = useNavigate();
+  const { state: sidebarState, toggleSidebar, isMobile } = useSidebar();
+  const isAdmin =
+    user?.primaryEmailAddress?.emailAddress === "emilio@serniacapital.com";
+
+  const [conversations, setConversations] = useState<ConversationSummary[]>(
+    () => getCachedConversations() || []
+  );
+  const [isLoading, setIsLoading] = useState(!getCachedConversations());
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const fetchRef = useRef(0);
+
+  const fetchConversations = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      if (!isSignedIn) return;
+      const fetchId = ++fetchRef.current;
+      if (!opts?.silent) setIsLoading(true);
+
+      try {
+        const token = await getToken();
+        const res = await fetch(`${API_BASE}/conversations/history?limit=50`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok && fetchId === fetchRef.current) {
+          const data = await res.json();
+          const convos = data.conversations || [];
+          setConversations(convos);
+          setCachedConversations(convos);
+        }
+      } catch {
+        // keep existing data on error
+      } finally {
+        if (fetchId === fetchRef.current) setIsLoading(false);
+      }
+    },
+    [isSignedIn, getToken]
+  );
+
+  // Initial load: use cache or wait for prefetch, then fetch fresh
+  useEffect(() => {
+    if (!isSignedIn) return;
+
+    const cached = getCachedConversations();
+    if (cached) {
+      setConversations(cached);
+      setIsLoading(false);
+      // Still refresh in background
+      fetchConversations({ silent: true });
+    } else if (prefetchPromise) {
+      // Wait for in-flight prefetch
+      prefetchPromise.then((convos) => {
+        if (convos && convos.length > 0) {
+          setConversations(convos);
+          setIsLoading(false);
+        } else {
+          fetchConversations();
+        }
+      });
+    } else {
+      fetchConversations();
+    }
+  }, [isSignedIn, fetchConversations]);
+
+  // Refresh when page becomes visible
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible" && isSignedIn) {
+        fetchConversations({ silent: true });
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibility);
+  }, [isSignedIn, fetchConversations]);
+
+  // Filter conversations
+  const filtered = conversations.filter((conv) => {
+    if (sourceFilter !== "all") {
+      const matchesModality = conv.modality === sourceFilter;
+      const matchesTrigger =
+        sourceFilter === "sms"
+          ? conv.trigger_source === "sms"
+          : sourceFilter === "email"
+            ? conv.trigger_source === "email" ||
+              conv.trigger_source === "zillow_email"
+            : false;
+      if (!matchesModality && !matchesTrigger) return false;
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      const matchesPreview = conv.preview?.toLowerCase().includes(q);
+      const matchesContact = conv.trigger_contact_name
+        ?.toLowerCase()
+        .includes(q);
+      const matchesParticipant = conv.participant?.toLowerCase().includes(q);
+      if (!matchesPreview && !matchesContact && !matchesParticipant)
+        return false;
+    }
+    return true;
+  });
+
+  const handleDelete = async (convId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm("Delete this conversation?")) return;
+
+    try {
+      const token = await getToken();
+      const res = await fetch(`${API_BASE}/conversation/${convId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        setConversations((prev) =>
+          prev.filter((c) => c.conversation_id !== convId)
+        );
+        onDeleteConversation?.(convId);
+      }
+    } catch {
+      console.error("Failed to delete conversation");
+    }
+  };
+
+  const handleSelect = (conv: ConversationSummary) => {
+    onSelectConversation(conv.conversation_id, conv.modality);
+    if (isMobile) toggleSidebar();
+  };
+
+  const handleNewConversation = () => {
+    onNewConversation();
+    if (isMobile) toggleSidebar();
+  };
+
+  const isCollapsed = sidebarState === "collapsed";
+
+  return (
+    <Sidebar collapsible="icon" className="border-r">
+      <SidebarHeader className="border-b border-sidebar-border">
+        <div className="flex items-center justify-between gap-1 px-1">
+          {!isCollapsed && (
+            <Link
+              to="/"
+              className="flex items-center gap-2 text-sm font-semibold hover:opacity-80 transition-opacity"
+            >
+              <Building className="w-4 h-4 text-primary" />
+              <span>Sernia AI</span>
+            </Link>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleSidebar}
+            className="h-8 w-8 shrink-0"
+          >
+            <Menu className="h-4 w-4" />
+            <span className="sr-only">Toggle sidebar</span>
+          </Button>
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {/* New conversation button */}
+        <div className={cn("px-2 pt-2", isCollapsed && "px-1")}>
+          <Button
+            variant="outline"
+            className={cn(
+              "w-full gap-2 justify-start",
+              isCollapsed && "justify-center px-0"
+            )}
+            onClick={handleNewConversation}
+          >
+            <Plus className="w-4 h-4 shrink-0" />
+            {!isCollapsed && <span>New chat</span>}
+          </Button>
+        </div>
+
+        {/* Search and filters — hidden when collapsed */}
+        {!isCollapsed && (
+          <div className="px-2 pt-2 space-y-2">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+              <Input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search conversations..."
+                className="h-8 pl-8 pr-8 text-sm"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2"
+                >
+                  <X className="w-3.5 h-3.5 text-muted-foreground hover:text-foreground" />
+                </button>
+              )}
+            </div>
+
+            <div className="flex gap-1">
+              {SOURCE_FILTERS.map((f) => (
+                <Button
+                  key={f.value}
+                  variant={sourceFilter === f.value ? "default" : "ghost"}
+                  size="sm"
+                  className={cn(
+                    "h-7 text-xs px-2 gap-1",
+                    sourceFilter === f.value
+                      ? ""
+                      : "text-muted-foreground"
+                  )}
+                  onClick={() => setSourceFilter(f.value)}
+                >
+                  {f.icon}
+                  {f.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Conversation list */}
+        <ScrollArea className="flex-1 px-2 pt-1">
+          {isLoading && conversations.length === 0 ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              {searchQuery || sourceFilter !== "all"
+                ? "No matching conversations"
+                : "No conversations yet"}
+            </p>
+          ) : (
+            <div className="space-y-0.5 pb-2">
+              {filtered.map((conv) => {
+                const isActive =
+                  conv.conversation_id === activeConversationId;
+
+                if (isCollapsed) {
+                  return (
+                    <SidebarMenu key={conv.conversation_id}>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          tooltip={conv.preview || "Empty conversation"}
+                          isActive={isActive}
+                          onClick={() => handleSelect(conv)}
+                          className="h-8 w-8 p-0 justify-center"
+                        >
+                          {modalityIcon(conv)}
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    </SidebarMenu>
+                  );
+                }
+
+                return (
+                  <div
+                    key={conv.conversation_id}
+                    className={cn(
+                      "group flex items-start gap-2 px-2 py-2 rounded-lg cursor-pointer transition-colors",
+                      isActive
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-muted"
+                    )}
+                    onClick={() => handleSelect(conv)}
+                  >
+                    <div className="shrink-0 mt-0.5">
+                      {modalityIcon(conv)}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1">
+                        <span className="text-sm truncate flex-1">
+                          {conv.preview || "Empty conversation"}
+                        </span>
+                        {conv.has_pending && (
+                          <Badge
+                            variant="outline"
+                            className="text-[10px] px-1 py-0 h-4 text-amber-600 border-amber-300 shrink-0"
+                          >
+                            Pending
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1 text-xs text-muted-foreground mt-0.5">
+                        {conv.trigger_contact_name && (
+                          <>
+                            <span className="truncate">
+                              {conv.trigger_contact_name}
+                            </span>
+                            <span>&middot;</span>
+                          </>
+                        )}
+                        {conv.participant && !conv.trigger_contact_name && (
+                          <>
+                            <span className="truncate">{conv.participant}</span>
+                            <span>&middot;</span>
+                          </>
+                        )}
+                        <span className="shrink-0">
+                          {formatRelativeTime(conv.updated_at)}
+                        </span>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity shrink-0 text-muted-foreground hover:text-destructive"
+                      onClick={(e) =>
+                        handleDelete(conv.conversation_id, e)
+                      }
+                    >
+                      <Trash2 className="w-3 h-3" />
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </ScrollArea>
+      </SidebarContent>
+
+      {/* Footer with nav links */}
+      <SidebarFooter className="border-t border-sidebar-border">
+        <SidebarMenu>
+          {isAdmin && (
+            <>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  tooltip="All Conversations"
+                  onClick={() => {
+                    navigate("/sernia-admin");
+                    if (isMobile) toggleSidebar();
+                  }}
+                >
+                  <button className="flex w-full">
+                    <LayoutList className="w-4 h-4" />
+                    {!isCollapsed && <span>All Conversations</span>}
+                  </button>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  tooltip="Settings"
+                  onClick={() => {
+                    navigate("/sernia-settings");
+                    if (isMobile) toggleSidebar();
+                  }}
+                >
+                  <button className="flex w-full">
+                    <Settings className="w-4 h-4" />
+                    {!isCollapsed && <span>Settings</span>}
+                  </button>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </>
+          )}
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Home">
+              <Link to="/">
+                <Home className="w-4 h-4" />
+                {!isCollapsed && <span>Portfolio Home</span>}
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/apps/web-react-router/app/components/sernia/conversation-sidebar.tsx
+++ b/apps/web-react-router/app/components/sernia/conversation-sidebar.tsx
@@ -487,32 +487,26 @@ export function ConversationSidebar({
             <>
               <SidebarMenuItem>
                 <SidebarMenuButton
-                  asChild
                   tooltip="All Conversations"
                   onClick={() => {
                     navigate("/sernia-admin");
                     if (isMobile) toggleSidebar();
                   }}
                 >
-                  <button className="flex w-full">
-                    <LayoutList className="w-4 h-4" />
-                    {!isCollapsed && <span>All Conversations</span>}
-                  </button>
+                  <LayoutList className="w-4 h-4" />
+                  {!isCollapsed && <span>All Conversations</span>}
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton
-                  asChild
                   tooltip="Settings"
                   onClick={() => {
                     navigate("/sernia-settings");
                     if (isMobile) toggleSidebar();
                   }}
                 >
-                  <button className="flex w-full">
-                    <Settings className="w-4 h-4" />
-                    {!isCollapsed && <span>Settings</span>}
-                  </button>
+                  <Settings className="w-4 h-4" />
+                  {!isCollapsed && <span>Settings</span>}
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </>

--- a/apps/web-react-router/app/root.tsx
+++ b/apps/web-react-router/app/root.tsx
@@ -67,7 +67,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body className={cn("antialiased")}>
+      <body className={cn("antialiased overflow-x-hidden")}>
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/apps/web-react-router/app/root.tsx
+++ b/apps/web-react-router/app/root.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLocation,
 } from "react-router";
 import {
   ClerkProvider,
@@ -75,19 +76,36 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
+const SERNIA_ROUTE_PREFIXES = ["/sernia-chat", "/sernia-admin", "/sernia-settings"];
+
+function isSerniaRoute(pathname: string) {
+  return SERNIA_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
 export default function App({ loaderData }: Route.ComponentProps) {
+  const location = useLocation();
+  const isSernia = isSerniaRoute(location.pathname);
+
   return (
     <ClerkProvider loaderData={loaderData}>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
         <Toaster />
-        <SidebarProvider>
-          <AppSidebar />
-          <SidebarInset className="min-w-0 overflow-x-hidden">
-            <Navbar />
+        {isSernia ? (
+          // Sernia routes provide their own sidebar — render Outlet directly
+          <>
             <EnvBanner />
             <Outlet />
-          </SidebarInset>
-        </SidebarProvider>
+          </>
+        ) : (
+          <SidebarProvider>
+            <AppSidebar />
+            <SidebarInset className="min-w-0 overflow-x-hidden">
+              <Navbar />
+              <EnvBanner />
+              <Outlet />
+            </SidebarInset>
+          </SidebarProvider>
+        )}
       </ThemeProvider>
     </ClerkProvider>
   );

--- a/apps/web-react-router/app/routes/sernia-admin.tsx
+++ b/apps/web-react-router/app/routes/sernia-admin.tsx
@@ -73,8 +73,10 @@ import {
   ArrowUpDown,
   ArrowDown,
   ArrowUp,
-  Settings,
+  Menu,
 } from "lucide-react";
+import { SidebarProvider, SidebarInset, useSidebar } from "~/components/ui/sidebar";
+import { ConversationSidebar } from "~/components/sernia/conversation-sidebar";
 
 const API_BASE = "/api/sernia-ai";
 const PAGE_SIZE = 30;
@@ -394,6 +396,24 @@ function ConversationDetail({
 }
 
 // ---------------------------------------------------------------------------
+// Mobile sidebar toggle
+// ---------------------------------------------------------------------------
+
+function MobileSidebarToggle() {
+  const { toggleSidebar } = useSidebar();
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8 shrink-0 md:hidden"
+      onClick={toggleSidebar}
+    >
+      <Menu className="w-4 h-4" />
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main Admin Page
 // ---------------------------------------------------------------------------
 
@@ -572,15 +592,33 @@ export default function SerniaAdminPage() {
     getFacetedUniqueValues: getFacetedUniqueValues(),
   });
 
+  const handleSelectConversation = useCallback(
+    (convId: string) => {
+      navigate(`/sernia-chat?id=${convId}`);
+    },
+    [navigate]
+  );
+
+  const handleNewConversation = useCallback(() => {
+    navigate("/sernia-chat");
+  }, [navigate]);
+
   return (
     <AuthGuard
       requireDomain="serniacapital.com"
       message="Admin access required"
       icon={<Building className="w-16 h-16 text-muted-foreground" />}
     >
-      <div className="flex flex-col h-[calc(100dvh-52px)] bg-background">
+      <SidebarProvider>
+        <ConversationSidebar
+          onSelectConversation={handleSelectConversation}
+          onNewConversation={handleNewConversation}
+        />
+        <SidebarInset className="min-w-0 overflow-x-hidden">
+      <div className="flex flex-col h-dvh bg-background">
         {/* Header */}
         <div className="flex items-center gap-3 px-4 py-3 border-b">
+          <MobileSidebarToggle />
           <Button
             variant="ghost"
             size="icon"
@@ -590,17 +628,8 @@ export default function SerniaAdminPage() {
             <ArrowLeft className="w-4 h-4" />
           </Button>
           <div className="flex-1 min-w-0">
-            <h1 className="text-lg font-semibold">Conversations</h1>
+            <h1 className="text-lg font-semibold">All Conversations</h1>
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={() => navigate("/sernia-settings")}
-            title="Schedule & trigger settings"
-          >
-            <Settings className="w-4 h-4" />
-          </Button>
           <Button
             variant="outline"
             size="sm"
@@ -780,6 +809,8 @@ export default function SerniaAdminPage() {
           )}
         </SheetContent>
       </Sheet>
+        </SidebarInset>
+      </SidebarProvider>
     </AuthGuard>
   );
 }

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -483,6 +483,7 @@ function ChatView({
               />
               <Textarea
                 ref={textareaRef}
+                autoComplete="off"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
@@ -531,6 +532,7 @@ function ChatView({
               />
               <Textarea
                 ref={textareaRef}
+                autoComplete="off"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -22,33 +22,20 @@ import {
   StopCircle,
   Send,
   Loader2,
-  History,
   Plus,
-  Clock,
-  Trash2,
   RefreshCw,
   Bell,
   BellOff,
   Share,
   Download,
   Phone,
-  Mail,
-  Settings,
   Upload,
-  LayoutList,
+  Menu,
 } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "~/components/ui/sheet";
-import {
   ToolApprovalCard,
   ToolResultCard,
-  convertPendingFromApi,
   convertAllPendingFromApi,
   type PendingApproval,
 } from "~/components/chat/tool-cards";
@@ -59,6 +46,11 @@ import {
   FilePreviewStrip,
 } from "~/components/chat/file-attachment-area";
 import { FileMessageDisplay } from "~/components/chat/file-message-display";
+import { SidebarProvider, SidebarInset, useSidebar } from "~/components/ui/sidebar";
+import {
+  ConversationSidebar,
+  prefetchConversations,
+} from "~/components/sernia/conversation-sidebar";
 
 const API_BASE = "/api/sernia-ai";
 
@@ -87,17 +79,6 @@ const suggestedPrompts = [
     prompt: "Search for recent property info",
   },
 ];
-
-interface ConversationSummary {
-  conversation_id: string;
-  modality: string;
-  preview: string;
-  has_pending: boolean;
-  trigger_source: string | null;
-  trigger_contact_name: string | null;
-  created_at: string | null;
-  updated_at: string | null;
-}
 
 // ---------------------------------------------------------------------------
 // Inner chat component — remounts on conversation switch via `key` prop
@@ -761,7 +742,90 @@ function SystemInstructionsView({
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Outer page component — manages conversation selection & history
+// Chat header with sidebar toggle, admin tabs, push notifications
+// ---------------------------------------------------------------------------
+
+function ChatHeader({
+  isAdmin,
+  push,
+  onNewConversation,
+}: {
+  isAdmin: boolean;
+  push: ReturnType<typeof usePushNotifications>;
+  onNewConversation: () => void;
+}) {
+  const { toggleSidebar, isMobile } = useSidebar();
+
+  return (
+    <div className="flex items-center justify-between px-2 sm:px-4 py-2 border-b min-w-0">
+      <div className="flex items-center gap-1 min-w-0">
+        {/* Mobile sidebar toggle */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0 md:hidden"
+          onClick={toggleSidebar}
+        >
+          <Menu className="w-4 h-4" />
+        </Button>
+
+        {isAdmin && (
+          <TabsList>
+            <TabsTrigger value="chat">Chat</TabsTrigger>
+            <TabsTrigger value="instructions">Instructions</TabsTrigger>
+          </TabsList>
+        )}
+      </div>
+      <div className="flex items-center gap-0.5 shrink-0">
+        {push.isSupported && !push.needsInstall && (
+          <Button
+            variant={push.shouldPrompt ? "outline" : "ghost"}
+            size="icon"
+            className={cn("h-8 w-8", push.shouldPrompt && "animate-pulse")}
+            onClick={push.isSubscribed ? push.unsubscribe : push.subscribe}
+            disabled={push.isLoading || push.permission === "denied"}
+            title={
+              push.permission === "denied"
+                ? "Notifications blocked — update browser settings"
+                : push.isSubscribed
+                  ? "Disable push notifications"
+                  : "Enable push notifications"
+            }
+          >
+            {push.isSubscribed ? (
+              <Bell className="w-4 h-4" />
+            ) : (
+              <BellOff className="w-4 h-4 text-muted-foreground" />
+            )}
+          </Button>
+        )}
+        {push.canInstall && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={push.promptInstall}
+            title="Install Sernia Capital app"
+          >
+            <Download className="w-4 h-4" />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onNewConversation}
+          title="New conversation"
+        >
+          <Plus className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Outer page component — manages conversation selection & sidebar layout
 // ---------------------------------------------------------------------------
 
 export default function SerniaChatPage() {
@@ -770,7 +834,8 @@ export default function SerniaChatPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
-  const isAdmin = user?.primaryEmailAddress?.emailAddress === "emilio@serniacapital.com";
+  const isAdmin =
+    user?.primaryEmailAddress?.emailAddress === "emilio@serniacapital.com";
   const urlConversationId = searchParams.get("id");
   const [conversationId, setConversationId] = useState<string>(
     () => urlConversationId || crypto.randomUUID()
@@ -784,52 +849,26 @@ export default function SerniaChatPage() {
     useState<PendingApproval | null>(null);
   const [loadedAllPending, setLoadedAllPending] =
     useState<PendingApproval[]>([]);
-  const [conversationModality, setConversationModality] = useState<string>("web_chat");
-
-  const [conversationHistory, setConversationHistory] = useState<
-    ConversationSummary[]
-  >([]);
-  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
-  const [historyOpen, setHistoryOpen] = useState(false);
+  const [conversationModality, setConversationModality] =
+    useState<string>("web_chat");
   const push = usePushNotifications();
 
-  // Fetch conversation history
-  const fetchHistory = useCallback(async () => {
-    if (!isSignedIn) return;
-    setIsLoadingHistory(true);
-    try {
-      const token = await getToken();
-      const res = await fetch(`${API_BASE}/conversations/history`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setConversationHistory(data.conversations || []);
-      }
-    } catch (err) {
-      console.error("Failed to fetch history:", err);
-    } finally {
-      setIsLoadingHistory(false);
+  // Prefetch conversations for the sidebar as early as possible
+  useEffect(() => {
+    if (isSignedIn) {
+      prefetchConversations(getToken);
     }
   }, [isSignedIn, getToken]);
 
-  // Prefetch on mount so the list is ready when user opens history
-  useEffect(() => {
-    if (isSignedIn) fetchHistory();
-  }, [isSignedIn, fetchHistory]);
-
-  // Refresh when sheet opens (in case new conversations were created)
-  useEffect(() => {
-    if (historyOpen) fetchHistory();
-  }, [historyOpen, fetchHistory]);
-
   // Load conversation messages from API
-  // When silent=true, skip the loading spinner (used for background refreshes)
   const loadConversation = useCallback(
-    async (convId: string, opts?: { updateUrl?: boolean; modality?: string; silent?: boolean }) => {
+    async (
+      convId: string,
+      opts?: { updateUrl?: boolean; modality?: string; silent?: boolean }
+    ) => {
       if (!isSignedIn) return;
       if (!opts?.silent) {
-        setLoadedMessages(null); // triggers loading state
+        setLoadedMessages(null);
       }
 
       try {
@@ -855,9 +894,9 @@ export default function SerniaChatPage() {
         setConversationId(convId);
         setLoadedMessages(data.messages || []);
         setConversationModality(
-          opts?.modality || (convId.startsWith("ai_sms_from_") ? "sms" : "web_chat")
+          opts?.modality ||
+            (convId.startsWith("ai_sms_from_") ? "sms" : "web_chat")
         );
-        setHistoryOpen(false);
 
         if (opts?.updateUrl !== false) {
           navigate(`/sernia-chat?id=${convId}`, { replace: true });
@@ -874,7 +913,6 @@ export default function SerniaChatPage() {
   );
 
   // Load from URL on mount or when URL conversation ID changes
-  // (e.g. notification click navigates to a different conversation)
   useEffect(() => {
     if (urlConversationId && isSignedIn) {
       loadConversation(urlConversationId, { updateUrl: false });
@@ -884,21 +922,23 @@ export default function SerniaChatPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSignedIn, urlConversationId]);
 
-  // Re-fetch conversation when page regains visibility (covers PWA focus,
-  // notification click to same conversation, and tab switching).
-  // Uses silent mode to refresh messages in the background without showing
-  // the loading spinner or unmounting ChatView (preserves draft input).
+  // Re-fetch conversation when page regains visibility
   useEffect(() => {
     const handleVisibility = () => {
-      if (document.visibilityState === "visible" && isSignedIn && conversationId) {
+      if (
+        document.visibilityState === "visible" &&
+        isSignedIn &&
+        conversationId
+      ) {
         loadConversation(conversationId, { updateUrl: false, silent: true });
       }
     };
     document.addEventListener("visibilitychange", handleVisibility);
-    return () => document.removeEventListener("visibilitychange", handleVisibility);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibility);
   }, [isSignedIn, conversationId, loadConversation]);
 
-  // Listen for service worker messages (e.g. notification click on same conversation)
+  // Listen for service worker messages (notification click)
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       if (event.data?.type === "notification-click" && isSignedIn) {
@@ -909,287 +949,107 @@ export default function SerniaChatPage() {
       }
     };
     navigator.serviceWorker?.addEventListener("message", handler);
-    return () => navigator.serviceWorker?.removeEventListener("message", handler);
+    return () =>
+      navigator.serviceWorker?.removeEventListener("message", handler);
   }, [isSignedIn, loadConversation]);
 
-  // Delete a conversation
-  const deleteConversation = useCallback(
-    async (convId: string, e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (!isSignedIn) return;
-      if (!confirm("Are you sure you want to delete this conversation?"))
-        return;
-
-      try {
-        const token = await getToken();
-        const res = await fetch(`${API_BASE}/conversation/${convId}`, {
-          method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
-        });
-
-        if (res.ok) {
-          setConversationHistory((prev) =>
-            prev.filter((c) => c.conversation_id !== convId)
-          );
-          if (convId === conversationId) {
-            startNewConversation();
-          }
-        }
-      } catch (err) {
-        console.error("Failed to delete conversation:", err);
-      }
-    },
-    [isSignedIn, getToken, conversationId]
-  );
-
-  const startNewConversation = () => {
+  const startNewConversation = useCallback(() => {
     const newId = crypto.randomUUID();
     setConversationId(newId);
     setLoadedMessages([]);
     setLoadedPending(null);
     setLoadedAllPending([]);
     setConversationModality("web_chat");
-    setHistoryOpen(false);
     navigate(`/sernia-chat?id=${newId}`, { replace: true });
-  };
+  }, [navigate]);
 
-  const formatDate = (dateString: string | null) => {
-    if (!dateString) return "";
-    const date = new Date(dateString);
-    return date.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
-  };
+  const handleSelectConversation = useCallback(
+    (convId: string, modality?: string) => {
+      loadConversation(convId, { modality });
+    },
+    [loadConversation]
+  );
+
+  const handleDeleteConversation = useCallback(
+    (convId: string) => {
+      if (convId === conversationId) {
+        startNewConversation();
+      }
+    },
+    [conversationId, startNewConversation]
+  );
 
   // Loading state (waiting for messages to load from API)
   const isLoading = loadedMessages === null;
-
-  if (isLoading) {
-    return (
-      <AuthGuard
-        requireDomain="serniacapital.com"
-        message="Sernia AI assistant"
-        icon={<Building className="w-16 h-16 text-muted-foreground" />}
-      >
-        <div className="flex flex-col items-center justify-center h-[calc(100dvh-52px)] gap-4">
-          <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
-          <p className="text-muted-foreground">Loading conversation...</p>
-        </div>
-      </AuthGuard>
-    );
-  }
 
   return (
     <AuthGuard
       message="Sernia AI assistant"
       icon={<Building className="w-16 h-16 text-muted-foreground" />}
     >
-      <Tabs
-        defaultValue="chat"
-        className="flex flex-col min-w-0 h-[calc(100dvh-52px)] bg-background"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-2 sm:px-4 py-2 border-b min-w-0">
-          <div className="flex items-center gap-1 min-w-0">
-            <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
-              <SheetTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
-                  <History className="w-4 h-4" />
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="left" className="w-80">
-                <SheetHeader>
-                  <SheetTitle>Conversation History</SheetTitle>
-                </SheetHeader>
-                <div className="mt-4 space-y-2">
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start gap-2"
-                    onClick={startNewConversation}
-                  >
-                    <Plus className="w-4 h-4" />
-                    New Conversation
-                  </Button>
-                  <div className="h-px bg-border my-2" />
-                  {isLoadingHistory ? (
-                    <div className="flex justify-center py-4">
-                      <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-                    </div>
-                  ) : conversationHistory.length === 0 ? (
-                    <p className="text-sm text-muted-foreground text-center py-4">
-                      No previous conversations
-                    </p>
-                  ) : (
-                    conversationHistory.map((conv) => (
-                      <div
-                        key={conv.conversation_id}
-                        className={cn(
-                          "group flex items-center gap-1 p-2 rounded-lg hover:bg-muted transition-colors",
-                          conv.conversation_id === conversationId &&
-                            "bg-muted"
-                        )}
-                      >
-                        <button
-                          onClick={() =>
-                            loadConversation(conv.conversation_id, { modality: conv.modality })
-                          }
-                          className="flex-1 text-left min-w-0"
-                        >
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm truncate flex-1">
-                              {conv.preview || "Empty conversation"}
-                            </span>
-                            {conv.has_pending && (
-                              <Badge
-                                variant="outline"
-                                className="ml-2 text-xs"
-                              >
-                                Pending
-                              </Badge>
-                            )}
-                          </div>
-                          <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
-                            {conv.trigger_source === "sms" ? (
-                              <Phone className="w-3 h-3" />
-                            ) : conv.trigger_source === "email" || conv.trigger_source === "zillow_email" ? (
-                              <Mail className={cn("w-3 h-3", conv.trigger_source === "zillow_email" && "text-blue-500")} />
-                            ) : (
-                              <Clock className="w-3 h-3" />
-                            )}
-                            {conv.trigger_contact_name || formatDate(conv.updated_at)}
-                          </div>
-                        </button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
-                          onClick={(e) =>
-                            deleteConversation(conv.conversation_id, e)
-                          }
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
-                      </div>
-                    ))
-                  )}
+      <SidebarProvider>
+        <ConversationSidebar
+          activeConversationId={conversationId}
+          onSelectConversation={handleSelectConversation}
+          onNewConversation={startNewConversation}
+          onDeleteConversation={handleDeleteConversation}
+        />
+        <SidebarInset className="min-w-0 overflow-x-hidden">
+          {isLoading ? (
+            <div className="flex flex-col items-center justify-center h-dvh gap-4">
+              <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+              <p className="text-muted-foreground">Loading conversation...</p>
+            </div>
+          ) : (
+            <Tabs
+              defaultValue="chat"
+              className="flex flex-col min-w-0 h-dvh bg-background"
+            >
+              <ChatHeader
+                isAdmin={isAdmin}
+                push={push}
+                onNewConversation={startNewConversation}
+              />
+
+              {/* iOS install banner */}
+              {push.needsInstall && (
+                <div className="flex items-center gap-2 px-4 py-2 border-b bg-muted/50 text-xs text-muted-foreground">
+                  <Share className="w-3.5 h-3.5 shrink-0" />
+                  <span>
+                    {push.iosBrowser === "chrome"
+                      ? "For notifications: tap Share (top right) → Add to Home Screen"
+                      : "For notifications: tap Share (bottom center) → Add to Home Screen"}
+                  </span>
                 </div>
-              </SheetContent>
-            </Sheet>
+              )}
 
-            {isAdmin && (
-              <>
-                <TabsList>
-                  <TabsTrigger value="chat">Chat</TabsTrigger>
-                  <TabsTrigger value="instructions">Instructions</TabsTrigger>
-
-                </TabsList>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  onClick={() => navigate("/sernia-admin")}
-                  title="Browse all conversations"
-                >
-                  <LayoutList className="w-4 h-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  onClick={() => navigate("/sernia-settings")}
-                  title="Schedule & trigger settings"
-                >
-                  <Settings className="w-4 h-4" />
-                </Button>
-              </>
-            )}
-          </div>
-          <div className="flex items-center gap-0.5 shrink-0">
-            {push.isSupported && !push.needsInstall && (
-              <Button
-                variant={push.shouldPrompt ? "outline" : "ghost"}
-                size="icon"
-                className={cn("h-8 w-8", push.shouldPrompt && "animate-pulse")}
-                onClick={push.isSubscribed ? push.unsubscribe : push.subscribe}
-                disabled={push.isLoading || push.permission === "denied"}
-                title={
-                  push.permission === "denied"
-                    ? "Notifications blocked — update browser settings"
-                    : push.isSubscribed
-                      ? "Disable push notifications"
-                      : "Enable push notifications"
-                }
+              <TabsContent
+                value="chat"
+                className="flex-1 flex flex-col min-h-0 mt-0"
               >
-                {push.isSubscribed ? (
-                  <Bell className="w-4 h-4" />
-                ) : (
-                  <BellOff className="w-4 h-4 text-muted-foreground" />
-                )}
-              </Button>
-            )}
-            {push.canInstall && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                onClick={push.promptInstall}
-                title="Install Sernia Capital app"
-              >
-                <Download className="w-4 h-4" />
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={startNewConversation}
-              title="New conversation"
-            >
-              <Plus className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
+                <ChatView
+                  key={conversationId}
+                  conversationId={conversationId}
+                  initialMessages={loadedMessages}
+                  initialPending={loadedPending}
+                  initialAllPending={loadedAllPending}
+                  getToken={getToken}
+                  readOnly={conversationModality === "sms"}
+                />
+              </TabsContent>
 
-        {/* iOS install banner — shown when push requires Add to Home Screen */}
-        {push.needsInstall && (
-          <div className="flex items-center gap-2 px-4 py-2 border-b bg-muted/50 text-xs text-muted-foreground">
-            <Share className="w-3.5 h-3.5 shrink-0" />
-            <span>
-              {push.iosBrowser === "chrome"
-                ? "For notifications: tap Share (top right) → Add to Home Screen"
-                : "For notifications: tap Share (bottom center) → Add to Home Screen"}
-            </span>
-          </div>
-        )}
-
-        <TabsContent
-          value="chat"
-          className="flex-1 flex flex-col min-h-0 mt-0"
-        >
-          {/* ChatView — keyed by conversationId to force clean remount */}
-          <ChatView
-            key={conversationId}
-            conversationId={conversationId}
-            initialMessages={loadedMessages}
-            initialPending={loadedPending}
-            initialAllPending={loadedAllPending}
-            getToken={getToken}
-            readOnly={conversationModality === "sms"}
-          />
-        </TabsContent>
-
-        {isAdmin && (
-          <>
-            <TabsContent
-              value="instructions"
-              className="flex-1 flex flex-col min-h-0 mt-0"
-            >
-              <SystemInstructionsView getToken={getToken} />
-            </TabsContent>
-          </>
-        )}
-      </Tabs>
+              {isAdmin && (
+                <TabsContent
+                  value="instructions"
+                  className="flex-1 flex flex-col min-h-0 mt-0"
+                >
+                  <SystemInstructionsView getToken={getToken} />
+                </TabsContent>
+              )}
+            </Tabs>
+          )}
+        </SidebarInset>
+      </SidebarProvider>
     </AuthGuard>
   );
 }

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -359,7 +359,7 @@ function ChatView({
 
                   <div
                     className={cn(
-                      "flex flex-col gap-2 max-w-[85%] min-w-0 overflow-hidden",
+                      "flex flex-col gap-2 max-w-[85%] min-w-0",
                       message.role === "user" && "items-end"
                     )}
                   >
@@ -382,8 +382,8 @@ function ChatView({
                       <>
                         {segments.map((seg, i) =>
                           seg.type === "text" ? (
-                            <div key={i} className="bg-muted/50 rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden">
-                              <div className="text-sm prose prose-sm dark:prose-invert max-w-none break-words">
+                            <div key={i} className="bg-muted/50 rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
+                              <div className="text-sm prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
                                 <Markdown>{seg.content}</Markdown>
                               </div>
                             </div>

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -451,10 +451,7 @@ function ChatView({
           SMS conversation — reply via text message
         </div>
       ) : (
-      <form
-        onSubmit={handleSubmit}
-        autoComplete="none"
-        data-form-type="other"
+      <div
         className="shrink-0 flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-3xl"
       >
         {messages.length === 0 ? (
@@ -486,10 +483,6 @@ function ChatView({
               />
               <Textarea
                 ref={textareaRef}
-                autoComplete="none"
-                data-1p-ignore
-                data-lpignore="true"
-                data-form-type="other"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
@@ -507,7 +500,8 @@ function ChatView({
                 }
               />
               <Button
-                type="submit"
+                type="button"
+                onClick={() => handleSubmit()}
                 size="icon"
                 disabled={
                   (!input.trim() && !attachment.hasFiles) ||
@@ -537,10 +531,6 @@ function ChatView({
               />
               <Textarea
                 ref={textareaRef}
-                autoComplete="none"
-                data-1p-ignore
-                data-lpignore="true"
-                data-form-type="other"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
@@ -575,7 +565,8 @@ function ChatView({
                 </Button>
               ) : (
                 <Button
-                  type="submit"
+                  type="button"
+                  onClick={() => handleSubmit()}
                   size="icon"
                   disabled={
                     (!input.trim() && !attachment.hasFiles) ||
@@ -590,7 +581,7 @@ function ChatView({
             </div>
           </div>
         )}
-      </form>
+      </div>
       )}
     </>
   );

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -452,7 +452,7 @@ function ChatView({
         </div>
       ) : (
       <div
-        className="shrink-0 flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-3xl"
+        className="shrink-0 flex mx-auto px-4 bg-background py-3 md:py-4 gap-2 w-full md:max-w-3xl border-t"
       >
         {messages.length === 0 ? (
           <div className="flex flex-col gap-4 w-full">

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -453,7 +453,7 @@ function ChatView({
       ) : (
       <form
         onSubmit={handleSubmit}
-        autoComplete="off"
+        autoComplete="none"
         data-form-type="other"
         className="shrink-0 flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-3xl"
       >
@@ -486,8 +486,7 @@ function ChatView({
               />
               <Textarea
                 ref={textareaRef}
-                name="chat-message"
-                autoComplete="off"
+                autoComplete="none"
                 data-1p-ignore
                 data-lpignore="true"
                 data-form-type="other"
@@ -538,8 +537,7 @@ function ChatView({
               />
               <Textarea
                 ref={textareaRef}
-                name="chat-message"
-                autoComplete="off"
+                autoComplete="none"
                 data-1p-ignore
                 data-lpignore="true"
                 data-form-type="other"

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -853,6 +853,13 @@ export default function SerniaChatPage() {
     useState<string>("web_chat");
   const push = usePushNotifications();
 
+  // Track IDs created locally so the URL-change effect skips the API call
+  const newConversationIds = useRef<Set<string>>(new Set());
+  // If the initial load has no URL id, it's a new conversation — register it
+  if (!urlConversationId) {
+    newConversationIds.current.add(conversationId);
+  }
+
   // Prefetch conversations for the sidebar as early as possible
   useEffect(() => {
     if (isSignedIn) {
@@ -915,6 +922,11 @@ export default function SerniaChatPage() {
   // Load from URL on mount or when URL conversation ID changes
   useEffect(() => {
     if (urlConversationId && isSignedIn) {
+      // Skip API call for conversations we just created locally
+      if (newConversationIds.current.has(urlConversationId)) {
+        newConversationIds.current.delete(urlConversationId);
+        return;
+      }
       loadConversation(urlConversationId, { updateUrl: false });
     } else if (!urlConversationId && isSignedIn) {
       navigate(`/sernia-chat?id=${conversationId}`, { replace: true });
@@ -955,6 +967,7 @@ export default function SerniaChatPage() {
 
   const startNewConversation = useCallback(() => {
     const newId = crypto.randomUUID();
+    newConversationIds.current.add(newId);
     setConversationId(newId);
     setLoadedMessages([]);
     setLoadedPending(null);

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -454,6 +454,7 @@ function ChatView({
       <form
         onSubmit={handleSubmit}
         autoComplete="off"
+        data-form-type="other"
         className="shrink-0 flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-3xl"
       >
         {messages.length === 0 ? (
@@ -487,6 +488,9 @@ function ChatView({
                 ref={textareaRef}
                 name="chat-message"
                 autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
@@ -536,6 +540,9 @@ function ChatView({
                 ref={textareaRef}
                 name="chat-message"
                 autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {

--- a/apps/web-react-router/app/routes/sernia-settings.tsx
+++ b/apps/web-react-router/app/routes/sernia-settings.tsx
@@ -84,7 +84,6 @@ export default function SerniaSettingsPage() {
   const { getToken } = useAuth();
   const navigate = useNavigate();
 
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -105,7 +104,6 @@ export default function SerniaSettingsPage() {
 
   // Fetch settings
   const fetchSettings = useCallback(async () => {
-    setLoading(true);
     setError(null);
     try {
       const token = await getToken();
@@ -120,8 +118,6 @@ export default function SerniaSettingsPage() {
       setSaved(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load settings");
-    } finally {
-      setLoading(false);
     }
   }, [getToken]);
 
@@ -253,11 +249,6 @@ export default function SerniaSettingsPage() {
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
-          {loading ? (
-            <div className="flex justify-center py-16">
-              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : (
             <div className="max-w-2xl mx-auto p-4 space-y-6">
               {/* Status messages */}
               {error && (
@@ -393,7 +384,6 @@ export default function SerniaSettingsPage() {
                 </CardContent>
               </Card>
             </div>
-          )}
         </div>
       </div>
         </SidebarInset>

--- a/apps/web-react-router/app/routes/sernia-settings.tsx
+++ b/apps/web-react-router/app/routes/sernia-settings.tsx
@@ -249,6 +249,11 @@ export default function SerniaSettingsPage() {
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
+          {saved === null && !error ? (
+            <div className="flex justify-center py-16">
+              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
             <div className="max-w-2xl mx-auto p-4 space-y-6">
               {/* Status messages */}
               {error && (
@@ -384,6 +389,7 @@ export default function SerniaSettingsPage() {
                 </CardContent>
               </Card>
             </div>
+          )}
         </div>
       </div>
         </SidebarInset>

--- a/apps/web-react-router/app/routes/sernia-settings.tsx
+++ b/apps/web-react-router/app/routes/sernia-settings.tsx
@@ -7,7 +7,6 @@ import { Button } from "~/components/ui/button";
 import { Switch } from "~/components/ui/switch";
 import { Label } from "~/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "~/components/ui/card";
-import { Badge } from "~/components/ui/badge";
 import { cn } from "~/lib/utils";
 import {
   Building,
@@ -15,7 +14,10 @@ import {
   ArrowLeft,
   Save,
   RotateCcw,
+  Menu,
 } from "lucide-react";
+import { SidebarProvider, SidebarInset, useSidebar } from "~/components/ui/sidebar";
+import { ConversationSidebar } from "~/components/sernia/conversation-sidebar";
 
 const API_BASE = "/api/sernia-ai";
 
@@ -62,6 +64,20 @@ interface ScheduleConfig {
 interface Settings {
   triggers_enabled: boolean;
   schedule_config: ScheduleConfig;
+}
+
+function SettingsMobileSidebarToggle() {
+  const { toggleSidebar } = useSidebar();
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8 shrink-0 md:hidden"
+      onClick={toggleSidebar}
+    >
+      <Menu className="w-4 h-4" />
+    </Button>
+  );
 }
 
 export default function SerniaSettingsPage() {
@@ -174,15 +190,33 @@ export default function SerniaSettingsPage() {
       prev.includes(h) ? prev.filter((x) => x !== h) : [...prev, h]
     );
 
+  const handleSelectConversation = useCallback(
+    (convId: string) => {
+      navigate(`/sernia-chat?id=${convId}`);
+    },
+    [navigate]
+  );
+
+  const handleNewConversation = useCallback(() => {
+    navigate("/sernia-chat");
+  }, [navigate]);
+
   return (
     <AuthGuard
       requireDomain="serniacapital.com"
       message="Admin access required"
       icon={<Building className="w-16 h-16 text-muted-foreground" />}
     >
-      <div className="flex flex-col h-[calc(100dvh-52px)] bg-background">
+      <SidebarProvider>
+        <ConversationSidebar
+          onSelectConversation={handleSelectConversation}
+          onNewConversation={handleNewConversation}
+        />
+        <SidebarInset className="min-w-0 overflow-x-hidden">
+      <div className="flex flex-col h-dvh bg-background">
         {/* Header */}
         <div className="flex items-center gap-3 px-4 py-3 border-b">
+          <SettingsMobileSidebarToggle />
           <Button
             variant="ghost"
             size="icon"
@@ -362,6 +396,8 @@ export default function SerniaSettingsPage() {
           )}
         </div>
       </div>
+        </SidebarInset>
+      </SidebarProvider>
     </AuthGuard>
   );
 }


### PR DESCRIPTION
Replace the Sheet-based conversation history drawer with a persistent
collapsible sidebar using shadcn's Sidebar component. The global app
sidebar is now hidden on all sernia routes, replaced with a dedicated
conversation sidebar that includes:

- Unified view of all conversations (web chat, SMS, email triggers)
- Source type filters (All/Chat/SMS/Email) and text search
- Prefetch + cache of page 1 for instant sidebar load
- Collapsible icon mode with tooltips
- Home link + admin nav (Settings, All Conversations) in footer
- Mobile-responsive (Sheet on mobile, fixed sidebar on desktop)

All three sernia routes (chat, admin, settings) share the same sidebar
layout for consistent navigation.

https://claude.ai/code/session_01DxbU7NM9H2Yn2jJQBTg8wi