### PR TITLE
fix: Logfire alerts, pnpm 11 upgrade, production protection hooks

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,55 @@
+# PreToolUse Hooks
+
+These hooks implement parameter-based permission control for MCP tools. Claude Code's `settings.json` permissions are all-or-nothing per tool - these hooks add granular control based on tool arguments.
+
+## Philosophy
+
+**Protect production, allow development freely.**
+
+- Read operations are always safe
+- Write operations to non-production environments should flow without friction
+- Production modifications require explicit confirmation
+- Destructive operations (deletes) always require confirmation
+
+## Railway (`railway-link-guard.sh`)
+
+| Environment | Decision |
+|-------------|----------|
+| `production` | ask |
+| All others (dev, PR envs, etc.) | allow |
+
+**Why:** Prevents accidental production deploys/changes. Development and PR environments are sandboxed.
+
+## Neon (`neon-guard.sh`)
+
+| Operation | Decision | Rationale |
+|-----------|----------|-----------|
+| `delete_branch`, `delete_project` | ask | Permanently destroys data |
+| `complete_database_migration` | ask | Applies DDL to parent (main) branch |
+| `complete_query_tuning` | ask | Applies changes to main branch |
+| `run_sql` without `branchId` | ask | Neon defaults to main branch when omitted |
+| `run_sql` on main/production branch | ask | Direct production write |
+| `run_sql` on PR/feature branches | allow | Safe sandbox |
+| `reset_from_parent` | allow | Only refreshes child from main, doesn't modify production |
+| All read-only tools | allow (no hook) | No modification risk |
+
+**Key insight:** Neon's `branchId` parameter is optional - if omitted, it defaults to the main branch. This is the primary risk vector for accidental production writes.
+
+## Adding New Hooks
+
+1. Create a bash script in this directory
+2. Read JSON from stdin: `INPUT=$(cat)`
+3. Extract parameters with jq: `echo "$INPUT" | jq -r '.tool_input.paramName'`
+4. Output decision JSON: `{"decision":"allow"}` or `{"decision":"ask","reason":"..."}`
+5. Register in `.claude/settings.json` under `hooks.PreToolUse`
+
+## Testing Hooks
+
+```bash
+# Test with sample input
+echo '{"tool_name":"mcp__Neon__run_sql","tool_input":{"sql":"SELECT 1"}}' | ./neon-guard.sh
+# Should output: {"decision":"ask","reason":"SQL with no branchId (defaults to main) - requires confirmation"}
+
+echo '{"tool_name":"mcp__Neon__run_sql","tool_input":{"sql":"SELECT 1","branchId":"br-pr-123"}}' | ./neon-guard.sh
+# Should output: {"decision":"allow"}
+```

--- a/.claude/hooks/neon-guard.sh
+++ b/.claude/hooks/neon-guard.sh
@@ -1,19 +1,34 @@
 #!/bin/bash
 # Guard Neon operations: require confirmation for destructive actions on main/production
+# Key insight: branchId is optional - if omitted, Neon defaults to main branch
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
-BRANCH_NAME=$(echo "$INPUT" | jq -r '.tool_input.branchName // .tool_input.branch // empty')
+BRANCH_ID=$(echo "$INPUT" | jq -r '.tool_input.branchId // empty')
 
-# Delete operations always require confirmation
-if [[ "$TOOL_NAME" == *"delete_branch"* ]] || [[ "$TOOL_NAME" == *"delete_project"* ]]; then
+# Always destructive - require confirmation regardless of branch
+if [[ "$TOOL_NAME" == *"delete_branch"* ]] || \
+   [[ "$TOOL_NAME" == *"delete_project"* ]] || \
+   [[ "$TOOL_NAME" == *"reset_from_parent"* ]]; then
   echo '{"decision":"ask","reason":"Destructive Neon operation - requires confirmation"}'
   exit 0
 fi
 
-# SQL on main/production branch requires confirmation
+# Migration completion applies to parent (usually main) - always ask
+if [[ "$TOOL_NAME" == *"complete_database_migration"* ]] || \
+   [[ "$TOOL_NAME" == *"complete_query_tuning"* ]]; then
+  echo '{"decision":"ask","reason":"Applies changes to parent/main branch - requires confirmation"}'
+  exit 0
+fi
+
+# SQL operations: ask if no branchId (defaults to main) or explicitly main/production
 if [[ "$TOOL_NAME" == *"run_sql"* ]]; then
