### PR TITLE
fix(open_phone): handle duplicate event race condition gracefully

### DIFF
--- a/api/src/open_phone/routes.py
+++ b/api/src/open_phone/routes.py
@@ -237,10 +237,26 @@ async def webhook(
             return {"message": "Event recorded successfully"}
 
     except IntegrityError as e:
-        # For other IntegrityErrors, log it as an error with traceback and then raise HTTPException
+        await session.rollback()
         event_id_for_log = payload.id if hasattr(payload, 'id') else "unknown"
+
+        # Check if this is a duplicate key violation on event_id (race condition)
+        # PostgreSQL unique_violation error code is '23505'
+        is_duplicate_event = (
+            hasattr(e, 'orig') and
+            hasattr(e.orig, 'pgcode') and
+            e.orig.pgcode == '23505' and
+            'event_id' in str(e)
+        )
+
+        if is_duplicate_event:
+            # Race condition: another request already inserted this event
+            logfire.info(f"Event {event_id_for_log} already processed (duplicate key race condition), skipping")
+            return {"message": "Event already processed"}
+
+        # For other IntegrityErrors, log it as an error with traceback and then raise HTTPException
         log_message = f"Unhandled IntegrityError processing event_id {event_id_for_log}. Full payload: {payload}. Database Error: {e}"
-        logfire.exception(log_message) # exc_info=True includes the stack trace
+        logfire.exception(log_message)
 
         raise HTTPException(status_code=500, detail=f"A database integrity error occurred processing event {event_id_for_log}. Please refer to server logs for details.")
     except Exception as e:


### PR DESCRIPTION
## Summary

- Fixes Logfire issue #75: database integrity error on OpenPhone webhook
- Handles race condition when two webhook requests for the same event arrive simultaneously
- Both requests pass the duplicate check, but second insert fails with unique constraint violation
- Now detects PostgreSQL error code `23505` on `event_id` and returns success instead of 500 error

## Root Cause

The webhook handler checks if an event exists before inserting, but under concurrent load:
1. Request A checks → not found
2. Request B checks → not found  
3. Request A inserts → success
4. Request B inserts → IntegrityError (duplicate key)

The fix gracefully handles this by treating duplicate key violations on `event_id` as "already processed" (idempotent behavior).

## Test plan

- [ ] Deploy to Railway preview environment
- [ ] Verify webhook endpoint still processes new events correctly
- [ ] Confirm duplicate events no longer cause 500 errors in Logfire

## Links

- Slack thread: https://panepartnersllc.slack.com/archives/C09T58LBLRE/p1777642759586029?thread_ts=1777640580.438259&cid=C09T58LBLRE
- Railway preview: https://react-router-portfolio-pr-{PR_NUMBER}.up.railway.app/

https://claude.ai/code/session_01MncbKbwQmEkYxxXH5ubREJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MncbKbwQmEkYxxXH5ubREJ)_