### PR TITLE
fix(dockerfile): copy pnpm-workspace.yaml for allowBuilds config

### DIFF
--- a/apps/web-react-router/Dockerfile
+++ b/apps/web-react-router/Dockerfile
@@ -13,6 +13,7 @@ RUN pnpm install --filter web-react-router
 FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web-react-router/node_modules ./apps/web-react-router/node_modules
+COPY pnpm-workspace.yaml package.json ./
 COPY apps/web-react-router ./apps/web-react-router
 WORKDIR /app/apps/web-react-router
 RUN pnpm run build
@@ -20,7 +21,8 @@ RUN pnpm run build
 FROM base
 WORKDIR /app
 # Copy root package.json for pnpm config, .npmrc for build settings, app package.json for deps
-COPY package.json pnpm-lock.yaml .npmrc ./
+# pnpm-workspace.yaml needed for allowBuilds config
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY apps/web-react-router/package.json ./apps/web-react-router/
 WORKDIR /app/apps/web-react-router
 RUN pnpm install --prod --ignore-scripts


### PR DESCRIPTION
## Summary

Fixes production build failure after PR #248 merge.

The build and final Docker stages need access to `pnpm-workspace.yaml` to read the `allowBuilds` configuration for pnpm 11's build script approval.

**Error:**
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @clerk/shared@3.47.5, esbuild@0.27.7, msw@2.14.6
```

**Root cause:** The `deps` stage copies `pnpm-workspace.yaml`, but the `build` and final stages did not. When React Router's build triggers internal pnpm operations, it couldn't find the `allowBuilds` config.

## Changes

- Copy `pnpm-workspace.yaml` to build stage (for `pnpm run build`)
- Copy `pnpm-workspace.yaml` to final stage (for `pnpm install --prod`)

## Test plan

- [ ] Production build succeeds after merge

https://claude.ai/code/session_01FNLfaKNvKNhip8NTg5RhPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNLfaKNvKNhip8NTg5RhPF)_