### PR TITLE
fix: block SSRF attacks via document-url message parts

### DIFF
--- a/api/src/ai_demos/chat_emilio/routes.py
+++ b/api/src/ai_demos/chat_emilio/routes.py
@@ -20,8 +20,10 @@ from pydantic_ai.ui.vercel_ai.request_types import RequestData, SubmitMessage
 
 from api.src.ai_demos.chat_emilio.agent import agent, PortfolioContext
 from api.src.utils.swagger_schema import expand_json_schema
+from api.src.utils.input_sanitization import sanitize_request_json
 from api.src.ai_demos.models import persist_agent_run_result
 import functools
+import json
 from api.src.database.database import DBSession
 
 router = APIRouter(prefix="/chat-emilio", tags=["ai"])
@@ -151,20 +153,23 @@ async def chat_emilio(request: Request, session: DBSession) -> Response:
     """
     logfire.info("Portfolio chat request using VercelAIAdapter")
 
-    # Read the request JSON to get the conversation ID
+    # Read and sanitize request body to prevent SSRF attacks via document-url parts
     request_json = await request.json()
-    conversation_id = request_json.get('id')
+    sanitized_json = sanitize_request_json(request_json)
+    # Replace request body so VercelAIAdapter uses sanitized version
+    request._body = json.dumps(sanitized_json).encode()
+
+    conversation_id = sanitized_json.get('id')
 
     # Validate that there are messages to process — the Anthropic API rejects
     # requests with an empty messages array ("at least one message is required").
-    messages = request_json.get('messages', [])
+    messages = sanitized_json.get('messages', [])
     if not messages:
         logfire.warn("chat_emilio: empty messages array in request", conversation_id=conversation_id)
         return Response(status_code=400, content="messages array is empty")
-    
+
     # Log new messages
-    if request_json.get('trigger') == 'submit-message':
-        messages = request_json.get('messages', [])
+    if sanitized_json.get('trigger') == 'submit-message':
         if messages:
             # Structured logging for easy querying/alerting in Logfire UI
             latest_message = messages[-1]

--- a/api/src/ai_demos/chat_weather/routes.py
+++ b/api/src/ai_demos/chat_weather/routes.py
@@ -9,9 +9,11 @@ from pydantic_ai.ui.vercel_ai.request_types import SubmitMessage
 
 from api.src.ai_demos.chat_weather.agent import agent, ChatContext
 from api.src.utils.swagger_schema import expand_json_schema
+from api.src.utils.input_sanitization import sanitize_request_json
 from api.src.ai_demos.models import persist_agent_run_result
 import logfire
 import functools
+import json
 from api.src.database.database import DBSession
 
 router = APIRouter(prefix="/chat-weather", tags=["ai"])
@@ -145,18 +147,22 @@ async def chat(request: Request, session: DBSession) -> Response:
     """
     logfire.info("Weather chat request using VercelAIAdapter")
 
-    # Log new messages
+    # Read and sanitize request body to prevent SSRF attacks via document-url parts
     request_json = await request.json()
-    if request_json.get('trigger') == 'submit-message':
-        messages = request_json.get('messages', [])
+    sanitized_json = sanitize_request_json(request_json)
+    # Replace request body so VercelAIAdapter uses sanitized version
+    request._body = json.dumps(sanitized_json).encode()
+
+    if sanitized_json.get('trigger') == 'submit-message':
+        messages = sanitized_json.get('messages', [])
         # Structured logging for easy querying/alerting in Logfire UI
-        latest_message = messages[-1]
+        latest_message = messages[-1] if messages else {}
         logfire.info("new chat message",
             slack_alert=True,
             endpoint="/api/ai-demos/chat-weather",
             message_text=latest_message.get('parts', [{}])[0].get('text', '') if latest_message.get('parts') else '',
         )
-    conversation_id = request_json.get('id')
+    conversation_id = sanitized_json.get('id')
 
     # Use functools.partial to create a callback with pre-filled arguments
     # oncomplete only expectes AgentRunResult, so we need to create a partial function to pass our custom arguments

--- a/api/src/ai_demos/multi_agent_chat/routes.py
+++ b/api/src/ai_demos/multi_agent_chat/routes.py
@@ -1,6 +1,7 @@
 """
 Routes for Graph-based router agent that dynamically routes to Emilio or Weather agents
 """