-  if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "production" ] || [ -z "$BRANCH_NAME" ]; then
+  if [ -z "$BRANCH_ID" ]; then
+    echo '{"decision":"ask","reason":"SQL with no branchId (defaults to main) - requires confirmation"}'
+    exit 0
+  fi
+  # Check for explicit main/production branch names or IDs containing "main"
+  if [[ "$BRANCH_ID" == "main" ]] || [[ "$BRANCH_ID" == "production" ]] || [[ "$BRANCH_ID" == *"main"* ]]; then
     echo '{"decision":"ask","reason":"SQL on main/production branch - requires confirmation"}'
     exit 0
   fi

--- a/.claude/hooks/neon-guard.sh
+++ b/.claude/hooks/neon-guard.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Guard Neon operations: require confirmation for destructive actions on main/production
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+BRANCH_NAME=$(echo "$INPUT" | jq -r '.tool_input.branchName // .tool_input.branch // empty')
+
+# Delete operations always require confirmation
+if [[ "$TOOL_NAME" == *"delete_branch"* ]] || [[ "$TOOL_NAME" == *"delete_project"* ]]; then
+  echo '{"decision":"ask","reason":"Destructive Neon operation - requires confirmation"}'
+  exit 0
+fi
+
+# SQL on main/production branch requires confirmation
+if [[ "$TOOL_NAME" == *"run_sql"* ]]; then
+  if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "production" ] || [ -z "$BRANCH_NAME" ]; then
+    echo '{"decision":"ask","reason":"SQL on main/production branch - requires confirmation"}'
+    exit 0
+  fi
+fi
+
+echo '{"decision":"allow"}'

--- a/.claude/hooks/neon-guard.sh
+++ b/.claude/hooks/neon-guard.sh
@@ -8,8 +8,7 @@ BRANCH_ID=$(echo "$INPUT" | jq -r '.tool_input.branchId // empty')
 
 # Always destructive - require confirmation regardless of branch
 if [[ "$TOOL_NAME" == *"delete_branch"* ]] || \
-   [[ "$TOOL_NAME" == *"delete_project"* ]] || \
-   [[ "$TOOL_NAME" == *"reset_from_parent"* ]]; then
+   [[ "$TOOL_NAME" == *"delete_project"* ]]; then
   echo '{"decision":"ask","reason":"Destructive Neon operation - requires confirmation"}'
   exit 0
 fi

--- a/.claude/hooks/railway-link-guard.sh
+++ b/.claude/hooks/railway-link-guard.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Guard Railway link-environment: require confirmation for production only
+
+INPUT=$(cat)
+ENV_NAME=$(echo "$INPUT" | jq -r '.tool_input.environmentName // empty')
+
+if [ "$ENV_NAME" = "production" ]; then
+  echo '{"decision":"ask","reason":"Production environment - requires confirmation"}'
+else
+  echo '{"decision":"allow"}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -141,15 +141,6 @@
         ]
       },
       {
-        "matcher": "mcp__Neon__reset_from_parent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
-          }
-        ]
-      },
-      {
         "matcher": "mcp__Neon__complete_database_migration",
         "hooks": [
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -139,6 +139,33 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
           }
         ]
+      },
+      {
+        "matcher": "mcp__Neon__reset_from_parent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__Neon__complete_database_migration",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__Neon__complete_query_tuning",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
+          }
+        ]
       }
     ],
     "Notification": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,7 @@
       "mcp__Railway__list-deployments",
       "mcp__Railway__list-variables",
       "mcp__Railway__get-logs",
+      "mcp__Railway__link-environment",
       "mcp__cloudflare-dns",
       "mcp__cloudflare-docs",
       "mcp__claude-in-chrome",
@@ -72,7 +73,6 @@
       "mcp__Railway__create-environment",
       "mcp__Railway__generate-domain",
       "mcp__Railway__set-variables",
-      "mcp__Railway__link-environment",
       "mcp__Railway__link-service"
     ]
   },
