### PR TITLE
fix(sernia-ai): dedupe Zillow email trigger to logical new messages

### DIFF
--- a/api/src/google/gmail/db_ops.py
+++ b/api/src/google/gmail/db_ops.py
@@ -32,21 +32,32 @@ async def save_email_message(
     session: AsyncSession,
     message_data: Dict[str, Any],
     history_id: Optional[int] = None
-) -> Optional[EmailMessage]:
+) -> tuple[Optional[EmailMessage], bool]:
     """
     Save a Gmail message to the database.
-    
+
     Args:
         session: SQLAlchemy async session
         message_data: Processed message data containing all required fields
         history_id: The Gmail history ID related to this message (optional)
-        
+
     Returns:
-        The saved EmailMessage instance or None if save failed
+        Tuple ``(email_msg, was_inserted)``:
+        - ``email_msg``: The saved ``EmailMessage`` instance, or ``None`` if the
+          save failed.
+        - ``was_inserted``: ``True`` if this call inserted a brand-new row;
+          ``False`` if it updated an existing row (e.g. pubsub redelivery or
+          Gmail label-change notification for a message we'd already saved).
     """
     try:
         message_id = message_data.get('message_id')
         logfire.info(f"Saving email message {message_id} to database")
+
+        # Check whether this message_id already exists. This lets callers
+        # distinguish truly new emails from pubsub redeliveries / label-change
+        # notifications (both of which trigger upserts on the same message_id).
+        existing = await get_email_by_message_id(session, message_id)
+        was_inserted = existing is None
 
         # Parse the date and ensure it's timezone aware
         date_str = message_data['date']
@@ -102,12 +113,12 @@ async def save_email_message(
         session.expire_all()
         email_msg = await get_email_by_message_id(session, message_id)
         logfire.info(f"Successfully saved email message {message_id}")
-        return email_msg
+        return email_msg, was_inserted
 
     except Exception as e:
         logfire.exception(f"Failed to save email message: {str(e)}")
         await session.rollback()
-        return None
+        return None, False
 
 
 
@@ -134,33 +145,35 @@ async def test_save_email_message():
     saved_msg = None
     async with get_test_session() as session:
         try:
-            # Save message with history_id
-            saved_msg = await save_email_message(session, message_data, history_id)
+            # Save message with history_id — first call should be a fresh insert
+            saved_msg, was_inserted = await save_email_message(session, message_data, history_id)
             assert saved_msg is not None
+            assert was_inserted is True
             assert saved_msg.message_id == message_data['message_id']
             assert saved_msg.first_history_id == history_id
             assert saved_msg.history_ids == [history_id]
             assert saved_msg.label_ids == message_data['label_ids']
-            
+
             # Verify we can retrieve it
             retrieved = await get_email_by_message_id(session, message_data['message_id'])
             assert retrieved is not None
             assert retrieved.subject == message_data['subject']
-            
-            # Test update with a new history_id
+
+            # Test update with a new history_id — second call should be an update, not an insert
             new_history_id = 67890
             updated_data = message_data.copy()
             updated_data['raw_payload'] = {'test': 'updated data'}
             updated_data['label_ids'] = ['INBOX', 'READ']
-            
-            updated_msg = await save_email_message(session, updated_data, new_history_id)
+
+            updated_msg, was_inserted_again = await save_email_message(session, updated_data, new_history_id)
             assert updated_msg is not None
+            assert was_inserted_again is False
             assert updated_msg.message_id == message_data['message_id']
             assert updated_msg.first_history_id == history_id  # First history should not change
             assert new_history_id in updated_msg.history_ids  # New history should be added
             assert updated_msg.label_ids == updated_data['label_ids']  # Labels should be updated
             assert updated_msg.raw_payload == updated_data['raw_payload']  # Payload should be updated
-            
+
         finally:
             # Cleanup: Delete test message
             if saved_msg:

--- a/api/src/google/pubsub/routes.py
+++ b/api/src/google/pubsub/routes.py
@@ -192,8 +192,13 @@ async def process_gmail_notification(pubsub_notification_data: dict):
 
                 # Save to database using a short-lived session (will update if message exists).
                 # This avoids holding a pooled connection during slow Gmail API calls.
+                # was_inserted tells us whether this save was a fresh insert (new logical
+                # email) or an update of an existing row (pubsub redelivery or Gmail
+                # label-change notification for a message we'd already seen).
                 async with session_context() as save_session:
-                    saved_msg = await save_email_message(save_session, processed_email_message, history_id)
+                    saved_msg, was_inserted = await save_email_message(
+                        save_session, processed_email_message, history_id
+                    )
                 if saved_msg:
                     processed_email_messages.append(processed_email_message)
                     logfire.info(
@@ -201,15 +206,17 @@ async def process_gmail_notification(pubsub_notification_data: dict):
                         f"{processed_email_message['subject']} (ID: {email_message_id})"
                     )
 
-                    # Queue Zillow emails for debounced trigger processing.
-                    # No is_new gate — added_message_ids is unreliable (often empty),
-                    # and the debounce window deduplicates anyway.
+                    # Queue Zillow emails for debounced trigger processing —
+                    # but only on the initial insert. Upserts on an existing
+                    # message_id (redelivery / label change) are not new logical
+                    # email events and should not refire the trigger. The queue
+                    # itself also dedupes by message_id as a secondary guard.
                     from_addr = processed_email_message.get("from_address", "")
                     is_zillow = bool(
                         from_addr
                         and ("@zillow.com" in from_addr.lower() or ".zillow.com" in from_addr.lower())
                     )
-                    if is_zillow:
+                    if is_zillow and was_inserted:
                         logfire.info(
                             "zillow_trigger_gate: queuing",
                             email_message_id=email_message_id,
@@ -225,6 +232,13 @@ async def process_gmail_notification(pubsub_notification_data: dict):
                                 from_address=from_addr,
                                 body_text=processed_email_message.get("body_text"),
                             )
+                        )
+                    elif is_zillow and not was_inserted:
+                        logfire.info(
+                            "zillow_trigger_gate: skipping (not a new email — pubsub redelivery or label change)",
+                            email_message_id=email_message_id,
+                            from_address=from_addr,
+                            subject=processed_email_message.get("subject", ""),
                         )
                 else:
                     failed_email_ids.append(email_message_id)

