### PR TITLE
refactor: rename ANTHROPIC_API_KEY to SERNIA_ANTHROPIC_API_KEY

### DIFF
--- a/.claude/prep_claude_remote_env_var.py
+++ b/.claude/prep_claude_remote_env_var.py
@@ -15,10 +15,10 @@ ZPROFILE_KEYS = [
 ]
 
 # Keys from .env that must NOT be injected into the Claude Code remote env.
-# ANTHROPIC_API_KEY collides with the key Claude Cloud injects for itself and
-# breaks the remote session. Tracked as a TODO: rename in app code, Railway
-# secrets, and .env so this skip can be removed.
-SKIP_KEYS = {"ANTHROPIC_API_KEY"}
+# Empty by default — our app's Anthropic key lives under SERNIA_ANTHROPIC_API_KEY
+# (see api/index.py for the bridge to ANTHROPIC_API_KEY) so it no longer
+# collides with the ANTHROPIC_API_KEY Claude Cloud injects for itself.
+SKIP_KEYS: set[str] = set()
 
 
 def parse_zprofile_secrets(keys):

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,13 @@
 
 # Get your OpenAI API Key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=****
+
+# Anthropic API key — named SERNIA_ANTHROPIC_API_KEY (not ANTHROPIC_API_KEY)
+# to avoid colliding with the ANTHROPIC_API_KEY that Claude Cloud injects for
+# the Claude Code session in remote dev environments. api/index.py bridges
+# this to ANTHROPIC_API_KEY at startup so the Anthropic SDK auto-discovers it.
+SERNIA_ANTHROPIC_API_KEY=****
+
 CRON_SECRET=****
 OPEN_PHONE_WEBHOOK_WEBHOOK_SECRET=****
 OPEN_PHONE_API_KEY=****

--- a/api/index.py
+++ b/api/index.py
@@ -4,6 +4,13 @@ import json
 import logfire
 import os
 
+# Bridge SERNIA_ANTHROPIC_API_KEY -> ANTHROPIC_API_KEY for the Anthropic SDK.
+# Renamed to avoid colliding with the ANTHROPIC_API_KEY that Claude Cloud
+# injects for the Claude Code session in the remote dev environment.
+_sernia_anthropic_key = os.environ.get("SERNIA_ANTHROPIC_API_KEY")
+if _sernia_anthropic_key:
+    os.environ["ANTHROPIC_API_KEY"] = _sernia_anthropic_key
+
 import logfire
 from api.src.utils.logfire_config import ensure_logfire_configured
 

--- a/api/src/sernia_ai/PLAN.md
+++ b/api/src/sernia_ai/PLAN.md
@@ -525,7 +525,7 @@ Core function shared by all triggers:
 
 | Variable | Purpose |
 |----------|---------|
-| `ANTHROPIC_API_KEY` | Main + sub-agent LLM calls |
+| `SERNIA_ANTHROPIC_API_KEY` | Main + sub-agent LLM calls (bridged to `ANTHROPIC_API_KEY` at startup; renamed to avoid colliding with the key Claude Cloud injects in remote dev) |
 | `OPEN_PHONE_API_KEY` | Quo/OpenPhone API access |
 | `OPEN_PHONE_WEBHOOK_SECRET` | HMAC signature verification |
 | `VAPID_PRIVATE_KEY` / `VAPID_PUBLIC_KEY` | Web Push signing |


### PR DESCRIPTION
## Summary

Closes #244 — renames our app's Anthropic key from `ANTHROPIC_API_KEY` to `SERNIA_ANTHROPIC_API_KEY` to avoid colliding with the `ANTHROPIC_API_KEY` Claude Cloud injects for the Claude Code session in remote dev.

- **`api/index.py`** — bridges `SERNIA_ANTHROPIC_API_KEY` → `ANTHROPIC_API_KEY` at startup (before pydantic-ai constructs the Anthropic provider) so the Anthropic SDK still auto-discovers the key without app code changes elsewhere.
- **`.claude/prep_claude_remote_env_var.py`** — drops `ANTHROPIC_API_KEY` from `SKIP_KEYS`. The prep script can now pass the (renamed) Anthropic key through cleanly.
- **`.env.example`** — documents the new `SERNIA_ANTHROPIC_API_KEY` var with rationale.
- **`api/src/sernia_ai/PLAN.md`** — updates the env-var table.

## Railway

`SERNIA_ANTHROPIC_API_KEY` has been added to **production** and **development** Railway envs (additive, with `skipDeploys`). The old `ANTHROPIC_API_KEY` is intentionally **kept in place** for now as a rollback safety — it can be removed in a follow-up after this deploy is verified.

PR preview environments inherit from the base env and will pick up the new var automatically.

## Test plan

- [ ] Confirm Railway PR preview deploys successfully: https://react-router-portfolio-pr-245.up.railway.app/
- [ ] Verify Sernia AI chat still works against an Anthropic model (Sonnet 4.6 or Opus 4.7) in the PR preview
- [ ] After merge + production deploy, verify `/api/sernia-ai/chat` works with an Anthropic model in production
- [ ] After production verification, remove the old `ANTHROPIC_API_KEY` Railway secret in a follow-up PR/manual cleanup
- [ ] Verify next Claude Code remote session no longer prints the `Warning: skipping ANTHROPIC_API_KEY` line

https://claude.ai/code/session_01NW1Thg8m9GD1kVi8eiKyvh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NW1Thg8m9GD1kVi8eiKyvh)_