### PR TITLE
fix(sernia-chat): keep input above keyboard on iOS

### DIFF
--- a/apps/web-react-router/app/hooks/use-visual-viewport-height.tsx
+++ b/apps/web-react-router/app/hooks/use-visual-viewport-height.tsx
@@ -4,12 +4,18 @@ import { useEffect } from "react";
  * Tracks window.visualViewport.height into the CSS variable --chat-vh so
  * flex containers can stay within the visible viewport when the iOS virtual
  * keyboard opens. dvh alone does not shrink for the keyboard on iOS Safari.
+ *
+ * Also locks html/body scrolling while mounted: without this, iOS Safari
+ * scrolls the page when the keyboard opens, pushing the chat input below
+ * the visible area. With body scroll locked and the chat shell sized to
+ * --chat-vh, the input bar stays anchored just above the keyboard.
  */
 export function useVisualViewportHeight() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const vv = window.visualViewport;
     const root = document.documentElement;
+    const body = document.body;
 
     const update = () => {
       const h = vv ? vv.height : window.innerHeight;
@@ -25,6 +31,13 @@ export function useVisualViewportHeight() {
     window.addEventListener("resize", update);
     window.addEventListener("orientationchange", update);
 
+    const prevHtmlOverflow = root.style.overflow;
+    const prevBodyOverflow = body.style.overflow;
+    const prevBodyOverscroll = body.style.overscrollBehavior;
+    root.style.overflow = "hidden";
+    body.style.overflow = "hidden";
+    body.style.overscrollBehavior = "none";
+
     return () => {
       if (vv) {
         vv.removeEventListener("resize", update);
@@ -33,6 +46,9 @@ export function useVisualViewportHeight() {
       window.removeEventListener("resize", update);
       window.removeEventListener("orientationchange", update);
       root.style.removeProperty("--chat-vh");
+      root.style.overflow = prevHtmlOverflow;
+      body.style.overflow = prevBodyOverflow;
+      body.style.overscrollBehavior = prevBodyOverscroll;
     };
   }, []);
 }


### PR DESCRIPTION
## Summary
- Lock `html`/`body` scroll while the Sernia chat is mounted so iOS Safari can't scroll the page when the virtual keyboard opens. Combined with the existing `--chat-vh` sizing, this keeps the input bar anchored to the bottom of the visible viewport instead of being pushed off-screen.
- Restores the previous overflow values on unmount so other routes are unaffected.

## Why
Previously, when the keyboard opened on iOS, the visual viewport shrank but iOS still scrolled the page to keep the focused textarea visible. Because `SidebarInset` has `min-h-svh` (taller than the visual viewport), the page had room to scroll and the input ended up below the keyboard — the user had to scroll to bring it back into view. Locking body scroll prevents the page from moving, so the chat shell (sized via `--chat-vh = visualViewport.height`) exactly fills the visible area and the input sits just above the keyboard, like ChatGPT's mobile UI.

## Test plan
- [ ] On iOS Safari, open `/sernia-chat`, tap the textarea, confirm the input stays directly above the keyboard with no scroll required.
- [ ] Dismiss the keyboard, confirm the input returns to the bottom of the screen and the messages list scrolls normally.
- [ ] Navigate away from `/sernia-chat` and confirm body scroll is restored on other routes.
- [ ] Desktop: confirm no regression — messages list still scrolls within its container.

Preview: https://react-router-portfolio-pr-245.up.railway.app/

https://claude.ai/code/session_01WgLYVjDF94M28TuL3KkGL8