### PR TITLE
Throttle OpenPhone API calls to stop 429 alert noise

### DIFF
--- a/api/src/open_phone/rate_limit.py
+++ b/api/src/open_phone/rate_limit.py
@@ -1,0 +1,146 @@
+"""Shared rate limiting + 429 retry for OpenPhone (Quo) API calls.
+
+OpenPhone enforces a per-API-key rate limit (documented at ~10 requests/sec).
+The Sernia AI agent fires bursts of parallel reads — e.g. ``list_active_sms_threads``
+refreshes the paginated contact cache and then fans out ``/v1/messages`` +
+``/v1/calls`` for every active conversation via ``asyncio.gather`` — which
+periodically blew past that limit and came back ``429 Too Many Requests``.
+
+Those 429s were non-fatal (callers swallow ``httpx.HTTPError`` and degrade
+gracefully, e.g. dropping a thread snippet) but they:
+  1. Logged at error level, tripping the "Error-level records (non-local)"
+     Logfire alert (pure noise — the agent run still succeeded), and
+  2. Silently dropped data (missing snippets / thread history).
+
+The fix is to throttle *before* requests leave the process so we stay under
+the limit, plus a bounded ``Retry-After``-aware retry as a safety net for the
+rare residual 429. A single process-wide token bucket is shared across every
+OpenPhone client (the central service client, the agent's Quo client, and the
+FastMCP-bridged tools that reuse it) so concurrent agent runs can't collectively
+exceed the limit.
+
+Wire it up by passing ``transport=build_rate_limited_transport()`` when
+constructing the ``httpx.AsyncClient`` — see ``service._openphone_client`` and
+``quo_tools._build_quo_client``.
+"""
+
+import asyncio
+import time
+
+import httpx
+import logfire
+
+# OpenPhone documents 10 req/s per API key. Stay safely under it to leave
+# headroom for clock skew, retries, and any traffic we don't route through
+# the bucket (e.g. one-off sends).
+MAX_REQUESTS_PER_SECOND = 8.0
+
+# Safety-net retries for the rare 429 that slips past the throttle. Kept small:
+# the token bucket is the real fix, retries just paper over jitter.
+MAX_RETRIES = 3
+
+# Fallback backoff (seconds) when the 429 response carries no ``Retry-After``
+# header. Exponential: 0.5, 1.0, 2.0, ... capped at MAX_BACKOFF.
+BASE_BACKOFF = 0.5
+MAX_BACKOFF = 8.0
+
+
+class _TokenBucket:
+    """Async token bucket — smooths bursts to a sustained ``rate`` per second.
+
+    ``capacity`` tokens accumulate while idle, allowing a short burst, then
+    requests are paced at ``rate`` per second. Process-wide and asyncio-safe.
+    """
+
+    def __init__(self, rate: float, capacity: float) -> None:
+        self._rate = rate
+        self._capacity = capacity
+        self._tokens = capacity
+        self._updated = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """Block until a token is available, then consume it."""
+        while True:
+            async with self._lock:
+                now = time.monotonic()
+                # Refill based on elapsed time since last update.
+                self._tokens = min(
+                    self._capacity,
+                    self._tokens + (now - self._updated) * self._rate,
+                )
+                self._updated = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                wait = (1.0 - self._tokens) / self._rate
+            # Sleep outside the lock so other tasks can refill/recheck.
+            await asyncio.sleep(wait)
+
+
+# Process-wide bucket shared by every OpenPhone client.
+_bucket = _TokenBucket(MAX_REQUESTS_PER_SECOND, MAX_REQUESTS_PER_SECOND)
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header value (delta-seconds) into seconds.
+
+    OpenPhone returns delta-seconds; HTTP-date form is not handled (treated as
+    absent so we fall back to exponential backoff).
+    """
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value.strip()))
+    except ValueError:
+        return None
+
+
+class RateLimitedTransport(httpx.AsyncBaseTransport):
+    """httpx transport that paces requests through the shared token bucket and
+    retries ``429`` responses with ``Retry-After``-aware backoff.
+
+    Wraps a real ``AsyncHTTPTransport`` for connection pooling. Each request
+    acquires a token before being sent, keeping aggregate throughput under the
+    OpenPhone limit regardless of how many tasks fan out concurrently.
+    """
+
+    def __init__(self, inner: httpx.AsyncBaseTransport | None = None) -> None:
+        self._inner = inner if inner is not None else httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        response: httpx.Response | None = None
+        for attempt in range(MAX_RETRIES + 1):
+            await _bucket.acquire()
+            response = await self._inner.handle_async_request(request)
+            if response.status_code != 429 or attempt == MAX_RETRIES:
+                return response
+
+            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+            delay = (
+                retry_after
+                if retry_after is not None
+                else min(BASE_BACKOFF * (2 ** attempt), MAX_BACKOFF)
+            )
+            # Discard the throttled response body before retrying.
+            await response.aclose()
+            logfire.debug(
+                "openphone 429 — retrying after {delay}s",
+                delay=delay,
+                attempt=attempt + 1,
+                max_retries=MAX_RETRIES,
+                url=str(request.url),
+            )
+            await asyncio.sleep(delay)
+
+        # Unreachable in practice (loop always returns), but satisfies typing.
+        assert response is not None
+        return response
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def build_rate_limited_transport() -> RateLimitedTransport:
+    """Construct a transport that throttles + retries OpenPhone requests."""
+    return RateLimitedTransport()

--- a/api/src/open_phone/service.py
+++ b/api/src/open_phone/service.py
@@ -24,12 +24,19 @@ _cache_ts: float = 0.0
 
 
 def _openphone_client() -> httpx.AsyncClient:
-    """Create a configured AsyncClient for the OpenPhone API."""
+    """Create a configured AsyncClient for the OpenPhone API.
+
+    Uses a shared rate-limited transport so bursts of parallel reads stay under
+    OpenPhone's per-key rate limit (see ``rate_limit.py``).
+    """
+    from api.src.open_phone.rate_limit import build_rate_limited_transport
+
     api_key = os.getenv("OPEN_PHONE_API_KEY", "")
     return httpx.AsyncClient(
         base_url="https://api.openphone.com",
         headers={"Authorization": api_key},
         timeout=15,
+        transport=build_rate_limited_transport(),
     )
 
 

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -1397,6 +1397,11 @@ async def _get_contact_by_id(client: httpx.AsyncClient, contact_id: str) -> dict
 # ---------------------------------------------------------------------------
 
 def _build_quo_client() -> httpx.AsyncClient:
+    # Shared rate-limited transport keeps the agent's bursty parallel reads
+    # (contact cache + per-conversation message/call fan-out) under OpenPhone's
+    # per-key rate limit. This client also backs the FastMCP-bridged tools.
+    from api.src.open_phone.rate_limit import build_rate_limited_transport
+
     api_key = os.environ.get("OPEN_PHONE_API_KEY", "")
     if not api_key:
         logfire.warn("OPEN_PHONE_API_KEY not set — Quo tools will fail at runtime")
@@ -1404,6 +1409,7 @@ def _build_quo_client() -> httpx.AsyncClient:
         base_url="https://api.openphone.com",
         headers={"Authorization": api_key},
         timeout=30,
+        transport=build_rate_limited_transport(),
     )
 
 

--- a/api/src/tests/test_openphone_rate_limit.py
+++ b/api/src/tests/test_openphone_rate_limit.py
@@ -1,0 +1,123 @@
+"""Unit tests for the OpenPhone rate-limiting + 429-retry transport.
+
+These guard the denoising fix: bursts of OpenPhone reads must stay under the
+per-key rate limit, and the rare residual 429 must be retried (Retry-After
+aware) instead of bubbling up as an error-level log that pages the team.
+"""
+import asyncio
+import time
+
+import httpx
+import pytest
+
+from api.src.open_phone.rate_limit import (
+    MAX_RETRIES,
+    RateLimitedTransport,
+    _parse_retry_after,
+    _TokenBucket,
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("0", 0.0),
+        ("2", 2.0),
+        ("  3.5 ", 3.5),
+        ("-1", 0.0),  # clamped to 0
+        (None, None),
+        ("", None),
+        ("Wed, 21 Oct 2015 07:28:00 GMT", None),  # HTTP-date not handled
+    ],
+)
+def test_parse_retry_after(value, expected):
+    assert _parse_retry_after(value) == expected
+
+
+@pytest.mark.asyncio
+async def test_transport_retries_429_then_succeeds():
+    """A 429 followed by a 200 should transparently return the 200."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Retry-After: 0 keeps the test fast.
+            return httpx.Response(429, headers={"Retry-After": "0"})
+        return httpx.Response(200, json={"ok": True})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 200
+    assert calls["n"] == 2  # one failure + one success
+
+
+@pytest.mark.asyncio
+async def test_transport_gives_up_after_max_retries():
+    """Persistent 429s exhaust the retry budget and return the final 429."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(429, headers={"Retry-After": "0"})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 429
+    # Initial attempt + MAX_RETRIES retries.
+    assert calls["n"] == MAX_RETRIES + 1
+
+
+@pytest.mark.asyncio
+async def test_transport_passes_through_non_429():
+    """Non-429 responses are returned on the first attempt, no retry."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(404)
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/calls/bogus")
+
+    assert resp.status_code == 404
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_throttles_burst():
+    """With capacity exhausted, the next acquire waits ~1/rate seconds."""
+    # rate=20/s, capacity=2: first two acquires are instant (burst), the third
+    # must wait for a token to refill (~0.05s).
+    bucket = _TokenBucket(rate=20.0, capacity=2.0)
+    await bucket.acquire()
+    await bucket.acquire()
+
+    start = time.monotonic()
+    await bucket.acquire()
+    elapsed = time.monotonic() - start
+
+    # Allow generous slack for scheduler jitter, but it must have waited.
+    assert elapsed >= 0.03
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_allows_initial_burst():
+    """Up to `capacity` acquires complete without throttling."""
+    bucket = _TokenBucket(rate=1.0, capacity=5.0)
+    start = time.monotonic()
+    await asyncio.gather(*(bucket.acquire() for _ in range(5)))
+    elapsed = time.monotonic() - start
+    # Five tokens were pre-loaded; none should have blocked.
+    assert elapsed < 0.05

