### PR TITLE
fix(sernia-chat): pin input bar above keyboard with position:fixed

### DIFF
--- a/apps/web-react-router/app/hooks/use-visual-viewport-height.tsx
+++ b/apps/web-react-router/app/hooks/use-visual-viewport-height.tsx
@@ -1,14 +1,15 @@
 import { useEffect } from "react";
 
 /**
- * Tracks window.visualViewport.height into the CSS variable --chat-vh so
- * flex containers can stay within the visible viewport when the iOS virtual
- * keyboard opens. dvh alone does not shrink for the keyboard on iOS Safari.
+ * Tracks window.visualViewport into CSS variables so the chat input bar
+ * can stay anchored to the bottom of the visible viewport, above the iOS
+ * keyboard:
+ *   --chat-vh        : visualViewport.height (height of visible viewport)
+ *   --keyboard-inset : space the keyboard takes from the bottom of the
+ *                      layout viewport (0 when keyboard is closed)
  *
- * Also locks html/body scrolling while mounted: without this, iOS Safari
- * scrolls the page when the keyboard opens, pushing the chat input below
- * the visible area. With body scroll locked and the chat shell sized to
- * --chat-vh, the input bar stays anchored just above the keyboard.
+ * Also locks html/body scrolling while mounted so iOS Safari can't push
+ * the page up when the keyboard opens.
  */
 export function useVisualViewportHeight() {
   useEffect(() => {
@@ -18,8 +19,17 @@ export function useVisualViewportHeight() {
     const body = document.body;
 
     const update = () => {
-      const h = vv ? vv.height : window.innerHeight;
-      root.style.setProperty("--chat-vh", `${h}px`);
+      if (vv) {
+        root.style.setProperty("--chat-vh", `${vv.height}px`);
+        const inset = Math.max(
+          0,
+          window.innerHeight - vv.height - vv.offsetTop
+        );
+        root.style.setProperty("--keyboard-inset", `${inset}px`);
+      } else {
+        root.style.setProperty("--chat-vh", `${window.innerHeight}px`);
+        root.style.setProperty("--keyboard-inset", "0px");
+      }
     };
 
     update();
@@ -46,6 +56,7 @@ export function useVisualViewportHeight() {
       window.removeEventListener("resize", update);
       window.removeEventListener("orientationchange", update);
       root.style.removeProperty("--chat-vh");
+      root.style.removeProperty("--keyboard-inset");
       root.style.overflow = prevHtmlOverflow;
       body.style.overflow = prevBodyOverflow;
       body.style.overscrollBehavior = prevBodyOverscroll;

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -157,9 +157,30 @@ function ChatView({
     }
   }, [input, draftKey]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const inputBarRef = useRef<HTMLDivElement>(null);
   const [messagesContainerRef, messagesEndRef] =
     useScrollToBottom<HTMLDivElement>();
   const attachment = useFileAttachments();
+
+  // Track the actual height of the input bar so the messages list reserves
+  // matching bottom padding. The input bar is position:fixed on mobile, so
+  // without this the latest message would render under it.
+  useEffect(() => {
+    const el = inputBarRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const h = entries[0]?.contentRect.height ?? 0;
+      document.documentElement.style.setProperty(
+        "--chat-input-h",
+        `${h}px`
+      );
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      document.documentElement.style.removeProperty("--chat-input-h");
+    };
+  }, [readOnly]);
 
   const isStandalonePwa = useIsStandalonePwa();
   const pullDistance = usePullToRefresh({
@@ -439,7 +460,7 @@ function ChatView({
       {/* Messages */}
       <div
         ref={messagesContainerRef}
-        className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll overflow-x-hidden overscroll-none pt-4 relative"
+        className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll overflow-x-hidden overscroll-none pt-4 relative max-md:pb-[var(--chat-input-h,5rem)]"
         {...attachment.dropTargetProps}
       >
         {isStandalonePwa && pullDistance > 0 && (
@@ -601,15 +622,22 @@ function ChatView({
         onChange={attachment.handleFileInputChange}
       />
 
-      {/* Input Area — hidden for read-only SMS conversations */}
+      {/* Input Area — hidden for read-only SMS conversations.
+          On mobile we pin it with position:fixed at --keyboard-inset above
+          the bottom so it stays directly above the iOS keyboard instead of
+          being pushed off-screen with the page. */}
       {readOnly ? (
-        <div className="flex items-center justify-center px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] border-t text-sm text-muted-foreground">
+        <div
+          ref={inputBarRef}
+          className="flex items-center justify-center px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] border-t text-sm text-muted-foreground bg-background max-md:fixed max-md:left-0 max-md:right-0 max-md:bottom-[var(--keyboard-inset,0px)] max-md:z-30"
+        >
           <Phone className="w-4 h-4 mr-2" />
           SMS conversation — reply via text message
         </div>
       ) : (
       <div
-        className="shrink-0 flex mx-auto px-4 bg-background pt-3 md:pt-4 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:pb-[calc(1rem+env(safe-area-inset-bottom))] gap-2 w-full md:max-w-3xl border-t"
+        ref={inputBarRef}
+        className="shrink-0 flex mx-auto px-4 bg-background pt-3 md:pt-4 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:pb-[calc(1rem+env(safe-area-inset-bottom))] gap-2 w-full md:max-w-3xl border-t max-md:fixed max-md:left-0 max-md:right-0 max-md:bottom-[var(--keyboard-inset,0px)] max-md:z-30"
       >
         {messages.length === 0 ? (
           <div className="flex flex-col gap-4 w-full">


### PR DESCRIPTION
## Summary
Follow-up to #245 — the body-scroll lock alone wasn't enough on iOS PWA; the input bar was still ending up off-screen. This PR pins the input bar with `position: fixed` directly above the keyboard.

- Hook now computes `--keyboard-inset = window.innerHeight - vv.height - vv.offsetTop` alongside `--chat-vh`.
- Mobile input bar (and the read-only SMS footer) is `position: fixed` with `bottom: var(--keyboard-inset)`. On desktop (`md+`) the existing flex layout is unchanged.
- A `ResizeObserver` tracks the input bar's height into `--chat-input-h` so the messages list reserves matching bottom padding and the latest message isn't hidden under the fixed bar.

## Why
On iOS Safari and PWA, `position: fixed` elements stay anchored to the layout viewport, not the visual viewport — but with `bottom: var(--keyboard-inset)` we shift them up by the keyboard height. This matches how ChatGPT's mobile UI keeps its input directly above the keyboard.

## Test plan
- [ ] iOS Safari and PWA: open `/sernia-chat`, tap textarea → input stays directly above the keyboard, no scrolling needed.
- [ ] Dismiss keyboard → input returns to the bottom of the screen.
- [ ] Long conversation: latest message is fully visible above the fixed input bar.
- [ ] Empty state: suggestions + input visible together at the bottom; "Sernia AI" header visible above.
- [ ] Read-only SMS conversation: footer pill is fixed above the keyboard too.
- [ ] Desktop (≥ md): no visual regression — input bar still flows in the flex column.

Preview: https://react-router-portfolio-pr-247.up.railway.app/

https://claude.ai/code/session_01WgLYVjDF94M28TuL3KkGL8