### PR TITLE
Denoise OpenPhone 429s: tighter throttle + final-status span level

### DIFF
--- a/api/src/open_phone/rate_limit.py
+++ b/api/src/open_phone/rate_limit.py
@@ -12,12 +12,26 @@ gracefully, e.g. dropping a thread snippet) but they:
      Logfire alert (pure noise — the agent run still succeeded), and
   2. Silently dropped data (missing snippets / thread history).
 
-The fix is to throttle *before* requests leave the process so we stay under
-the limit, plus a bounded ``Retry-After``-aware retry as a safety net for the
-rare residual 429. A single process-wide token bucket is shared across every
-OpenPhone client (the central service client, the agent's Quo client, and the
-FastMCP-bridged tools that reuse it) so concurrent agent runs can't collectively
-exceed the limit.
+The fix has two parts:
+
+  * **Throttle before requests leave the process.** A single process-wide token
+    bucket paces all OpenPhone traffic to stay under the limit. The bucket is
+    deliberately *low-burst* (small ``capacity``) so a fan-out of N parallel
+    requests can't all fire in the same instant and trip the limit — the
+    earlier version allowed an 8-request burst and still drew 429s.
+
+  * **One span per logical request, level set from the FINAL status.** httpx's
+    auto-instrumentation emits a span per transport attempt and flags any 4xx
+    at error level — so a 429 that we *successfully retried* still left an
+    error-level span behind and paged us. Instead, each inner attempt runs
+    under ``logfire.suppress_instrumentation()`` (no per-attempt span) and the
+    transport emits a single span whose level reflects the final outcome: a
+    recovered 429 → final 200 → info (no alert); a genuine 4xx/5xx (or a 429
+    that exhausts retries) → error, so real problems still page.
+
+A single process-wide bucket is shared across every OpenPhone client (the
+central service client, the agent's Quo client, and the FastMCP-bridged tools
+that reuse it) so concurrent agent runs can't collectively exceed the limit.
 
 Wire it up by passing ``transport=build_rate_limited_transport()`` when
 constructing the ``httpx.AsyncClient`` — see ``service._openphone_client`` and
@@ -30,13 +44,17 @@ import time
 import httpx
 import logfire
 
-# OpenPhone documents 10 req/s per API key. Stay safely under it to leave
-# headroom for clock skew, retries, and any traffic we don't route through
-# the bucket (e.g. one-off sends).
-MAX_REQUESTS_PER_SECOND = 8.0
+# OpenPhone documents 10 req/s per API key. Sustained pace, kept under the
+# limit with headroom for clock skew and traffic we don't route through the
+# bucket (e.g. one-off sends).
+MAX_REQUESTS_PER_SECOND = 6.0
 
-# Safety-net retries for the rare 429 that slips past the throttle. Kept small:
-# the token bucket is the real fix, retries just paper over jitter.
+# Max instantaneous burst. Small on purpose: with rate=6 and capacity=3 the
+# worst case in any one-second window is ~9 requests, safely under 10. A larger
+# capacity is what let the previous version trip the limit on fan-out.
+BURST_CAPACITY = 3.0
+
+# Safety-net retries for the rare 429 that slips past the throttle.
 MAX_RETRIES = 3
 
 # Fallback backoff (seconds) when the 429 response carries no ``Retry-After``
@@ -79,7 +97,7 @@ class _TokenBucket:
 
 
 # Process-wide bucket shared by every OpenPhone client.
-_bucket = _TokenBucket(MAX_REQUESTS_PER_SECOND, MAX_REQUESTS_PER_SECOND)
+_bucket = _TokenBucket(MAX_REQUESTS_PER_SECOND, BURST_CAPACITY)
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -96,45 +114,71 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
 
 
+def _level_for_status(status_code: int) -> str | None:
+    """Logfire level for a request's *final* status, or None for the default.
+
+    Mirrors httpx auto-instrumentation (4xx/5xx → error) but applies only to
+    the final outcome — so a 429 retried into a 2xx lands at the default
+    (info) level and doesn't trip the error-level alert, while genuine errors
+    (including a 429 that exhausts retries) still surface at error level.
+    """
+    if status_code >= 400:
+        return "error"
+    return None
+
+
 class RateLimitedTransport(httpx.AsyncBaseTransport):
     """httpx transport that paces requests through the shared token bucket and
     retries ``429`` responses with ``Retry-After``-aware backoff.
 
     Wraps a real ``AsyncHTTPTransport`` for connection pooling. Each request
     acquires a token before being sent, keeping aggregate throughput under the
-    OpenPhone limit regardless of how many tasks fan out concurrently.
+    OpenPhone limit regardless of how many tasks fan out concurrently. Per-
+    attempt httpx instrumentation is suppressed; the transport emits one span
+    per logical request whose level reflects the final status (see module doc).
     """
 
     def __init__(self, inner: httpx.AsyncBaseTransport | None = None) -> None:
         self._inner = inner if inner is not None else httpx.AsyncHTTPTransport()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        method = request.method
