### PR TITLE
feat(sernia-ai): deny HITL with feedback in a single LLM round trip

### DIFF
--- a/api/src/ai_demos/hitl_utils.py
+++ b/api/src/ai_demos/hitl_utils.py
@@ -111,6 +111,7 @@ async def resume_with_approvals(
     clerk_user_id: str | None = None,
     session: AsyncSession | None = None,
     metadata: dict | None = None,
+    user_message: str | None = None,
 ) -> AgentRunResult:
     """
     Resume a paused agent with approval decisions. Agent-agnostic.
@@ -122,6 +123,12 @@ async def resume_with_approvals(
         deps: Agent-specific deps object
         clerk_user_id: Clerk user ID for DB ownership filter, or None for shared access
         session: Optional existing DB session
+        user_message: Optional user-typed message to include as a real user turn
+            alongside the tool return parts. PydanticAI bundles this with the
+            ToolReturnParts into a single ModelRequest (see CallToolsNode), so
+            it persists in history as a normal UserPromptPart. Use this for
+            "deny with feedback" flows where the user wants their reply stored
+            as a regular message, not just as a tool-denial reason.
     """
     async with provide_session(session) as s:
         messages = await get_conversation_messages(conversation_id, clerk_user_id, session=s)
@@ -158,6 +165,7 @@ async def resume_with_approvals(
     deferred_results = DeferredToolResults(approvals=approvals_dict)
 
     result = await agent.run(
+        user_prompt=user_message,
         message_history=messages,
         deferred_tool_results=deferred_results,
         deps=deps,

--- a/api/src/sernia_ai/routes.py
+++ b/api/src/sernia_ai/routes.py
@@ -352,6 +352,12 @@ class ApprovalDecisionRequest(BaseModel):
 class ApprovalRequest(BaseModel):
     """Batch approval request for one or more tool calls."""
     decisions: list[ApprovalDecisionRequest]
+    # Optional user-typed message attached to this approval round. PydanticAI
+    # bundles this alongside the ToolReturnParts into a single ModelRequest
+    # (see CallToolsNode), so it persists as a real UserPromptPart — used by
+    # the "deny with feedback" flow where the user's reply should live in
+    # message history as a normal chat turn, not just as a tool-denial reason.
+    user_message: str | None = None
 
 
 @router.post("/conversation/{conversation_id}/approve")
@@ -414,6 +420,7 @@ async def approve_conversation(
                 clerk_user_id=None,  # Shared team access
                 session=session,
                 metadata={"trigger_source": "api/sernia-ai/approve"},
+                user_message=body.user_message,
             )
 
         # Persist the approval result (tool outputs + agent follow-up) to DB

--- a/apps/web-react-router/app/components/chat/process-message.ts
+++ b/apps/web-react-router/app/components/chat/process-message.ts
@@ -14,6 +14,8 @@ export interface ToolSegment {
   toolName: string;
   args: any;
   result: any;
+  /** True when the source tool part was a denied tool return (state "output-denied"). */
+  denied?: boolean;
 }
 
 export interface FileSegment {
@@ -41,7 +43,8 @@ function isCompletedTool(part: any): boolean {
   return (
     part.result !== undefined ||
     part.output !== undefined ||
-    part.state === "output-available"
+    part.state === "output-available" ||
+    part.state === "output-denied"
   );
 }
 
@@ -65,12 +68,29 @@ function parseToolPart(part: any): ToolSegment {
     }
   }
 
+  // PydanticAI / Vercel AI v5 emits `state: "output-denied"` on denied tool
+  // returns. Also recognize the legacy `approval.approved === false` shape from
+  // older `ToolOutputDeniedPart` serializations, and the `outcome` field on
+  // raw PydanticAI ToolReturnParts if we ever render them directly.
+  const denied =
+    part.state === "output-denied" ||
+    part.outcome === "denied" ||
+    part.approval?.approved === false;
+
+  let result: any = part.result;
+  if (result === undefined) result = part.output;
+  if (result === undefined && denied) {
+    result = part.approval?.reason || "The tool call was denied.";
+  }
+  if (result === undefined) result = "Completed";
+
   return {
     type: "tool",
     toolCallId: part.toolCallId || part.tool_call_id || part.id,
     toolName: toolName || "unknown",
     args,
-    result: part.result || part.output || "Completed",
+    result,
+    denied,
   };
 }
 

--- a/apps/web-react-router/app/components/chat/tool-cards.tsx
+++ b/apps/web-react-router/app/components/chat/tool-cards.tsx
@@ -64,6 +64,40 @@ interface ApprovalItemDecision {
   editedBody?: string;
 }
 
+export interface ApprovalDecisionPayload {
+  tool_call_id: string;
+  approved: boolean;
+  reason?: string;
+  override_args?: Record<string, any>;
+}
+
+/**
+ * POST a batch of approve/deny decisions to the Sernia approve endpoint.
+ * Shared between the approval card and the main chat input's "deny with feedback" path.
+ */
+export async function submitApprovalDecisions(params: {
+  apiBase: string;
+  conversationId: string;
+  getToken: () => Promise<string | null>;
+  decisions: ApprovalDecisionPayload[];
+}): Promise<any> {
+  const token = await params.getToken();
+  const url = `${params.apiBase}/conversation/${params.conversationId}/approve`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ decisions: params.decisions }),
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.detail || "Failed to process approval");
+  }
+  return res.json();
+}
+
 /** Get a short summary for a tool call (e.g., recipient for emails/sms) */
 function getToolSummary(p: PendingApproval): string {
   // For email tools, show recipient
@@ -145,10 +179,7 @@ export function ToolApprovalCard({
 
     setProcessing(true);
     try {
-      const token = await getToken();
-      const url = `${apiBase}/conversation/${conversationId}/approve`;
-
-      const decisionList = pendingList.map((p) => {
+      const decisionList: ApprovalDecisionPayload[] = pendingList.map((p) => {
         const d = decisions[p.toolCallId];
         const { key: msgKey, value: originalValue } = getMessageFromArgs(p.args);
         const overrideArgs =
@@ -158,27 +189,18 @@ export function ToolApprovalCard({
 
         return {
           tool_call_id: p.toolCallId,
-          approved: d.approved,
+          approved: d.approved === true,
           override_args: overrideArgs,
           reason: d.approved ? undefined : "Denied by user",
         };
       });
 
-      const res = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ decisions: decisionList }),
+      const result = await submitApprovalDecisions({
+        apiBase,
+        conversationId,
+        getToken,
+        decisions: decisionList,
       });
-
-      if (!res.ok) {
-        const error = await res.json();
-        throw new Error(error.detail || "Failed to process approval");
-      }
-
-      const result = await res.json();
       onApprovalComplete(result);
     } catch (err) {
       console.error("Approval error:", err);

--- a/apps/web-react-router/app/components/chat/tool-cards.tsx
+++ b/apps/web-react-router/app/components/chat/tool-cards.tsx
@@ -74,12 +74,17 @@ export interface ApprovalDecisionPayload {
 /**
  * POST a batch of approve/deny decisions to the Sernia approve endpoint.
  * Shared between the approval card and the main chat input's "deny with feedback" path.
+ *
+ * When `userMessage` is provided, the backend bundles it with the ToolReturnParts
+ * into a single ModelRequest (see PydanticAI CallToolsNode), so the user's reply
+ * persists as a real UserPromptPart in the conversation.
  */
 export async function submitApprovalDecisions(params: {
   apiBase: string;
   conversationId: string;
   getToken: () => Promise<string | null>;
   decisions: ApprovalDecisionPayload[];
+  userMessage?: string;
 }): Promise<any> {
   const token = await params.getToken();
   const url = `${params.apiBase}/conversation/${params.conversationId}/approve`;
@@ -89,7 +94,10 @@ export async function submitApprovalDecisions(params: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ decisions: params.decisions }),
+    body: JSON.stringify({
+      decisions: params.decisions,
+      ...(params.userMessage ? { user_message: params.userMessage } : {}),
+    }),
   });
   if (!res.ok) {
     const error = await res.json().catch(() => ({}));
@@ -507,16 +515,25 @@ export function ToolResultCard({
   toolName,
   args,
   result,
+  denied,
 }: {
   toolName: string;
   args?: Record<string, any>;
   result: string;
+  /**
+   * Explicit denial flag from the source tool part (state === "output-denied"
+   * on the Vercel AI part or our optimistic equivalent). When not supplied,
+   * falls back to sniffing the result string for legacy messages stored
+   * before the flag existed.
+   */
+  denied?: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const isDenied =
-    result === "Denied by user" ||
-    result === "The tool call was denied." ||
-    result.startsWith("Denied:");
+    denied ??
+    (result === "Denied by user" ||
+      result === "The tool call was denied." ||
+      result.startsWith("Denied:"));
 
   const isTruncated = result.length > RESULT_TRUNCATE_LIMIT;
   const displayResult = isTruncated

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -37,6 +37,7 @@ import {
   ToolApprovalCard,
   ToolResultCard,
   convertAllPendingFromApi,
+  submitApprovalDecisions,
   type PendingApproval,
 } from "~/components/chat/tool-cards";
 import { processMessage } from "~/components/chat/process-message";
@@ -103,7 +104,7 @@ function ChatView({
     useState<PendingApproval | null>(initialPending);
   const [allPendingApprovals, setAllPendingApprovals] =
     useState<PendingApproval[]>(initialAllPending || (initialPending ? [initialPending] : []));
-  const [isProcessingApproval] = useState(false);
+  const [isProcessingApproval, setIsProcessingApproval] = useState(false);
   const draftKey = `sernia-draft-${conversationId}`;
   const [input, setInput] = useState(
     () => (typeof window !== "undefined" && sessionStorage.getItem(draftKey)) || ""
@@ -211,27 +212,70 @@ function ChatView({
     }
   }, [input]);
 
-  const handleSubmit = (e?: React.FormEvent) => {
+  const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();
-    const hasContent = input.trim() || attachment.hasFiles;
-    if (hasContent && status !== "submitted" && status !== "streaming") {
-      const parts: any[] = [
-        ...attachment.files.map((f) => ({
-          type: "file",
-          mediaType: f.mediaType,
-          url: f.url,
-          filename: f.filename,
-        })),
-      ];
-      if (input.trim()) {
-        parts.push({ type: "text", text: input });
+    if (status === "submitted" || status === "streaming" || isProcessingApproval) return;
+
+    const text = input.trim();
+    const hasContent = text || attachment.hasFiles;
+    if (!hasContent) return;
+
+    // Deny-with-feedback path: when a HITL approval is pending and the user
+    // types a message, treat the submit as an implicit denial of every pending
+    // tool call, using the typed text as the denial reason. The agent sees the
+    // reason on ToolDenied() and produces its follow-up in the same LLM call —
+    // collapsing the old two-round-trip flow (deny, then type feedback) into one.
+    if (allPendingApprovals.length > 0 && text) {
+      setIsProcessingApproval(true);
+      // Optimistically render the user's feedback as a chat bubble so the
+      // conversation reads naturally. The backend stores it on the tool's
+      // ToolDenied reason, not as a standalone user turn.
+      const optimisticUserMsg = {
+        id: crypto.randomUUID(),
+        role: "user" as const,
+        parts: [{ type: "text", text }],
+      };
+      setMessages((prev: any[]) => [...prev, optimisticUserMsg]);
+      try {
+        const result = await submitApprovalDecisions({
+          apiBase: API_BASE,
+          conversationId,
+          getToken,
+          decisions: allPendingApprovals.map((p) => ({
+            tool_call_id: p.toolCallId,
+            approved: false,
+            reason: text,
+          })),
+        });
+        setInput("");
+        handleApprovalComplete(result);
+      } catch (err) {
+        console.error("Deny-with-feedback error:", err);
+        alert(err instanceof Error ? err.message : "Failed to submit feedback");
+        // Roll back the optimistic bubble so the user can retry.
+        setMessages((prev: any[]) => prev.filter((m) => m.id !== optimisticUserMsg.id));
+      } finally {
+        setIsProcessingApproval(false);
       }
-      setPendingApproval(null);
-      setAllPendingApprovals([]);
-      sendMessage({ role: "user", parts });
-      setInput("");
-      attachment.clearFiles();
+      return;
     }
+
+    const parts: any[] = [
+      ...attachment.files.map((f) => ({
+        type: "file",
+        mediaType: f.mediaType,
+        url: f.url,
+        filename: f.filename,
+      })),
+    ];
+    if (text) {
+      parts.push({ type: "text", text: input });
+    }
+    setPendingApproval(null);
+    setAllPendingApprovals([]);
+    sendMessage({ role: "user", parts });
+    setInput("");
+    attachment.clearFiles();
   };
 
   const handleSuggestedPrompt = (prompt: string) => {
@@ -277,9 +321,8 @@ function ChatView({
                 return {
                   ...part,
                   state: "output-available",
-                  output: wasApproved
-                    ? realResult || "Completed"
-                    : "Denied by user",
+                  output:
+                    realResult || (wasApproved ? "Completed" : "Denied by user"),
                 };
               }
               return part;
@@ -517,6 +560,11 @@ function ChatView({
           </div>
         ) : (
           <div className="flex flex-col gap-2 w-full">
+            {pendingApproval && (
+              <p className="text-xs text-amber-700 dark:text-amber-400 px-1">
+                Sending a message will deny the pending action{allPendingApprovals.length > 1 ? "s" : ""} — your text becomes the feedback the AI sees.
+              </p>
+            )}
             <FilePreviewStrip
               files={attachment.files}
               onRemove={attachment.removeFile}
@@ -527,7 +575,8 @@ function ChatView({
                 disabled={
                   status === "submitted" ||
                   status === "streaming" ||
-                  !!pendingApproval
+                  !!pendingApproval ||
+                  isProcessingApproval
                 }
               />
               <Textarea
@@ -544,7 +593,7 @@ function ChatView({
                 onPaste={attachment.handlePaste}
                 placeholder={
                   pendingApproval
-                    ? "Approve or deny the action above first..."
+                    ? "Type feedback to deny pending action… or use the Approve/Deny buttons above."
                     : "Ask Sernia AI anything..."
                 }
                 className="min-h-0 max-h-[calc(75dvh)] overflow-hidden resize-none rounded-lg py-2 text-base md:text-sm bg-muted"
@@ -552,7 +601,7 @@ function ChatView({
                 disabled={
                   status === "submitted" ||
                   status === "streaming" ||
-                  !!pendingApproval
+                  isProcessingApproval
                 }
               />
               {status === "streaming" ? (
@@ -573,11 +622,16 @@ function ChatView({
                   disabled={
                     (!input.trim() && !attachment.hasFiles) ||
                     status === "submitted" ||
-                    !!pendingApproval
+                    isProcessingApproval ||
+                    (!!pendingApproval && !input.trim())
                   }
                   className="h-9 w-9 shrink-0 rounded-lg"
                 >
-                  <Send className="w-4 h-4" />
+                  {isProcessingApproval ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Send className="w-4 h-4" />
+                  )}
                 </Button>
               )}
             </div>

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -221,15 +221,18 @@ function ChatView({
     if (!hasContent) return;
 
     // Deny-with-feedback path: when a HITL approval is pending and the user
-    // types a message, treat the submit as an implicit denial of every pending
-    // tool call, using the typed text as the denial reason. The agent sees the
-    // reason on ToolDenied() and produces its follow-up in the same LLM call —
-    // collapsing the old two-round-trip flow (deny, then type feedback) into one.
+    // types a message, submit implicitly denies every pending tool call and
+    // attaches the typed text as a real user turn. The backend passes the
+    // text to PydanticAI's agent.run(user_prompt=...), which bundles it with
+    // the ToolReturnParts into a single ModelRequest (UserPromptPart). So it
+    // lives in the DB as a normal chat turn, not just a tool-denial reason.
+    // This also collapses the old two-round-trip flow (deny → wait → type
+    // feedback) into one LLM call.
     if (allPendingApprovals.length > 0 && text) {
       setIsProcessingApproval(true);
-      // Optimistically render the user's feedback as a chat bubble so the
-      // conversation reads naturally. The backend stores it on the tool's
-      // ToolDenied reason, not as a standalone user turn.
+      // Render the user's message optimistically so the chat feels responsive.
+      // On refresh, the same text will load from the DB as a UserPromptPart;
+      // IDs differ but the visible bubble is identical so there is no dupe.
       const optimisticUserMsg = {
         id: crypto.randomUUID(),
         role: "user" as const,
@@ -246,13 +249,13 @@ function ChatView({
             approved: false,
             reason: text,
           })),
+          userMessage: text,
         });
         setInput("");
         handleApprovalComplete(result);
       } catch (err) {
         console.error("Deny-with-feedback error:", err);
         alert(err instanceof Error ? err.message : "Failed to submit feedback");
-        // Roll back the optimistic bubble so the user can retry.
         setMessages((prev: any[]) => prev.filter((m) => m.id !== optimisticUserMsg.id));
       } finally {
         setIsProcessingApproval(false);
@@ -299,6 +302,20 @@ function ChatView({
       // Backend returns actual tool results keyed by tool_call_id
       const toolResults: Record<string, string> = result.tool_results || {};
 
+      // If the backend surfaced a new round of pending approvals (because the
+      // resumed agent called more deferred tools), we need to render a fresh
+      // approval card. Build assistant-message parts that mirror what the
+      // streaming chat would have produced (state: "input-available", no output).
+      const newPendingParts =
+        Array.isArray(result.pending) && result.pending.length > 0
+          ? result.pending.map((p: any) => ({
+              type: `tool-${p.tool_name}`,
+              toolCallId: p.tool_call_id,
+              input: p.args || {},
+              state: "input-available",
+            }))
+          : [];
+
       setMessages((prev: any[]) => {
         const updated = [...prev];
         const lastAssistantIdx = updated.findLastIndex(
@@ -318,9 +335,12 @@ function ChatView({
                 const realResult = part.toolCallId
                   ? toolResults[part.toolCallId]
                   : undefined;
+                // Match the Vercel AI SDK / PydanticAI adapter's on-refresh
+                // encoding: denied returns use state "output-denied" so the
+                // renderer doesn't have to sniff the output string.
                 return {
                   ...part,
-                  state: "output-available",
+                  state: wasApproved ? "output-available" : "output-denied",
                   output:
                     realResult || (wasApproved ? "Completed" : "Denied by user"),
                 };
@@ -331,16 +351,37 @@ function ChatView({
           updated[lastAssistantIdx] = { ...lastMsg };
         }
 
+        const followUpParts: any[] = [];
         if (result.output) {
+          followUpParts.push({ type: "text", text: result.output });
+        }
+        followUpParts.push(...newPendingParts);
+
+        if (followUpParts.length > 0) {
           updated.push({
             id: crypto.randomUUID(),
             role: "assistant" as const,
-            parts: [{ type: "text", text: result.output }],
+            parts: followUpParts,
           });
         }
 
         return updated;
       });
+
+      // If there are new pending approvals, immediately reflect them in state
+      // so the approval card shows without waiting for the messages-watcher
+      // useEffect to tick.
+      if (newPendingParts.length > 0) {
+        const asPendingApprovals: PendingApproval[] = newPendingParts.map(
+          (p: any) => ({
+            toolCallId: p.toolCallId,
+            toolName: p.type.replace("tool-", ""),
+            args: p.input,
+          })
+        );
+        setPendingApproval(asPendingApprovals[0]);
+        setAllPendingApprovals(asPendingApprovals);
+      }
     },
     [setMessages]
   );
@@ -430,7 +471,7 @@ function ChatView({
                                 <Markdown>{seg.content}</Markdown>
                               </div>
                             </div>
-                          ) : (
+                          ) : seg.type === "tool" ? (
                             <ToolResultCard
                               key={seg.toolCallId}
                               toolName={seg.toolName}
@@ -440,8 +481,9 @@ function ChatView({
                                   ? seg.result
                                   : JSON.stringify(seg.result)
                               }
+                              denied={seg.denied}
                             />
-                          )
+                          ) : null
                         )}
 
                         {isLastAssistant && pendingApproval && (


### PR DESCRIPTION
Enable the main chat textarea during a pending HITL approval. Typing and
submitting implicitly denies every pending tool call and sends the typed
text as the denial reason, which the agent sees on `ToolDenied(reason)`.
The agent's follow-up happens in the same LLM call — replacing the old
two-step flow (click Deny, wait for generic follow-up, then type feedback).

- Extract `submitApprovalDecisions` helper in tool-cards.tsx; reuse from
  both the approval card and the main chat input.
- Re-enable the textarea + send button during HITL; keep file attachments
  disabled (no place to attach files in a denial-reason payload).
- Show an amber hint above the input when an approval is pending.
- Optimistically render the user's feedback as a chat bubble; roll back on
  error.
- Prefer the backend's real tool result over the "Denied by user" sentinel
  so the actual feedback text shows in the ToolResultCard on expand.