+import json
 import logfire
 from fastapi import APIRouter
 from starlette.requests import Request
@@ -13,7 +14,7 @@ from api.src.ai_demos.multi_agent_chat.graph import (
     multi_agent_graph,
 )
 from api.src.utils.swagger_schema import expand_json_schema
-import logfire
+from api.src.utils.input_sanitization import sanitize_request_json
 
 
 router = APIRouter(prefix="/multi-agent-chat", tags=["ai"])
@@ -142,11 +143,16 @@ async def multi_agent_chat(request: Request) -> Response:
     logfire.info("LOGFIRE: Multi-agent chat request using Graph Beta API")
     logfire.info("CLASSIC LOGGER: Multi-agent chat request using Graph Beta API")
 
+    # Read and sanitize request body to prevent SSRF attacks via document-url parts
     request_json = await request.json()
-    user_message = _extract_latest_message_text(request_json)
-    message_history = request_json.get("messages") or None
+    sanitized_json = sanitize_request_json(request_json)
+    # Replace request body so downstream agents (VercelAIAdapter) use sanitized version
+    request._body = json.dumps(sanitized_json).encode()
 
-    if request_json.get('trigger') == 'submit-message':
+    user_message = _extract_latest_message_text(sanitized_json)
+    message_history = sanitized_json.get("messages") or None
+
+    if sanitized_json.get('trigger') == 'submit-message':
         logfire.info(
             "new multi-agent chat message",
             slack_alert=True,

--- a/api/src/utils/input_sanitization.py
+++ b/api/src/utils/input_sanitization.py
@@ -1,0 +1,77 @@
+"""
+Input sanitization utilities for AI agent endpoints.
+
+Protects against SSRF and other attacks by sanitizing user-provided message parts
+before they reach AI agents.
+"""
+from typing import Any
+import logfire
+
+
+# Message part types that should be stripped for security
+# document-url: Can be used for SSRF attacks (fetch arbitrary URLs)
+# document-file: Could be used to leak file contents
+BLOCKED_PART_TYPES = {"document-url", "document-file", "file"}
+
+
+def sanitize_message_parts(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Remove potentially dangerous message parts.
+
+    Returns only text parts, stripping document-url, document-file, etc.
+    that could be used for SSRF or other attacks.
+    """
+    safe_parts = []
+    for part in parts:
+        part_type = part.get("type", "")
+        if part_type in BLOCKED_PART_TYPES:
+            # Log security event for monitoring
+            logfire.warn(
+                "blocked dangerous message part",
+                part_type=part_type,
+                url=part.get("url", "")[:200] if part.get("url") else None,
+            )
+            continue
+        safe_parts.append(part)
+    return safe_parts
+
+
+def sanitize_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Sanitize all messages in a conversation, removing dangerous parts.
+
+    This should be applied to incoming Vercel AI SDK messages before
+    passing them to VercelAIAdapter or agents.
+    """
+    sanitized = []
+    for msg in messages:
+        parts = msg.get("parts", [])
+        safe_parts = sanitize_message_parts(parts)
+
+        # Only include message if it has any parts left
+        if safe_parts:
+            sanitized_msg = {**msg, "parts": safe_parts}
+            sanitized.append(sanitized_msg)
+        else:
+            # Message had only dangerous parts - log and skip
+            logfire.warn(
+                "dropped message with only dangerous parts",
+                message_role=msg.get("role"),
+            )
+
+    return sanitized
+
+
+def sanitize_request_json(request_json: dict[str, Any]) -> dict[str, Any]:
+    """
+    Sanitize a full Vercel AI SDK request payload.
+
+    Returns a copy with messages sanitized.
+    """
+    if "messages" not in request_json:
+        return request_json
+
+    return {
+        **request_json,
+        "messages": sanitize_messages(request_json["messages"]),
+    }


### PR DESCRIPTION
Add input sanitization to AI demo chat endpoints to block SSRF attack
vectors. Attackers were sending malicious document-url parts targeting
AWS metadata (169.254.169.254), Railway internal endpoints, and localhost.

The new sanitization layer strips document-url, document-file, and file
parts from incoming messages before they reach VercelAIAdapter.

https://claude.ai/code/session_01Ro7qFb64uf5mNUse33UvJT