@@ -90,6 +90,53 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/setup_remote.sh",
             "timeout": 60000
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__Railway__link-environment",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/railway-link-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__Neon__delete_branch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__Neon__delete_project",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__Neon__run_sql",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__Neon__run_sql_transaction",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/neon-guard.sh"
           }
         ]
       }

--- a/.claude/setup_remote.sh
+++ b/.claude/setup_remote.sh
@@ -102,14 +102,14 @@ if command -v railway &>/dev/null && [ -n "$RAILWAY_MCP_TOKEN" ]; then
   fi
   export RAILWAY_API_TOKEN="$RAILWAY_MCP_TOKEN"
 
-  # Pre-link to production/fastapi as a sensible default. MCP tools can switch
+  # Pre-link to development/fastapi as a sensible default. MCP tools can switch
   # to other envs/services via link-environment / link-service.
   if railway link \
     --project "$PORTFOLIO_PROJECT_ID" \
-    --environment production \
+    --environment development \
     --service fastapi \
     >/dev/null 2>&1; then
-    echo "Railway project pre-linked (portfolio / production / fastapi)"
+    echo "Railway project pre-linked (portfolio / development / fastapi)"
   else
     echo "WARNING: Railway pre-link failed — run 'railway link' manually if needed"
   fi

--- a/.claude/setup_remote.sh
+++ b/.claude/setup_remote.sh
@@ -29,6 +29,8 @@ echo "Project directory: $PROJECT_DIR"
 # =============================================================================
 echo ""
 echo "--- Starting pnpm install in background ---"
+# Enable corepack to use packageManager from package.json
+corepack enable
 pnpm install > /tmp/pnpm_install.log 2>&1 &
 PNPM_PID=$!
 

--- a/.npmrc
+++ b/.npmrc
@@ -3,6 +3,3 @@
 supportedArchitectures.os=current,linux
 supportedArchitectures.cpu=current,arm64,x64
 supportedArchitectures.libc=current,musl,glibc
-
-# pnpm 11: allow all packages to run build scripts
-onlyBuiltDependencies=*

--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,6 @@
 supportedArchitectures.os=current,linux
 supportedArchitectures.cpu=current,arm64,x64
 supportedArchitectures.libc=current,musl,glibc
+
+# pnpm 11: allow all packages to run build scripts
+onlyBuiltDependencies=*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ When running in Claude Code's cloud environment (`CLAUDE_CODE_REMOTE=true`), a *
 3. Runs database migrations (`alembic upgrade head`)
 4. Seeds the database
 5. Installs pnpm dependencies and builds React Router app
-6. Bridges `RAILWAY_MCP_TOKEN` → `RAILWAY_API_TOKEN` and pre-links the portfolio project to `production/fastapi` so Railway MCP tools (`get-logs`, `list-deployments`, etc.) work on first try. Switch envs/services with the `link-environment` / `link-service` MCP tools. **Note:** PR environments are created dynamically with auto-generated names — use the Railway web UI or GitHub PR status links to access PR-specific build logs.
+6. Bridges `RAILWAY_MCP_TOKEN` → `RAILWAY_API_TOKEN` and pre-links the portfolio project to `production/fastapi` so Railway MCP tools (`get-logs`, `list-deployments`, etc.) work on first try. Switch envs/services with the `link-environment` / `link-service` MCP tools. **PR environments:** Named `portfolio-pr-<number>` (e.g., `portfolio-pr-248`). List all with `railway environment list --json`.
 
 **Verification**: Check `/tmp/.claude_remote_setup_ran` exists to confirm the hook ran.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ When running in Claude Code's cloud environment (`CLAUDE_CODE_REMOTE=true`), a *
 3. Runs database migrations (`alembic upgrade head`)
 4. Seeds the database
 5. Installs pnpm dependencies and builds React Router app
-6. Bridges `RAILWAY_MCP_TOKEN` → `RAILWAY_API_TOKEN` and pre-links the portfolio project to `production/fastapi` so Railway MCP tools (`get-logs`, `list-deployments`, etc.) work on first try. Switch envs/services with the `link-environment` / `link-service` MCP tools.
+6. Bridges `RAILWAY_MCP_TOKEN` → `RAILWAY_API_TOKEN` and pre-links the portfolio project to `production/fastapi` so Railway MCP tools (`get-logs`, `list-deployments`, etc.) work on first try. Switch envs/services with the `link-environment` / `link-service` MCP tools. **Note:** PR environments are created dynamically with auto-generated names — use the Railway web UI or GitHub PR status links to access PR-specific build logs.
 
 **Verification**: Check `/tmp/.claude_remote_setup_ran` exists to confirm the hook ran.
 
