### PR TITLE
fix: block SSRF attacks and update deprecated model

### DIFF
--- a/api/src/ai_demos/chat_weather/agent.py
+++ b/api/src/ai_demos/chat_weather/agent.py
@@ -18,7 +18,7 @@ class ChatContext:
 
 
 # Create the agent with the OpenAI model
-model = OpenAIChatModel("gpt-4-turbo-preview")
+model = OpenAIChatModel("gpt-4.1-nano")
 
 agent = Agent(
     model=model,


### PR DESCRIPTION
## Summary

- **Block SSRF attacks** via `document-url` message parts in AI demo chat endpoints
- **Update deprecated model** from `gpt-4-turbo-preview` to `gpt-4.1-nano` for chat_weather agent

## Details

### SSRF Fix
Attackers were sending malicious `document-url` parts targeting:
- AWS metadata (`169.254.169.254`)
- Railway internal endpoints (`metadata.railway.internal`)
- Localhost (`127.0.0.1`)

Added `input_sanitization.py` that strips `document-url`, `document-file`, and `file` parts from incoming messages before they reach `VercelAIAdapter`. Applied to all 3 affected routes:
- `/api/ai-demos/chat-weather`
- `/api/ai-demos/chat-emilio`
- `/api/ai-demos/multi-agent-chat`

### Model Update
`gpt-4-turbo-preview` no longer exists in OpenAI's API (404 errors). Updated to `gpt-4.1-nano` for cost efficiency.

## Test plan
- [x] Verified sanitization strips document-url parts
- [x] Verified PydanticAI accepts gpt-4.1-nano model name
- [x] Imports verified for all modified routes

Slack thread: https://panepartnersllc.slack.com/archives/C09T58LBLRE/p1776647611529969

https://claude.ai/code/session_01Ro7qFb64uf5mNUse33UvJT