### PR TITLE
fix(dockerfile): copy pnpm-workspace.yaml for allowBuilds config

### DIFF
--- a/apps/web-react-router/Dockerfile
+++ b/apps/web-react-router/Dockerfile
@@ -13,6 +13,7 @@ RUN pnpm install --filter web-react-router
 FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web-react-router/node_modules ./apps/web-react-router/node_modules
+COPY pnpm-workspace.yaml package.json ./
 COPY apps/web-react-router ./apps/web-react-router
 WORKDIR /app/apps/web-react-router
 RUN pnpm run build
@@ -20,7 +21,8 @@ RUN pnpm run build
 FROM base
 WORKDIR /app
 # Copy root package.json for pnpm config, .npmrc for build settings, app package.json for deps
-COPY package.json pnpm-lock.yaml .npmrc ./
+# pnpm-workspace.yaml needed for allowBuilds config
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY apps/web-react-router/package.json ./apps/web-react-router/
 WORKDIR /app/apps/web-react-router
 RUN pnpm install --prod --ignore-scripts


### PR DESCRIPTION
## Summary

Fixes production build failure after PR #248 merge.

**Why PR #248 worked but production failed:** The PR environment had cached Docker layers from before pnpm 11, so it didn't trigger a fresh install that would evaluate the `allowBuilds` check. Production had no cache after merge, forcing a fresh install.

**Error:**
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @clerk/shared@3.47.5, esbuild@0.27.7, msw@2.14.6
```

**Root cause:** The `deps` stage copies `pnpm-workspace.yaml`, but the `build` and final stages did not. When pnpm operations run in those stages, they couldn't find the `allowBuilds` config.

## Changes

- Copy `pnpm-workspace.yaml` to build stage (for `pnpm run build`)
- Copy `pnpm-workspace.yaml` to final stage (for `pnpm install --prod`)

## Test plan

- [ ] PR environment build succeeds (react-router service)
- [ ] Production build succeeds after merge

Railway preview: https://react-router-portfolio-pr-250.up.railway.app/

https://claude.ai/code/session_01FNLfaKNvKNhip8NTg5RhPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNLfaKNvKNhip8NTg5RhPF)_