### PR TITLE
fix: skip Clerk lookup for "visitor" placeholder user ID

### DIFF
--- a/api/src/ai_demos/models.py
+++ b/api/src/ai_demos/models.py
@@ -248,9 +248,9 @@ async def save_agent_conversation(
         messages_json = _sanitize_json(data)
 
     # Look up user email from Clerk for convenience/debugging
-    # Skip for system user IDs (e.g. "system:sernia-ai") — not real Clerk users
+    # Skip for placeholder/system user IDs — not real Clerk users
     user_email = None
-    if clerk_user_id and not clerk_user_id.startswith("system:"):
+    if clerk_user_id and clerk_user_id not in ("visitor",) and not clerk_user_id.startswith("system:"):
         user_email = await _get_user_email_from_clerk(clerk_user_id)
 
     # Use session.merge which performs an upsert (SELECT + INSERT/UPDATE)


### PR DESCRIPTION
## Summary

- Skip Clerk API lookup for `"visitor"` placeholder user ID in demo chat endpoints

## Problem

Demo chat endpoints (`chat-weather`, `chat-emilio`) use `clerk_user_id="visitor"` for anonymous users. This triggered Clerk API 404 errors that showed up in Logfire error alerts.

## Fix

Added `"visitor"` to the skip list alongside `system:` prefixed IDs in `save_agent_conversation()`.

## Test plan

- [x] Verified the code change
- [x] Anonymous demo chat requests will no longer trigger Clerk lookups

https://claude.ai/code/session_01Ro7qFb64uf5mNUse33UvJT