@@ -158,6 +158,9 @@ cd api && uv run alembic revision --autogenerate -m "description"
 
 # Add Shadcn component
 cd apps/web-react-router && pnpm dlx @shadcn/ui@latest add <component>
+
+# Approve build scripts for new packages (pnpm 11+)
+pnpm approve-builds <package-name>  # Updates pnpm-workspace.yaml allowBuilds
 ```
 
 ### Testing Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ When running in Claude Code's cloud environment (`CLAUDE_CODE_REMOTE=true`), a *
 3. Runs database migrations (`alembic upgrade head`)
 4. Seeds the database
 5. Installs pnpm dependencies and builds React Router app
-6. Bridges `RAILWAY_MCP_TOKEN` → `RAILWAY_API_TOKEN` and pre-links the portfolio project to `production/fastapi` so Railway MCP tools (`get-logs`, `list-deployments`, etc.) work on first try. Switch envs/services with the `link-environment` / `link-service` MCP tools. **PR environments:** Named `portfolio-pr-<number>` (e.g., `portfolio-pr-248`). List all with `railway environment list --json`.
+6. Bridges `RAILWAY_MCP_TOKEN` → `RAILWAY_API_TOKEN` and pre-links the portfolio project to `development/fastapi` (not production - safer default). Switch envs/services with the `link-environment` / `link-service` MCP tools. **PR environments:** Named `portfolio-pr-<number>` (e.g., `portfolio-pr-248`). List all with `railway environment list --json`.
 
 **Verification**: Check `/tmp/.claude_remote_setup_ran` exists to confirm the hook ran.
 
@@ -47,6 +47,8 @@ pnpm dev-with-fastapi # Both
 ```
 
 **Expected warnings**: Logfire API unreachable (proxy restrictions) - non-blocking.
+
+**Production Protection**: PreToolUse hooks in `.claude/hooks/` guard Railway and Neon operations. Philosophy: protect production, allow development freely. See [`.claude/hooks/README.md`](.claude/hooks/README.md) for details.
 
 ### Local CLI Development
 
@@ -79,7 +81,8 @@ OpenPhone, Google Workspace, Twilio, Clerk, Railway, ClickUp
 /
 ├── .claude/                   # Claude Code hooks and settings
 │   ├── settings.json          # Permissions, hooks config