--- a/apps/sernia_mcp/src/sernia_mcp/clients/quo.py
+++ b/apps/sernia_mcp/src/sernia_mcp/clients/quo.py
@@ -20,8 +20,12 @@ _cache_ts: float = 0.0
 def build_quo_client() -> httpx.AsyncClient:
     """Return a fresh AsyncClient for the OpenPhone API.
 
-    Use inside ``async with`` so connections close cleanly.
+    Use inside ``async with`` so connections close cleanly. The rate-limited
+    transport keeps bursty parallel reads under OpenPhone's per-key rate limit
+    (see ``rate_limit.py``).
     """
+    from sernia_mcp.clients.rate_limit import build_rate_limited_transport
+
     api_key = os.environ.get("QUO_API_KEY", "")
     if not api_key:
         logfire.warn("QUO_API_KEY not set — Quo tool calls will fail")
@@ -29,6 +33,7 @@ def build_quo_client() -> httpx.AsyncClient:
         base_url="https://api.openphone.com",
         headers={"Authorization": api_key},
         timeout=30,
+        transport=build_rate_limited_transport(),
     )
 
 

--- a/apps/sernia_mcp/src/sernia_mcp/clients/rate_limit.py
+++ b/apps/sernia_mcp/src/sernia_mcp/clients/rate_limit.py
@@ -1,0 +1,116 @@
+"""Shared rate limiting + 429 retry for OpenPhone (Quo) API calls.
+
+VENDORED from ``api/src/open_phone/rate_limit.py`` (keep in sync — see the
+vendored-client policy in ``apps/sernia_mcp/CLAUDE.md``).
+
+OpenPhone enforces a per-API-key rate limit (~10 requests/sec). Bursts of
+parallel reads (contact-cache pagination + per-conversation message/call
+fan-out) periodically exceeded it and came back ``429 Too Many Requests``.
+Those 429s were non-fatal but logged at error level (alert noise) and silently
+dropped data. The fix throttles requests *before* they leave the process so we
+stay under the limit, with a bounded ``Retry-After``-aware retry as a safety
+net. A single process-wide token bucket is shared across every OpenPhone client.
+
+Wire it up via ``transport=build_rate_limited_transport()`` in
+``clients/quo.build_quo_client``.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import logfire
+
+# OpenPhone documents 10 req/s per API key. Stay safely under it.
+MAX_REQUESTS_PER_SECOND = 8.0
+
+# Safety-net retries for the rare 429 that slips past the throttle.
+MAX_RETRIES = 3
+
+# Fallback backoff (seconds) when the 429 carries no ``Retry-After`` header.
+BASE_BACKOFF = 0.5
+MAX_BACKOFF = 8.0
+
+
+class _TokenBucket:
+    """Async token bucket — smooths bursts to a sustained ``rate`` per second."""
+
+    def __init__(self, rate: float, capacity: float) -> None:
+        self._rate = rate
+        self._capacity = capacity
+        self._tokens = capacity
+        self._updated = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """Block until a token is available, then consume it."""
+        while True:
+            async with self._lock:
+                now = time.monotonic()
+                self._tokens = min(
+                    self._capacity,
+                    self._tokens + (now - self._updated) * self._rate,
+                )
+                self._updated = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                wait = (1.0 - self._tokens) / self._rate
+            await asyncio.sleep(wait)
+
+
+_bucket = _TokenBucket(MAX_REQUESTS_PER_SECOND, MAX_REQUESTS_PER_SECOND)
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header (delta-seconds) into seconds, else None."""
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value.strip()))
+    except ValueError:
+        return None
+
+
+class RateLimitedTransport(httpx.AsyncBaseTransport):
+    """httpx transport that paces requests through the shared token bucket and
+    retries ``429`` responses with ``Retry-After``-aware backoff."""
+
+    def __init__(self, inner: httpx.AsyncBaseTransport | None = None) -> None:
+        self._inner = inner if inner is not None else httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        response: httpx.Response | None = None
+        for attempt in range(MAX_RETRIES + 1):
+            await _bucket.acquire()
+            response = await self._inner.handle_async_request(request)
+            if response.status_code != 429 or attempt == MAX_RETRIES:
+                return response
+
+            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+            delay = (
+                retry_after
+                if retry_after is not None
+                else min(BASE_BACKOFF * (2 ** attempt), MAX_BACKOFF)
+            )
+            await response.aclose()
+            logfire.debug(
+                "openphone 429 — retrying after {delay}s",
+                delay=delay,
+                attempt=attempt + 1,
+                max_retries=MAX_RETRIES,
+                url=str(request.url),
+            )
+            await asyncio.sleep(delay)
+
+        assert response is not None
+        return response
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def build_rate_limited_transport() -> RateLimitedTransport:
+    """Construct a transport that throttles + retries OpenPhone requests."""
+    return RateLimitedTransport()