+        url = str(request.url)
         response: httpx.Response | None = None
-        for attempt in range(MAX_RETRIES + 1):
-            await _bucket.acquire()
-            response = await self._inner.handle_async_request(request)
-            if response.status_code != 429 or attempt == MAX_RETRIES:
-                return response
+        attempts = 0
 
-            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-            delay = (
-                retry_after
-                if retry_after is not None
-                else min(BASE_BACKOFF * (2 ** attempt), MAX_BACKOFF)
-            )
-            # Discard the throttled response body before retrying.
-            await response.aclose()
-            logfire.debug(
-                "openphone 429 — retrying after {delay}s",
-                delay=delay,
-                attempt=attempt + 1,
-                max_retries=MAX_RETRIES,
-                url=str(request.url),
-            )
-            await asyncio.sleep(delay)
+        with logfire.span("{method} {url}", method=method, url=url, _span_name=method) as span:
+            for attempt in range(MAX_RETRIES + 1):
+                attempts += 1
+                await _bucket.acquire()
+                # Suppress per-attempt auto-instrumentation: a retried 429 would
+                # otherwise leave an error-level span behind and page us. We
+                # record one span (this context) for the logical request below.
+                with logfire.suppress_instrumentation():
+                    response = await self._inner.handle_async_request(request)
+                if response.status_code != 429 or attempt == MAX_RETRIES:
+                    break
 
-        # Unreachable in practice (loop always returns), but satisfies typing.
-        assert response is not None
+                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                delay = (
+                    retry_after
+                    if retry_after is not None
+                    else min(BASE_BACKOFF * (2 ** attempt), MAX_BACKOFF)
+                )
+                # Discard the throttled response body before retrying.
+                await response.aclose()
+                await asyncio.sleep(delay)
+
+            assert response is not None
+            span.set_attribute("http.method", method)
+            span.set_attribute("http.url", url)
+            span.set_attribute("http.status_code", response.status_code)
+            if attempts > 1:
+                span.set_attribute("openphone.attempts", attempts)
+            level = _level_for_status(response.status_code)
+            if level is not None:
+                span.set_level(level)
+
         return response
 
     async def aclose(self) -> None:

--- a/api/src/tests/test_openphone_rate_limit.py
+++ b/api/src/tests/test_openphone_rate_limit.py
@@ -13,9 +13,27 @@ import pytest
 from api.src.open_phone.rate_limit import (
     MAX_RETRIES,
     RateLimitedTransport,
+    _level_for_status,
     _parse_retry_after,
     _TokenBucket,
 )
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        (200, None),
+        (202, None),
+        (404, "error"),
+        (429, "error"),  # only seen here when retries are exhausted
+        (500, "error"),
+        (503, "error"),
+    ],
+)
+def test_level_for_status(status, expected):
+    # A recovered 429 reaches this helper as its final 2xx status, so it maps
+    # to None (default/info) — no error-level span, no alert.
+    assert _level_for_status(status) == expected
 
 
 @pytest.mark.parametrize(

--- a/apps/sernia_mcp/src/sernia_mcp/clients/rate_limit.py
+++ b/apps/sernia_mcp/src/sernia_mcp/clients/rate_limit.py
@@ -4,12 +4,19 @@ VENDORED from ``api/src/open_phone/rate_limit.py`` (keep in sync — see the
 vendored-client policy in ``apps/sernia_mcp/CLAUDE.md``).
 
 OpenPhone enforces a per-API-key rate limit (~10 requests/sec). Bursts of
-parallel reads (contact-cache pagination + per-conversation message/call
-fan-out) periodically exceeded it and came back ``429 Too Many Requests``.
-Those 429s were non-fatal but logged at error level (alert noise) and silently
-dropped data. The fix throttles requests *before* they leave the process so we
-stay under the limit, with a bounded ``Retry-After``-aware retry as a safety
-net. A single process-wide token bucket is shared across every OpenPhone client.
+parallel reads periodically exceeded it and came back ``429 Too Many Requests``
+— non-fatal but logged at error level (alert noise) and silently dropping data.
+
+The fix has two parts:
+
+  * **Throttle before requests leave the process** via a single process-wide,
+    *low-burst* token bucket, so a fan-out of parallel requests can't fire all
+    at once and trip the limit.
+  * **One span per logical request, level set from the FINAL status.** Each
+    inner attempt runs under ``logfire.suppress_instrumentation()`` (so a
+    retried 429 leaves no error-level span), and the transport emits a single
+    span whose level reflects the final outcome — recovered 429 → info (no
+    alert); genuine 4xx/5xx (or a 429 that exhausts retries) → error.
 
 Wire it up via ``transport=build_rate_limited_transport()`` in
 ``clients/quo.build_quo_client``.
@@ -22,8 +29,12 @@ import time
 import httpx
 import logfire
 
-# OpenPhone documents 10 req/s per API key. Stay safely under it.
-MAX_REQUESTS_PER_SECOND = 8.0
+# OpenPhone documents 10 req/s per API key. Sustained pace, under the limit.
+MAX_REQUESTS_PER_SECOND = 6.0
+
+# Max instantaneous burst. Small on purpose: rate=6 + capacity=3 → worst case
+# ~9 requests in any one-second window, safely under 10.
+BURST_CAPACITY = 3.0
 
 # Safety-net retries for the rare 429 that slips past the throttle.
 MAX_RETRIES = 3
@@ -60,7 +71,7 @@ class _TokenBucket:
             await asyncio.sleep(wait)
 
 
-_bucket = _TokenBucket(MAX_REQUESTS_PER_SECOND, MAX_REQUESTS_PER_SECOND)
+_bucket = _TokenBucket(MAX_REQUESTS_PER_SECOND, BURST_CAPACITY)
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -73,38 +84,60 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
 
 
+def _level_for_status(status_code: int) -> str | None:
+    """Logfire level for a request's *final* status, or None for default.
+
+    A 429 retried into a 2xx lands at the default (info) level (no alert);
+    genuine errors (incl. a 429 that exhausts retries) surface at error level.
+    """
+    if status_code >= 400:
+        return "error"
+    return None
+
+
 class RateLimitedTransport(httpx.AsyncBaseTransport):
     """httpx transport that paces requests through the shared token bucket and
-    retries ``429`` responses with ``Retry-After``-aware backoff."""
+    retries ``429`` responses with ``Retry-After``-aware backoff. Per-attempt
+    instrumentation is suppressed; one span per request is emitted with a level
+    driven by the final status (see module doc)."""
 
     def __init__(self, inner: httpx.AsyncBaseTransport | None = None) -> None:
         self._inner = inner if inner is not None else httpx.AsyncHTTPTransport()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        method = request.method
+        url = str(request.url)
         response: httpx.Response | None = None
-        for attempt in range(MAX_RETRIES + 1):
-            await _bucket.acquire()
-            response = await self._inner.handle_async_request(request)
-            if response.status_code != 429 or attempt == MAX_RETRIES:
-                return response
+        attempts = 0
 
-            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-            delay = (
-                retry_after
-                if retry_after is not None
-                else min(BASE_BACKOFF * (2 ** attempt), MAX_BACKOFF)
-            )
-            await response.aclose()
-            logfire.debug(
-                "openphone 429 — retrying after {delay}s",
-                delay=delay,
-                attempt=attempt + 1,
-                max_retries=MAX_RETRIES,
-                url=str(request.url),
-            )
-            await asyncio.sleep(delay)
+        with logfire.span("{method} {url}", method=method, url=url, _span_name=method) as span:
+            for attempt in range(MAX_RETRIES + 1):
+                attempts += 1
+                await _bucket.acquire()
+                with logfire.suppress_instrumentation():
+                    response = await self._inner.handle_async_request(request)
+                if response.status_code != 429 or attempt == MAX_RETRIES:
+                    break
 
-        assert response is not None
+                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                delay = (
+                    retry_after
+                    if retry_after is not None
+                    else min(BASE_BACKOFF * (2 ** attempt), MAX_BACKOFF)
+                )
+                await response.aclose()
+                await asyncio.sleep(delay)
+
+            assert response is not None
+            span.set_attribute("http.method", method)
+            span.set_attribute("http.url", url)
+            span.set_attribute("http.status_code", response.status_code)
+            if attempts > 1:
+                span.set_attribute("openphone.attempts", attempts)
+            level = _level_for_status(response.status_code)
+            if level is not None:
+                span.set_level(level)
+
         return response
 
     async def aclose(self) -> None:

--- a/apps/sernia_mcp/tests/test_quo_rate_limit.py
+++ b/apps/sernia_mcp/tests/test_quo_rate_limit.py
@@ -10,14 +10,33 @@ import asyncio
 import time
 
 import httpx
+import logfire
 import pytest
+from logfire.testing import TestExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 from sernia_mcp.clients.rate_limit import (
     MAX_RETRIES,
     RateLimitedTransport,
+    _level_for_status,
     _parse_retry_after,
     _TokenBucket,
 )
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        (200, None),
+        (202, None),
+        (404, "error"),
+        (429, "error"),
+        (500, "error"),
+        (503, "error"),
+    ],
+)
+def test_level_for_status(status, expected):
+    assert _level_for_status(status) == expected
 
 
 @pytest.mark.parametrize(
@@ -107,3 +126,78 @@ async def test_token_bucket_allows_initial_burst():
     await asyncio.gather(*(bucket.acquire() for _ in range(5)))
     elapsed = time.monotonic() - start
     assert elapsed < 0.05
+
+
+@pytest.fixture
+def logfire_exporter():
+    """Capture emitted spans via an isolated in-memory exporter."""
+    exporter = TestExporter()
+    logfire.configure(
+        send_to_logfire=False,
+        console=False,
+        additional_span_processors=[SimpleSpanProcessor(exporter)],
+    )
+    yield exporter
+    exporter.clear()
+
+
+def _request_spans(exporter: TestExporter) -> list[dict]:
+    """The transport's per-request spans (those carrying http.status_code)."""
+    return [
+        s
+        for s in exporter.exported_spans_as_dict()
+        if s["attributes"].get("http.status_code") is not None
+    ]
+
+
+async def test_recovered_429_is_not_error_level(logfire_exporter):
+    """A 429 retried into a 200 must emit exactly one span, NOT at error level.
+
+    This is the denoising guarantee: a self-healing rate-limit hit no longer
+    trips the error-level alert.
+    """
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+        return httpx.Response(200, json={"ok": True})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 200
+    logfire.force_flush()
+
+    spans = _request_spans(logfire_exporter)
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert attrs["http.status_code"] == 200
+    assert attrs.get("openphone.attempts") == 2  # one 429 + one success
+    # Default (info=9) when set_level was not called for an error status.
+    assert attrs.get("logfire.level_num", 9) < 17
+
+
+async def test_final_error_is_error_level(logfire_exporter):
+    """A genuine error (final 5xx) still surfaces at error level → still pages."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 500
+    logfire.force_flush()
+
+    spans = _request_spans(logfire_exporter)
+    assert len(spans) == 1
+    assert spans[0]["attributes"]["http.status_code"] == 500
+    assert spans[0]["attributes"].get("logfire.level_num") == 17


### PR DESCRIPTION
## What & why

Follow-up to #252 (merged). You got paged again — trace `019e78f85e0dd5f32aa11fd5b8914840` (2026-05-30, post-merge). Investigation: **same root cause, and the merged fix was partially working but had two gaps.**

The trace shows the retry transport doing its job — 4 × `429` were caught, logged `openphone 429 — retrying after 1.0s`, and **retried successfully to 200**. No data was dropped. But:

1. **The throttle was too bursty.** Capacity equalled the rate (8 == 8), so a parallel snippet fan-out still fired ~10 requests in <0.3s and tripped OpenPhone's ~10/s limit.
2. **Recovered 429s still paged.** httpx auto-instrumentation emits a span *per transport attempt* and flags 4xx at error level — so even a 429 that we successfully retried left a level-17 span behind, still tripping the "Error-level records (non-local)" alert.

## Fix

- **Pace, don't burst.** Split burst capacity from sustained rate: `rate = 6/s`, `capacity = 3` → worst case ~9 requests in any 1-second window, safely under the limit. (Single Hypercorn worker confirmed, so the per-process bucket fully governs OpenPhone traffic.)
- **One span per logical request, level from the FINAL status.** Each inner attempt now runs under `logfire.suppress_instrumentation()` (no per-attempt span), and the transport emits a single span whose level reflects the outcome:
  - recovered 429 → final 200 → **info** (no alert)
  - genuine 4xx/5xx, or a 429 that exhausts retries → **error** (still pages)

This preserves alerting for real OpenPhone problems while killing the self-healing-burst noise. Applied to both the monorepo client (`api/src/open_phone/rate_limit.py`) and the vendored `apps/sernia_mcp/src/sernia_mcp/clients/rate_limit.py`.

## Tests

- `_level_for_status` mapping (both suites).
- Span-capture tests (sernia_mcp, isolated logfire `TestExporter`): a retried-429 emits exactly one span at **info** with `openphone.attempts == 2`; a final 500 emits one span at **error** (`logfire.level_num == 17`).
- Existing retry-mechanics tests still pass. **api: 18 passed · sernia_mcp: 20 passed.**

## Preview

https://react-router-portfolio-pr-253.up.railway.app/

https://claude.ai/code/session_01C5RsK2y8X9f7rQjTy6CPb3