### PR TITLE
fix: remove orphaned tool returns from conversation history (issues 81/82)

### DIFF
--- a/api/src/ai_demos/models.py
+++ b/api/src/ai_demos/models.py
@@ -123,12 +123,18 @@ def _repair_orphaned_tool_calls(
     conversation_id: str = "",
     include_terminal: bool = False,
 ) -> list[ModelMessage]:
-    """Inject synthetic ToolReturnParts for orphaned ToolCallParts mid-conversation.
+    """Repair tool call/return mismatches in conversation history.
 
-    When an approval-gated tool call is saved to the DB but the ToolReturnPart
-    never arrives (timeout, crash, client disconnect), the conversation becomes
-    permanently broken — the Anthropic API rejects histories where tool_use
-    blocks have no matching tool_result.
+    Handles two scenarios that break model APIs:
+
+    1. Orphaned ToolCallParts (calls without returns) — When an approval-gated
+       tool call is saved to the DB but the ToolReturnPart never arrives
+       (timeout, crash, client disconnect). Fixed by injecting synthetic returns.
+
+    2. Orphaned ToolReturnParts (returns without calls) — When history is
+       trimmed/corrupted or the main agent model changes (e.g., Anthropic to
+       OpenAI) and old tool_call_ids reference non-existent calls.
+       Fixed by removing the orphaned returns.
 
     Args:
         include_terminal: When True, also patches the last ModelResponse.
