### PR TITLE
fix: resolve Logfire alert issues - glob pattern and unprocessed tool calls

### DIFF
--- a/api/src/sernia_ai/agent.py
+++ b/api/src/sernia_ai/agent.py
@@ -137,9 +137,16 @@ async def search_files(
     Args:
         query: Text to search for (case-insensitive substring match).
         glob_pattern: Glob pattern to filter files (default: all .md files).
+                      Use relative patterns like "**/*.md", not absolute paths.
     """
+    # Strip /workspace/ prefix and leading slashes - glob() only supports relative patterns
+    pattern = glob_pattern
+    if pattern.startswith("/workspace/"):
+        pattern = pattern[len("/workspace/") :]
+    pattern = pattern.lstrip("/")
+
     results: list[str] = []
-    for path in sorted(ctx.deps.workspace_path.glob(glob_pattern)):
+    for path in sorted(ctx.deps.workspace_path.glob(pattern)):
         if not path.is_file():
             continue
         try:

--- a/api/src/sernia_ai/routes.py
+++ b/api/src/sernia_ai/routes.py
@@ -48,6 +48,7 @@ from api.src.ai_demos.models import (
 from api.src.sernia_ai.triggers.ai_sms_event_trigger import (
     _fetch_sms_thread,
     _merge_sms_into_history,
+    _sanitize_tool_calls,
 )
 from api.src.sernia_ai.memory.git_sync import commit_and_push
 from api.src.sernia_ai.push.routes import router as push_router
@@ -227,6 +228,8 @@ async def chat_sernia(
     backend_message_history = await _merge_sms_if_needed(
         conversation_id, backend_message_history
     )
+    # Remove trailing unprocessed tool calls (can happen if a previous run crashed)
+    backend_message_history = _sanitize_tool_calls(backend_message_history)
 
     logfire.info(
         "sernia chat",

--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -31,6 +31,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     TextPart,
+    ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
 )
@@ -373,6 +374,37 @@ def _trim_sms_history(
     return messages[keep_from:], keep_from
 
 
+def _sanitize_tool_calls(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Remove trailing unprocessed tool calls from message history.
+
+    PydanticAI raises UserError if the history ends with a ModelResponse
+    containing ToolCallPart without a subsequent ToolReturnPart. This can
+    happen when history is trimmed mid-conversation or a previous run crashed.
+
+    Walks backwards from the end, removing messages until we reach a state
+    where no tool calls are pending.
+    """
+    if not messages:
+        return messages
+
+    result = list(messages)
+
+    while result:
+        last = result[-1]
+        if isinstance(last, ModelResponse):
+            has_tool_call = any(isinstance(p, ToolCallPart) for p in last.parts)
+            if has_tool_call:
+                logfire.info(
+                    "ai_sms_event: removing trailing tool call",
+                    removed_message_type=type(last).__name__,
+                )
+                result.pop()
+                continue
+        break
+
+    return result
+
+
 async def _send_sms_reply(to_phone: str, message: str) -> None:
     """Send an SMS reply from the AI phone number, auto-splitting if long. Never raises."""
     from api.src.sernia_ai.tools.quo_tools import split_sms
@@ -458,14 +490,16 @@ async def handle_ai_sms_event(event_data: dict) -> None:
         sms_thread = await _fetch_sms_thread(from_number)
 
         merged = _merge_sms_into_history(db_history, sms_thread)
-        history, trimmed_count = _trim_sms_history(merged)
+        trimmed, trimmed_count = _trim_sms_history(merged)
+        history = _sanitize_tool_calls(trimmed)
         logfire.info(
             "ai_sms_event: history loaded",
             from_number=from_number,
             db_messages=len(db_history),
             sms_messages=len(sms_thread),
             merged_messages=len(merged),
-            after_trim=len(history),
+            after_trim=len(trimmed),
+            after_sanitize=len(history),
             trimmed=trimmed_count,
         )
 


### PR DESCRIPTION
## Summary
- Fix `search_files` NotImplementedError by stripping `/workspace/` prefix from glob patterns (Path.glob() only supports relative patterns)
- Fix UserError about unprocessed tool calls by sanitizing history to remove trailing orphaned ToolCallParts before agent runs

## Test plan
- [x] Verified `_sanitize_tool_calls()` correctly removes trailing tool calls
- [x] Verified glob pattern normalization handles `/workspace/`, `/`, and relative paths
- [x] All module imports successful

Fixes Logfire issues #76, #77, #78, #79

Slack thread: https://panepartnersllc.slack.com/archives/C09T58LBLRE/p1776632786403759

https://claude.ai/code/session_01XoZn5MASKMCF6yoSuuf2HN