-│   └── setup_remote.sh        # Session-start hook script
+│   ├── setup_remote.sh        # Session-start hook script
+│   └── hooks/                 # PreToolUse guards for Railway/Neon
 ├── api/                       # FastAPI Backend
 │   ├── index.py               # Main app entry
 │   └── src/

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -469,22 +469,28 @@ async def _fetch_latest_call(
 async def _fetch_message_by_id(
     client: httpx.AsyncClient, activity_id: str,
 ) -> dict | None:
-    try:
-        resp = await client.get(f"/v1/messages/{activity_id}")
-        resp.raise_for_status()
-    except httpx.HTTPError:
-        return None
+    # Suppress instrumentation: this is a probe call that may return 404/400
+    # when the ID is a call, not a message. Expected failures shouldn't log.
+    with logfire.suppress_instrumentation():
+        try:
+            resp = await client.get(f"/v1/messages/{activity_id}")
+            resp.raise_for_status()
+        except httpx.HTTPError:
+            return None
     return resp.json().get("data")
 
 
 async def _fetch_call_by_id(
     client: httpx.AsyncClient, activity_id: str,
 ) -> dict | None:
-    try:
-        resp = await client.get(f"/v1/calls/{activity_id}")
-        resp.raise_for_status()
-    except httpx.HTTPError:
-        return None
+    # Suppress instrumentation: this is a probe call that may return 404/400
+    # when the ID is a message, not a call. Expected failures shouldn't log.
+    with logfire.suppress_instrumentation():
+        try:
+            resp = await client.get(f"/v1/calls/{activity_id}")
+            resp.raise_for_status()
+        except httpx.HTTPError:
+            return None
     return resp.json().get("data")
 
 
@@ -1087,28 +1093,37 @@ async def get_call_details_impl(
     import asyncio
 
     async def _fetch_call() -> dict | None:
-        try:
-            resp = await client.get(f"/v1/calls/{call_id}")
-            resp.raise_for_status()
-            return resp.json().get("data")
-        except httpx.HTTPError:
-            return None
+        # Suppress instrumentation: may return 404/400 for invalid call IDs
+        # or when the agent passes a message ID by mistake.
+        with logfire.suppress_instrumentation():
+            try:
+                resp = await client.get(f"/v1/calls/{call_id}")
+                resp.raise_for_status()
+                return resp.json().get("data")
+            except httpx.HTTPError:
+                return None
 
     async def _fetch_summary() -> dict | None:
-        try:
-            resp = await client.get(f"/v1/call-summaries/{call_id}")
-            resp.raise_for_status()
-            return resp.json().get("data")
-        except httpx.HTTPError:
-            return None
+        # Suppress instrumentation: summary may not exist yet (Quo generates
+        # it async) — 404/400 is expected for recent or short calls.
+        with logfire.suppress_instrumentation():
+            try:
+                resp = await client.get(f"/v1/call-summaries/{call_id}")
+                resp.raise_for_status()
+                return resp.json().get("data")
+            except httpx.HTTPError:
+                return None
 
     async def _fetch_transcript() -> dict | None:
-        try:
-            resp = await client.get(f"/v1/call-transcripts/{call_id}")
-            resp.raise_for_status()
-            return resp.json().get("data")
-        except httpx.HTTPError:
-            return None
+        # Suppress instrumentation: transcript may not exist yet (Quo generates
+        # it async) — 404/400 is expected for recent or short calls.
+        with logfire.suppress_instrumentation():
+            try:
+                resp = await client.get(f"/v1/call-transcripts/{call_id}")
+                resp.raise_for_status()
+                return resp.json().get("data")
+            except httpx.HTTPError:
+                return None
 
     call, summary, transcript = await asyncio.gather(
         _fetch_call(), _fetch_summary(), _fetch_transcript(),

--- a/apps/web-react-router/Dockerfile
+++ b/apps/web-react-router/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable
 WORKDIR /app
 
 FROM base AS deps
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY apps/web-react-router/package.json ./apps/web-react-router/
 RUN pnpm install --filter web-react-router
 
@@ -19,11 +19,11 @@ RUN pnpm run build
 
 FROM base
 WORKDIR /app
-# Copy root package.json for pnpm config (onlyBuiltDependencies), app package.json for deps
-COPY package.json pnpm-lock.yaml ./
+# Copy root package.json for pnpm config, .npmrc for build settings, app package.json for deps
+COPY package.json pnpm-lock.yaml .npmrc ./
 COPY apps/web-react-router/package.json ./apps/web-react-router/
 WORKDIR /app/apps/web-react-router
-RUN pnpm install --prod
+RUN pnpm install --prod --ignore-scripts
 COPY --from=build /app/apps/web-react-router/build ./build
 COPY apps/web-react-router/server.js ./server.js
 ENV PORT=5173

--- a/apps/web-react-router/Dockerfile
+++ b/apps/web-react-router/Dockerfile
@@ -1,8 +1,8 @@
 # Build context is repo root (not apps/web-react-router)
 # Uses workspace lockfile for single source of truth
 
-FROM node:20-alpine AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+FROM node:22-alpine AS base
+RUN corepack enable
 WORKDIR /app
 
 FROM base AS deps

--- a/apps/web-react-router/Dockerfile
+++ b/apps/web-react-router/Dockerfile
@@ -19,7 +19,10 @@ RUN pnpm run build
 
 FROM base
 WORKDIR /app
-COPY apps/web-react-router/package.json pnpm-lock.yaml ./
+# Copy root package.json for pnpm config (onlyBuiltDependencies), app package.json for deps
+COPY package.json pnpm-lock.yaml ./
+COPY apps/web-react-router/package.json ./apps/web-react-router/
+WORKDIR /app/apps/web-react-router
 RUN pnpm install --prod
 COPY --from=build /app/apps/web-react-router/build ./build
 COPY apps/web-react-router/server.js ./server.js

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio-monorepo",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.1.2",
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "scripts": {
     "reinstall": "rm -rf node_modules && rm -rf pnpm-lock.yaml && rm -rf apps/web-react-router/node_modules && rm -rf apps/my-expo-app/node_modules && pnpm install",
     "dev": "pnpm --filter web-react-router dev",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "portfolio-monorepo",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "reinstall": "rm -rf node_modules && rm -rf pnpm-lock.yaml && rm -rf apps/web-react-router/node_modules && rm -rf apps/my-expo-app/node_modules && pnpm install",
     "dev": "pnpm --filter web-react-router dev",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,7 @@
       "rollup@>=4.0.0 <4.59.0": ">=4.59.0",
       "ajv@>=7.0.0-alpha.0 <8.18.0": ">=8.18.0"
     },
-    "onlyBuiltDependencies": [
-      "@clerk/shared",
-      "esbuild",
-      "msw"
-    ]
+    "onlyBuiltDependencies": ["*"]
   },
   "devDependencies": {
     "@types/node": "^22.19.17",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
       "minimatch@>=9.0.0 <9.0.6": ">=9.0.6",
       "rollup@>=4.0.0 <4.59.0": ">=4.59.0",
       "ajv@>=7.0.0-alpha.0 <8.18.0": ">=8.18.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@clerk/shared",
+      "esbuild",
+      "msw"
+    ]
   },
   "devDependencies": {
     "@types/node": "^22.19.17",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
       "minimatch@>=9.0.0 <9.0.6": ">=9.0.6",
       "rollup@>=4.0.0 <4.59.0": ">=4.59.0",
       "ajv@>=7.0.0-alpha.0 <8.18.0": ">=8.18.0"
-    },
-    "onlyBuiltDependencies": ["*"]
+    }
   },
   "devDependencies": {
     "@types/node": "^22.19.17",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - 'apps/*'
-  - 'packages/*' 
+  - 'packages/*'
+allowBuilds:
+  '@clerk/shared': true
+  esbuild: true
+  msw: true


### PR DESCRIPTION
## Summary

- **Logfire false-positive alerts**: Wrap OpenPhone probe calls in `logfire.suppress_instrumentation()` to prevent expected 400/404 responses from triggering error alerts
- **pnpm 11 upgrade**: Node 22 in Dockerfile, build scripts approved via `pnpm approve-builds` adding `allowBuilds` to pnpm-workspace.yaml
- **Production protection hooks**: PreToolUse hooks for Railway and Neon MCP tools with parameter-based permission control

## Production Protection Philosophy

**Protect production, allow development freely.**

| Tool | Scenario | Decision |
|------|----------|----------|
| Railway `link-environment` | production | ask |
| Railway `link-environment` | dev, PR envs | allow |
| Neon `run_sql` | no branchId (defaults to main) | ask |
| Neon `run_sql` | PR/feature branch | allow |
| Neon `delete_branch`, `delete_project` | any | ask |
| Neon `complete_database_migration` | any | ask |

See [`.claude/hooks/README.md`](.claude/hooks/README.md) for full documentation.

## Changes

- `api/src/sernia_ai/tools/quo_tools.py` - Suppress Logfire instrumentation on probe calls
- `apps/web-react-router/Dockerfile` - Upgrade to Node 22 for pnpm 11
- `pnpm-workspace.yaml` - Add `allowBuilds` for pnpm 11 security
- `.claude/setup_remote.sh` - Default Railway link to development (not production)
- `.claude/hooks/railway-link-guard.sh` - Guard production environment
- `.claude/hooks/neon-guard.sh` - Guard main branch and destructive operations
- `.claude/settings.json` - Register PreToolUse hooks
- `CLAUDE.md` - Document hooks and update Railway environment info

## Test plan

- [x] Verify module imports successfully
- [x] Test hook scripts with sample JSON input
- [x] Railway build passes with pnpm 11
- [ ] Deploy and confirm no more spurious Logfire alerts for OpenPhone probes

## Links

- Railway preview: https://react-router-portfolio-pr-248.up.railway.app/

https://claude.ai/code/session_01FNLfaKNvKNhip8NTg5RhPF