--- a/api/src/sernia_ai/triggers/README.md
+++ b/api/src/sernia_ai/triggers/README.md
@@ -135,6 +135,9 @@ flowchart TD
 ### Key design choices
 
 - **10-minute debounce** — First email starts a fixed window; subsequent emails are accumulated. The agent fires once at the end with the full batch, so it can see all new leads at once. This prevents N agent runs for N emails arriving in quick succession.
+- **Dedup to logical *new* emails** — Gmail Pub/Sub has at-least-once delivery and every label change (e.g. INBOX→READ) fires another history notification that re-references the same `message_id`. Two guards collapse these back down to one event per logical email:
+  1. **Pubsub route gate** — `save_email_message()` returns `(email, was_inserted)`. The Zillow trigger is only queued when `was_inserted=True`. Redeliveries / label-change upserts don't refire the trigger.
+  2. **Queue-level dedup** — `queue_zillow_email_event()` skips a `message_id` that is already in `_pending_emails` or in `_recently_fired_message_ids` (1-hour TTL). This catches anything that slips past the pubsub gate (e.g. a redelivery that races the DB commit).
 - **Trigger instructions stay lean** — point to `areas/zillow_auto_reply.md` for detailed guidance (qualification criteria, availability schedule, response tone). This allows iterating on AI behavior without code deploys.
 - **Emilio-only notifications** — looks up Emilio's `clerk_user_id` from DB via contact slug `"emilio"` (cached at module level), then uses `notify_clerk_user_id` parameter in `run_agent_for_trigger()` to send push only to Emilio's subscriptions via `notify_user_push()`.
 - **Coexists with scheduled check** — `run_scheduled_checks()` still runs as a safety net, catching anything the event trigger misses (e.g., server downtime).