--- a/apps/sernia_mcp/tests/test_quo_rate_limit.py
+++ b/apps/sernia_mcp/tests/test_quo_rate_limit.py
@@ -1,0 +1,109 @@
+"""Unit tests for the vendored OpenPhone rate-limiting + 429-retry transport.
+
+Mirrors ``api/src/tests/test_openphone_rate_limit.py`` for the self-contained
+MCP service. Guards that bursts stay under the per-key rate limit and that the
+rare residual 429 is retried instead of bubbling up as error-level noise.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import pytest
+
+from sernia_mcp.clients.rate_limit import (
+    MAX_RETRIES,
+    RateLimitedTransport,
+    _parse_retry_after,
+    _TokenBucket,
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("0", 0.0),
+        ("2", 2.0),
+        ("  3.5 ", 3.5),
+        ("-1", 0.0),
+        (None, None),
+        ("", None),
+        ("Wed, 21 Oct 2015 07:28:00 GMT", None),
+    ],
+)
+def test_parse_retry_after(value, expected):
+    assert _parse_retry_after(value) == expected
+
+
+async def test_transport_retries_429_then_succeeds():
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+        return httpx.Response(200, json={"ok": True})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 200
+    assert calls["n"] == 2
+
+
+async def test_transport_gives_up_after_max_retries():
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(429, headers={"Retry-After": "0"})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 429
+    assert calls["n"] == MAX_RETRIES + 1
+
+
+async def test_transport_passes_through_non_429():
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(404)
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/calls/bogus")
+
+    assert resp.status_code == 404
+    assert calls["n"] == 1
+
+
+async def test_token_bucket_throttles_burst():
+    bucket = _TokenBucket(rate=20.0, capacity=2.0)
+    await bucket.acquire()
+    await bucket.acquire()
+
+    start = time.monotonic()
+    await bucket.acquire()
+    elapsed = time.monotonic() - start
+
+    assert elapsed >= 0.03
+
+
+async def test_token_bucket_allows_initial_burst():
+    bucket = _TokenBucket(rate=1.0, capacity=5.0)
+    start = time.monotonic()
+    await asyncio.gather(*(bucket.acquire() for _ in range(5)))
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05


### PR DESCRIPTION
## What & why

Investigated two Logfire traces that were paging via the **"Error-level records (non-local)"** alert:

- `019e73d206353eda9ceb7aaac34888ce` (web chat, 2026-05-29)
- `019e5f3892e323a7a630a443276196e4` (scheduled check, 2026-05-25)

**Same root cause in both.** Each is a *successful* Sernia `agent run`, but buried inside are OpenPhone HTTP `GET` spans logged at **level 17 (ERROR)** because they came back **HTTP 429 (Too Many Requests)**:

```
GET api.openphone.com/v1/messages …participants=+15187950065  → 429  ERROR
GET api.openphone.com/v1/calls    …participants=+15187950065  → 429  ERROR
…
```

`list_active_sms_threads` / `get_thread_messages` refresh the paginated contact cache and then fan out `/v1/messages` + `/v1/calls` for every active conversation at once via `asyncio.gather`. That burst blows past OpenPhone's ~10 req/s per-key limit. The calls are caught (`except httpx.HTTPError: return None`) so the agent run survives — but:

1. Each 429 logs at error level → trips the alert even though nothing failed (**pure noise**), and
2. The affected thread silently loses its snippet / history (**minor real data loss**).

There was **no concurrency limiting and no 429 retry** anywhere in the OpenPhone client path.

## Fix

A process-wide **token-bucket rate limiter (8 req/s) + `Retry-After`-aware bounded retry**, implemented as a custom `httpx` transport and shared across every OpenPhone client:

- `api/src/open_phone/rate_limit.py` (new) — wired into `_openphone_client()` (`service.py`) and `_build_quo_client()` (`quo_tools.py`, which also backs the FastMCP-bridged tools).
- `apps/sernia_mcp/src/sernia_mcp/clients/rate_limit.py` (new, **vendored** per the sernia_mcp vendored-client policy) — wired into `build_quo_client()`.

Throttling keeps bursts under the limit so the 429s — and the alert noise — go away; the bounded retry recovers any residual rate-limit hit. This addresses the underlying issue (unthrottled bursts + dropped data), not just the symptom.

## Tests

- `api/src/tests/test_openphone_rate_limit.py` and `apps/sernia_mcp/tests/test_quo_rate_limit.py` — 12 tests each (retry-then-succeed, give-up-after-max-retries, non-429 pass-through, `Retry-After` parsing, token-bucket throttle/burst). All pass.
- Pre-existing failures in the OpenPhone/sernia_mcp suites are unrelated (missing `api/src/tests/requests/` fixtures, a live `requests`-based network test hitting the real API, git_sync subprocess tests, live email tests).

## Preview

https://react-router-portfolio-pr-252.up.railway.app/

---

Note: the alert query itself is left unchanged — once throttling lands, genuine OpenPhone errors (sustained 429s, 5xx) will still page as intended, instead of transient self-healing bursts.

https://claude.ai/code/session_01C5RsK2y8X9f7rQjTy6CPb3