@@ -137,9 +143,44 @@ def _repair_orphaned_tool_calls(
             When False (default), the last ModelResponse is preserved for
             the approve flow and GET endpoints.
     """
-    # Collect all returned tool_call_ids
-    returned_ids: set[str] = set()
+    if not messages:
+        return messages
+
+    # Step 1: Collect all tool_call_ids from ToolCallParts (the valid set)
+    valid_call_ids: set[str] = set()
     for msg in messages:
+        if isinstance(msg, ModelResponse):
+            for part in msg.parts:
+                if isinstance(part, ToolCallPart):
+                    valid_call_ids.add(part.tool_call_id)
+
+    # Step 2: Remove orphaned ToolReturnParts (returns without matching calls)
+    cleaned: list[ModelMessage] = []
+    orphan_returns_removed = 0
+    for msg in messages:
+        if isinstance(msg, ModelRequest):
+            new_parts = []
+            for part in msg.parts:
+                if isinstance(part, ToolReturnPart):
+                    if part.tool_call_id not in valid_call_ids:
+                        orphan_returns_removed += 1
+                        continue
+                new_parts.append(part)
+            if new_parts:
+                cleaned.append(ModelRequest(parts=new_parts))
+        else:
+            cleaned.append(msg)
+
+    if orphan_returns_removed > 0:
+        logfire.warn(
+            "removed orphaned tool returns from conversation history",
+            conversation_id=conversation_id,
+            orphan_returns_removed=orphan_returns_removed,
+        )
+
+    # Step 3: Collect returned tool_call_ids (for orphan call detection)
+    returned_ids: set[str] = set()
+    for msg in cleaned:
         if isinstance(msg, ModelRequest):
             for part in msg.parts:
                 if isinstance(part, ToolReturnPart):
@@ -148,14 +189,14 @@ def _repair_orphaned_tool_calls(
     # Find the index of the last ModelResponse
     last_response_idx = -1
     if not include_terminal:
-        for i, msg in enumerate(messages):
+        for i, msg in enumerate(cleaned):
             if isinstance(msg, ModelResponse):
                 last_response_idx = i
 
-    # Walk messages and build repaired list
+    # Step 4: Add synthetic returns for orphaned ToolCallParts
     repaired: list[ModelMessage] = []
-    patched = False
-    for i, msg in enumerate(messages):
+    orphan_calls_patched = False
+    for i, msg in enumerate(cleaned):
         repaired.append(msg)
         if isinstance(msg, ModelResponse) and i != last_response_idx:
             orphans = [
@@ -173,9 +214,9 @@ def _repair_orphaned_tool_calls(
                 ]
                 repaired.append(ModelRequest(parts=synthetic_parts))
                 returned_ids.update(tc.tool_call_id for tc in orphans)
-                patched = True
+                orphan_calls_patched = True
 
-    if patched:
+    if orphan_calls_patched:
         logfire.warn(
             "repaired orphaned tool calls in conversation history",
             conversation_id=conversation_id,

--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -375,20 +375,56 @@ def _trim_sms_history(
 
 
 def _sanitize_tool_calls(messages: list[ModelMessage]) -> list[ModelMessage]:
-    """Remove trailing unprocessed tool calls from message history.
+    """Sanitize tool call/return pairs in message history.
 
-    PydanticAI raises UserError if the history ends with a ModelResponse
-    containing ToolCallPart without a subsequent ToolReturnPart. This can
-    happen when history is trimmed mid-conversation or a previous run crashed.
+    Handles two scenarios that break model APIs:
+    1. Orphaned ToolReturnParts — tool returns without matching tool calls.
+       This happens when history trimming cuts off older messages containing
+       the ToolCallPart, or when the main agent model changes (e.g., Anthropic
+       to OpenAI) and old tool_call_ids have incompatible formats.
+    2. Trailing ToolCallParts — tool calls at the end without subsequent returns.
+       This happens when a previous run crashed or history was trimmed.
 
-    Walks backwards from the end, removing messages until we reach a state
-    where no tool calls are pending.
+    Returns a sanitized copy of the message list.
     """
     if not messages:
         return messages
 
-    result = list(messages)
+    # Step 1: Collect all tool_call_ids from ToolCallParts
+    valid_tool_call_ids: set[str] = set()
+    for msg in messages:
+        if isinstance(msg, ModelResponse):
+            for part in msg.parts:
+                if isinstance(part, ToolCallPart):
+                    valid_tool_call_ids.add(part.tool_call_id)
 
+    # Step 2: Remove orphaned ToolReturnParts (returns without matching calls)
+    result: list[ModelMessage] = []
+    orphans_removed = 0
+    for msg in messages:
+        if isinstance(msg, ModelRequest):
+            # Filter out ToolReturnParts that reference non-existent tool calls
+            new_parts = []
+            for part in msg.parts:
+                if isinstance(part, ToolReturnPart):
+                    if part.tool_call_id not in valid_tool_call_ids:
+                        orphans_removed += 1
+                        continue
+                new_parts.append(part)
+
+            # Only include the request if it has remaining parts
+            if new_parts:
+                result.append(ModelRequest(parts=new_parts))
+        else:
+            result.append(msg)
+
+    if orphans_removed > 0:
+        logfire.info(
+            "ai_sms_event: removed orphaned tool returns",
+            orphans_removed=orphans_removed,
+        )
+
+    # Step 3: Remove trailing tool calls without returns
     while result:
         last = result[-1]
         if isinstance(last, ModelResponse):

--- a/api/src/tests/test_conversation_repair.py
+++ b/api/src/tests/test_conversation_repair.py
@@ -157,3 +157,104 @@ class TestRepairOrphanedToolCalls:
         assert isinstance(synthetic.parts[0], ToolReturnPart)
         assert synthetic.parts[0].tool_call_id == "tc1"
         assert "interrupted" in synthetic.parts[0].content.lower()
+
+    def test_removes_orphaned_tool_return(self):
+        """ToolReturnPart without matching ToolCallPart should be removed.
+
+        This happens when history is trimmed and the ToolCallPart was in the
+        trimmed portion, or when the main agent model changes and old
+        tool_call_ids reference non-existent calls.
+        """
+        msgs = [
+            # ToolReturnPart references a tool call that doesn't exist in history
+            ModelRequest(parts=[
+                ToolReturnPart(tool_name="old_tool", content="result", tool_call_id="toolu_orphan"),
+            ]),
+            ModelRequest(parts=[UserPromptPart(content="hello")]),
+            ModelResponse(parts=[TextPart(content="hi")]),
+        ]
+        result = _repair_orphaned_tool_calls(msgs)
+        # The orphaned ToolReturnPart should be removed
+        assert len(result) == 2
+        # First message should be the UserPromptPart
+        assert isinstance(result[0], ModelRequest)
+        assert len(result[0].parts) == 1
+        assert isinstance(result[0].parts[0], UserPromptPart)
+
+    def test_removes_orphaned_tool_return_keeps_other_parts(self):
+        """When a ModelRequest has both orphaned returns and valid parts, keep valid parts."""
+        msgs = [
+            ModelRequest(parts=[
+                ToolReturnPart(tool_name="old_tool", content="result", tool_call_id="toolu_orphan"),
+                UserPromptPart(content="hello"),
+            ]),
+            ModelResponse(parts=[TextPart(content="hi")]),
+        ]
+        result = _repair_orphaned_tool_calls(msgs)
+        assert len(result) == 2
+        # The request should still exist but without the orphaned return
+        assert isinstance(result[0], ModelRequest)
+        assert len(result[0].parts) == 1
+        assert isinstance(result[0].parts[0], UserPromptPart)
+
+    def test_removes_orphaned_returns_from_model_switch(self):
+        """Simulates the model switch scenario (Anthropic to OpenAI).
+
+        Old history has Anthropic-style tool_call_ids (toolu_...) that don't
+        match any ToolCallParts because the ToolCallPart was in trimmed history
+        or from a different model.
+        """
+        msgs = [
+            # This simulates trimmed history where ToolCallPart was cut off
+            ModelRequest(parts=[
+                ToolReturnPart(
+                    tool_name="send_sms",
+                    content="sent",
+                    tool_call_id="toolu_012dE58Mgx5qBuz7yjcZCkpk",  # Anthropic format
+                ),
+            ]),
+            ModelRequest(parts=[UserPromptPart(content="thanks")]),
+            ModelResponse(parts=[TextPart(content="you're welcome")]),
+        ]
+        result = _repair_orphaned_tool_calls(msgs)
+        # Orphaned return removed, only user prompt + response remain
+        assert len(result) == 2
+        assert isinstance(result[0], ModelRequest)
+        assert isinstance(result[0].parts[0], UserPromptPart)
+
+    def test_handles_mixed_orphaned_and_valid_returns(self):
+        """Some returns are valid (have matching calls), some are orphaned."""
+        msgs = [
+            ModelRequest(parts=[UserPromptPart(content="do two things")]),
+            ModelResponse(parts=[
+                ToolCallPart(tool_name="tool_a", args='{}', tool_call_id="tc1"),
+            ]),
+            ModelRequest(parts=[
+                ToolReturnPart(tool_name="tool_a", content="ok", tool_call_id="tc1"),
+                ToolReturnPart(tool_name="old_tool", content="stale", tool_call_id="toolu_orphan"),
+            ]),
+            ModelResponse(parts=[TextPart(content="done")]),
+        ]
+        result = _repair_orphaned_tool_calls(msgs)
+        # The orphaned return should be removed, valid return kept
+        assert len(result) == 4
+        request_with_returns = result[2]
+        assert isinstance(request_with_returns, ModelRequest)
+        assert len(request_with_returns.parts) == 1
+        assert request_with_returns.parts[0].tool_call_id == "tc1"
+
+    def test_removes_request_if_only_orphaned_returns(self):
+        """If a ModelRequest only contains orphaned ToolReturnParts, remove it entirely."""
+        msgs = [
+            ModelRequest(parts=[
+                ToolReturnPart(tool_name="tool_a", content="stale", tool_call_id="toolu_1"),
+                ToolReturnPart(tool_name="tool_b", content="stale", tool_call_id="toolu_2"),
+            ]),
+            ModelRequest(parts=[UserPromptPart(content="hello")]),
+            ModelResponse(parts=[TextPart(content="hi")]),
+        ]
+        result = _repair_orphaned_tool_calls(msgs)
+        # First request entirely removed because all parts were orphaned
+        assert len(result) == 2
+        assert isinstance(result[0], ModelRequest)
+        assert isinstance(result[0].parts[0], UserPromptPart)

--- a/api/src/tests/test_sms_merge_and_gates.py
+++ b/api/src/tests/test_sms_merge_and_gates.py
@@ -23,6 +23,7 @@ from pydantic_ai.messages import (
 from api.src.sernia_ai.triggers.ai_sms_event_trigger import (
     _extract_text_contents,
     _merge_sms_into_history,
+    _sanitize_tool_calls,
 )
 from api.src.sernia_ai.tools.quo_tools import _is_internal_contact
 
@@ -212,3 +213,146 @@ class TestIsInternalContact:
     def test_whitespace_not_trimmed(self):
         """Whitespace around company name is not trimmed."""
         assert _is_internal_contact(_make_contact(" Sernia Capital LLC ")) is False
+
+
+# ===========================================================================
+# _sanitize_tool_calls
+# ===========================================================================
+
+
+def _tool_call(name: str, call_id: str) -> ModelResponse:
+    return ModelResponse(parts=[ToolCallPart(tool_name=name, args='{}', tool_call_id=call_id)])
+
+
+def _tool_return(name: str, call_id: str, content: str = "ok") -> ModelRequest:
+    return ModelRequest(parts=[ToolReturnPart(tool_name=name, content=content, tool_call_id=call_id)])
+
+
+class TestSanitizeToolCalls:
+    def test_empty_messages(self):
+        assert _sanitize_tool_calls([]) == []
+
+    def test_no_tool_calls_unchanged(self):
+        msgs = [_user("hello"), _assistant("hi")]
+        assert _sanitize_tool_calls(msgs) == msgs
+
+    def test_removes_trailing_tool_call(self):
+        """Trailing ToolCallPart without return should be removed."""
+        msgs = [
+            _user("do something"),
+            _tool_call("send_sms", "tc1"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        # Trailing tool call removed
+        assert len(result) == 1
+        assert isinstance(result[0], ModelRequest)
+
+    def test_removes_orphaned_tool_return(self):
+        """ToolReturnPart without matching ToolCallPart should be removed."""
+        msgs = [
+            _tool_return("old_tool", "toolu_orphan"),
+            _user("hello"),
+            _assistant("hi"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        # Orphaned return removed
+        assert len(result) == 2
+        assert isinstance(result[0], ModelRequest)
+        assert isinstance(result[0].parts[0], UserPromptPart)
+
+    def test_keeps_valid_tool_call_return_pair(self):
+        """Valid ToolCallPart + ToolReturnPart pairs are preserved."""
+        msgs = [
+            _user("search"),
+            _tool_call("search_contacts", "tc1"),
+            _tool_return("search_contacts", "tc1"),
+            _assistant("found it"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        assert len(result) == 4
+
+    def test_removes_anthropic_style_orphan_from_trimmed_history(self):
+        """Simulates history trimming cutting off the ToolCallPart.
+
+        This is the exact bug that caused issues 81/82 — history trimming
+        removes the beginning of the conversation which contains the
+        ToolCallPart, leaving an orphaned ToolReturnPart.
+        """
+        msgs = [
+            # ToolCallPart was in trimmed portion — only return remains
+            _tool_return("send_sms", "toolu_012dE58Mgx5qBuz7yjcZCkpk"),
+            _user("thanks for sending that"),
+            _assistant("you're welcome"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        # Orphaned return removed
+        assert len(result) == 2
+        assert isinstance(result[0].parts[0], UserPromptPart)
+        assert result[0].parts[0].content == "thanks for sending that"
+
+    def test_mixed_valid_and_orphaned_returns(self):
+        """Some returns are valid (have matching calls), some are orphaned."""
+        msgs = [
+            # Orphaned return (no matching call)
+            _tool_return("old_tool", "toolu_orphan"),
+            _user("search"),
+            _tool_call("search_contacts", "tc1"),
+            _tool_return("search_contacts", "tc1"),
+            _assistant("found it"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        # Orphaned return removed, valid pair kept
+        assert len(result) == 4
+        # Check the return that remains is the valid one
+        returns = [
+            p for msg in result if isinstance(msg, ModelRequest)
+            for p in msg.parts if isinstance(p, ToolReturnPart)
+        ]
+        assert len(returns) == 1
+        assert returns[0].tool_call_id == "tc1"
+
+    def test_request_removed_if_only_orphaned_returns(self):
+        """ModelRequest with only orphaned ToolReturnParts is removed entirely."""
+        msgs = [
+            ModelRequest(parts=[
+                ToolReturnPart(tool_name="tool_a", content="stale", tool_call_id="toolu_1"),
+                ToolReturnPart(tool_name="tool_b", content="stale", tool_call_id="toolu_2"),
+            ]),
+            _user("hello"),
+            _assistant("hi"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        # First request entirely removed
+        assert len(result) == 2
+        assert isinstance(result[0].parts[0], UserPromptPart)
+
+    def test_request_keeps_non_orphan_parts(self):
+        """ModelRequest with both orphaned returns and valid parts keeps valid parts."""
+        msgs = [
+            ModelRequest(parts=[
+                ToolReturnPart(tool_name="old_tool", content="stale", tool_call_id="toolu_orphan"),
+                UserPromptPart(content="hello"),
+            ]),
+            _assistant("hi"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        assert len(result) == 2
+        # UserPromptPart preserved
+        assert isinstance(result[0], ModelRequest)
+        assert len(result[0].parts) == 1
+        assert isinstance(result[0].parts[0], UserPromptPart)
+
+    def test_handles_both_orphan_types(self):
+        """Both orphaned returns AND trailing calls are handled."""
+        msgs = [
+            # Orphaned return
+            _tool_return("old_tool", "toolu_orphan"),
+            _user("do something"),
+            # Trailing tool call without return
+            _tool_call("send_sms", "tc1"),
+        ]
+        result = _sanitize_tool_calls(msgs)
+        # Both removed
+        assert len(result) == 1
+        assert isinstance(result[0].parts[0], UserPromptPart)
+        assert result[0].parts[0].content == "do something"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 python_files = test_*.py *_test.py *.py
 python_functions = test_*
-addopts = -s -v -m "not live" --ignore=api/src/database/migrations --ignore=api/src/ai/email_approval_demo/agent.py # filter out live tests by default
+; Filter out live tests by default
+addopts = -s -v -m "not live" --ignore=api/src/database/migrations --ignore=api/src/ai/email_approval_demo/agent.py
 ; addopts = -s -v --ignore=api/src/database/migrations --ignore=api/src/ai/email_approval_demo/agent.py
 markers =
     live: hits real third-party APIs — run explicitly with: pytest -m live


### PR DESCRIPTION
After switching the main agent model from Anthropic to OpenAI, old
conversations in the DB have Anthropic-style tool call IDs (toolu_...).
When history trimming cuts off the ToolCallPart while keeping a later
ToolReturnPart, OpenAI rejects the request because it can't find the
matching tool call.

The fix extends both _sanitize_tool_calls (SMS trigger) and
_repair_orphaned_tool_calls (web chat) to:
1. Collect all valid tool_call_ids from ToolCallParts
2. Remove any ToolReturnParts that reference non-existent calls
3. Then handle trailing tool calls without returns (existing behavior)

Also fixes pytest.ini inline comment that was being parsed as a path.

https://claude.ai/code/session_01CVMKXeZnoHTMhZDeqFeMxA