--- a/api/src/sernia_ai/triggers/zillow_email_event_trigger.py
+++ b/api/src/sernia_ai/triggers/zillow_email_event_trigger.py
@@ -6,11 +6,20 @@ the first email starts a 10-minute window; any additional Zillow emails
 during that window are accumulated.  The agent fires once at the end of
 the window so it can assess all accumulated emails in a single run.
 
+Deduplication: Gmail Pub/Sub has at-least-once delivery, and a single logical
+message can show up in multiple history notifications (e.g. when Gmail label
+state changes). We dedupe by Gmail ``message_id`` at two levels:
+
+1. Within the current debounce window — skip if the id is already pending.
+2. Across recent windows — a short TTL "recently fired" cache guards against
+   a redelivery arriving moments after we fired the previous batch.
+
 Naming convention: all public symbols use the ``zillow_email_event`` root.
 """
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from textwrap import dedent
 
@@ -24,11 +33,32 @@ from api.src.sernia_ai.triggers.background_agent_runner import run_agent_for_tri
 # ---------------------------------------------------------------------------
 DEBOUNCE_SECONDS = 600  # 10 minutes
 
+# TTL for the recently-fired message_id cache. Must comfortably exceed the
+# debounce window so a redelivery landing after a batch fires still dedupes.
+RECENTLY_FIRED_TTL_SECONDS = 3600  # 1 hour
+
 # Module-level state for the debounce window.
 # _pending_emails accumulates email info dicts; _pending_task is the asyncio
 # task that sleeps for DEBOUNCE_SECONDS and then fires the trigger.
 _pending_emails: list[dict] = []
 _pending_task: asyncio.Task | None = None
+
+# {message_id: monotonic_epoch_when_fired} — TTL cache of message_ids that
+# were already included in a fired batch. Used to reject pubsub redeliveries
+# that arrive shortly after a window closes.
+_recently_fired_message_ids: dict[str, float] = {}
+
+
+def _prune_recently_fired(now: float | None = None) -> None:
+    """Drop entries older than RECENTLY_FIRED_TTL_SECONDS from the TTL cache."""
+    if now is None:
+        now = time.monotonic()
+    expired = [
+        mid for mid, ts in _recently_fired_message_ids.items()
+        if (now - ts) > RECENTLY_FIRED_TTL_SECONDS
+    ]
+    for mid in expired:
+        _recently_fired_message_ids.pop(mid, None)
 
 # Module-level cache for Emilio's clerk_user_id (looked up once from DB).
 _emilio_clerk_user_id: str | None = None
@@ -80,8 +110,32 @@ async def queue_zillow_email_event(
     The first email in a quiet period starts a 10-minute timer.  All
     subsequent emails within that window are accumulated.  When the timer
     fires, the agent runs once and sees every email in the batch.
+
+    Duplicate Gmail ``message_id`` values (pubsub redelivery, label-change
+    history events for the same physical message) are dropped: once already
+    pending or already fired within the TTL, additional calls for the same
+    id become no-ops.
     """
     global _pending_task
+
+    # Dedupe by Gmail message_id. Empty message_id falls through (can't dedupe
+    # without an identifier) but we should never see that in practice.
+    if message_id:
+        _prune_recently_fired()
+        if message_id in _recently_fired_message_ids:
+            logfire.info(
+                "zillow_email_event: dropping duplicate (recently fired)",
+                message_id=message_id,
+                subject=subject,
+            )
+            return
+        if any(e["message_id"] == message_id for e in _pending_emails):
+            logfire.info(
+                "zillow_email_event: dropping duplicate (already pending)",
+                message_id=message_id,
+                subject=subject,
+            )
+            return
 
     email_info = {
         "thread_id": thread_id,
@@ -118,6 +172,15 @@ async def _debounced_fire() -> None:
 
     if not emails:
         return
+
+    # Mark all fired message_ids as recently-fired so redeliveries landing
+    # after this window closes still dedupe.
+    now = time.monotonic()
+    _prune_recently_fired(now)
+    for email in emails:
+        mid = email.get("message_id")
+        if mid:
+            _recently_fired_message_ids[mid] = now
 
     logfire.info(
         "zillow_email_event: debounce window closed, firing trigger",

--- a/api/src/tests/test_triggers.py
+++ b/api/src/tests/test_triggers.py
@@ -13,17 +13,23 @@ from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserProm
 
 @pytest.fixture(autouse=True)
 def _clear_trigger_cooldowns():
-    """Reset the in-memory rate-limit cooldowns between tests."""
+    """Reset the in-memory rate-limit cooldowns and dedupe state between tests."""
     from api.src.sernia_ai.triggers.background_agent_runner import _trigger_cooldowns
     from api.src.sernia_ai.triggers.ai_sms_event_trigger import _ai_sms_call_timestamps
     import api.src.sernia_ai.triggers.zillow_email_event_trigger as zillow_mod
     _trigger_cooldowns.clear()
     _ai_sms_call_timestamps.clear()
     zillow_mod._emilio_clerk_user_id = None
+    zillow_mod._pending_emails.clear()
+    zillow_mod._pending_task = None
+    zillow_mod._recently_fired_message_ids.clear()
     yield
     _trigger_cooldowns.clear()
     _ai_sms_call_timestamps.clear()
     zillow_mod._emilio_clerk_user_id = None
+    zillow_mod._pending_emails.clear()
+    zillow_mod._pending_task = None
+    zillow_mod._recently_fired_message_ids.clear()
 
 
 # =========================================================================
@@ -1161,6 +1167,121 @@ class TestGetEmilioClerkUserId:
         ):
             result = await mod._get_emilio_clerk_user_id()
             assert result is None
+
+
+class TestQueueZillowEmailEventDedup:
+    """Dedup behavior of queue_zillow_email_event by Gmail message_id."""
+
+    @pytest.mark.asyncio
+    async def test_dedup_within_pending_window(self):
+        """Re-queuing the same message_id while pending should be a no-op."""
+        import api.src.sernia_ai.triggers.zillow_email_event_trigger as mod
+
+        # Replace asyncio.create_task so the debounce timer never actually starts.
+        def _close_coro(coro, *args, **kwargs):
+            # Close the coroutine so pytest doesn't warn about it never being awaited.
+            if hasattr(coro, "close"):
+                coro.close()
+            return MagicMock()
+
+        with patch.object(mod.asyncio, "create_task", side_effect=_close_coro):
+            await mod.queue_zillow_email_event(
+                thread_id="t1",
+                message_id="msg_dup_1",
+                subject="Amelia requesting info",
+                from_address="lead@convo.zillow.com",
+                body_text="hi",
+            )
+            # Three pubsub redeliveries of the same logical email
+            for _ in range(3):
+                await mod.queue_zillow_email_event(
+                    thread_id="t1",
+                    message_id="msg_dup_1",
+                    subject="Amelia requesting info",
+                    from_address="lead@convo.zillow.com",
+                    body_text="hi",
+                )
+
+        assert len(mod._pending_emails) == 1
+        assert mod._pending_emails[0]["message_id"] == "msg_dup_1"
+
+    @pytest.mark.asyncio
+    async def test_distinct_ids_accumulate(self):
+        """Distinct message_ids should all be accumulated in the batch."""
+        import api.src.sernia_ai.triggers.zillow_email_event_trigger as mod
+
+        def _close_coro(coro, *args, **kwargs):
+            # Close the coroutine so pytest doesn't warn about it never being awaited.
+            if hasattr(coro, "close"):
+                coro.close()
+            return MagicMock()
+
+        with patch.object(mod.asyncio, "create_task", side_effect=_close_coro):
+            for mid in ("msg_a", "msg_b", "msg_c"):
+                await mod.queue_zillow_email_event(
+                    thread_id="t1",
+                    message_id=mid,
+                    subject="Subj",
+                    from_address="lead@convo.zillow.com",
+                    body_text=None,
+                )
+
+        ids = [e["message_id"] for e in mod._pending_emails]
+        assert ids == ["msg_a", "msg_b", "msg_c"]
+
+    @pytest.mark.asyncio
+    async def test_recently_fired_ttl_blocks_requeue(self):
+        """A message_id marked as recently fired should be rejected on re-queue."""
+        import time as _time
+        import api.src.sernia_ai.triggers.zillow_email_event_trigger as mod
+
+        mod._recently_fired_message_ids["msg_just_fired"] = _time.monotonic()
+
+        def _close_coro(coro, *args, **kwargs):
+            # Close the coroutine so pytest doesn't warn about it never being awaited.
+            if hasattr(coro, "close"):
+                coro.close()
+            return MagicMock()
+
+        with patch.object(mod.asyncio, "create_task", side_effect=_close_coro):
+            await mod.queue_zillow_email_event(
+                thread_id="t1",
+                message_id="msg_just_fired",
+                subject="Subj",
+                from_address="lead@convo.zillow.com",
+                body_text=None,
+            )
+
+        assert mod._pending_emails == []
+
+    @pytest.mark.asyncio
+    async def test_recently_fired_prunes_expired(self):
+        """TTL cache entries older than RECENTLY_FIRED_TTL_SECONDS should be pruned."""
+        import time as _time
+        import api.src.sernia_ai.triggers.zillow_email_event_trigger as mod
+
+        # Entry from two hours ago — older than the 1h TTL
+        mod._recently_fired_message_ids["msg_expired"] = _time.monotonic() - 7200
+
+        def _close_coro(coro, *args, **kwargs):
+            # Close the coroutine so pytest doesn't warn about it never being awaited.
+            if hasattr(coro, "close"):
+                coro.close()
+            return MagicMock()
+
+        with patch.object(mod.asyncio, "create_task", side_effect=_close_coro):
+            await mod.queue_zillow_email_event(
+                thread_id="t1",
+                message_id="msg_expired",
+                subject="Subj",
+                from_address="lead@convo.zillow.com",
+                body_text=None,
+            )
+
+        # Expired entry was pruned, so the email was accepted into the batch
+        assert "msg_expired" not in mod._recently_fired_message_ids
+        assert len(mod._pending_emails) == 1
+        assert mod._pending_emails[0]["message_id"] == "msg_expired"
 
 
 class TestZillowEmailBatchedTrigger:


### PR DESCRIPTION
## Summary

In prod today (conv `57451467-7c1b-488e-85b9-32153e00b615`), the Zillow email trigger fired with 28 "new" emails in one batch, even though only ~7 unique Gmail `message_id`s were represented — the rest were pubsub redeliveries / Gmail label-change notifications refiring the trigger for emails we'd already seen. The 10-minute debounce was batching them correctly; it was just batching duplicates.

This PR adds two dedup guards:

1. **Pubsub route gate.** `save_email_message()` now returns `(email, was_inserted)`. The Zillow trigger is only queued when `was_inserted=True`; upserts on an existing `message_id` (the common case for label changes and pubsub redeliveries) are skipped with a log line.
2. **Queue-level dedup.** `queue_zillow_email_event()` dedupes by Gmail `message_id` against the current pending list *and* a 1-hour TTL "recently fired" cache, so any redelivery that slips past the pubsub gate (e.g. races the DB commit) still becomes a no-op.

The 10-minute debounce window itself is unchanged.

Docs in `api/src/sernia_ai/triggers/README.md` updated to document the new dedup behavior.

## Test plan

- [x] New unit tests in `test_triggers.py::TestQueueZillowEmailEventDedup` cover in-window dedup, distinct-id accumulation, TTL-blocked re-queue, and TTL pruning.
- [x] `save_email_message` test updated to assert `was_inserted` flips from True (first save) to False (update).
- [x] Full `test_triggers.py` suite passes (84 tests).
- [ ] After deploy: watch Logfire for the next burst of Zillow pubsub events and confirm `zillow_trigger_gate: skipping` (for label-change upserts) and `zillow_email_event: dropping duplicate` lines appear, and that the fired batch contains one entry per unique `message_id`.

https://claude.ai/code/session_01JjjvXpgdpWXA45cjpB6h2P