### PR TITLE
refactor(logfire): drop watermark for stateless fixed lookback

### DIFF
--- a/.github/logfire-investigate/README.md
+++ b/.github/logfire-investigate/README.md
@@ -1,6 +1,6 @@
 # logfire-investigate
 
-Self-contained GitHub Actions routine: once per day, pull **new** Logfire
+Self-contained GitHub Actions routine: once per day, pull recent Logfire
 exceptions and fire a Claude Code routine **exactly once** so it investigates and
 opens a PR. Pull model only — no webhooks, no hosted endpoint.
 
@@ -11,28 +11,46 @@ Everything for this job lives in this folder, except the workflow YAML itself
 .github/
 ├── workflows/logfire_investigate.yml   # cron trigger (must live here)
 └── logfire-investigate/
-    ├── investigate.py                  # all the logic
-    ├── last_run.txt                    # watermark (ISO8601 UTC, single line)
+    ├── investigate.py                  # all the logic (stateless)
     ├── ignore_signatures.txt           # git-tracked "Ignored" suppression list
-    ├── history.log                     # append-only audit log
+    ├── history.log                     # append-only audit log of fires
     └── README.md
 ```
 
 ## How it works
 
-1. Read the watermark from `last_run.txt` (defaults to now − 24h if empty).
+1. Compute a **fixed lookback window**: `min_timestamp = now − LOOKBACK_HOURS`
+   (default **28h** = the 24h cron period + a 4h buffer). No stored state.
 2. Run every query in `SOURCES` (in `investigate.py`) against Logfire
-   `/v1/query` with `min_timestamp = watermark`, and union the rows (deduped on
+   `/v1/query` with that `min_timestamp`, and union the rows (deduped on
    `(trace_id, span_id)`).
 3. Group rows by Logfire exception **fingerprint** (with a
    `type/service/span_name` fallback for non-fingerprinted error-level records).
 4. Drop groups matching any line in `ignore_signatures.txt`.
 5. If anything remains, fire the routine **once** with a single batched payload
    (an extra turn appended to the routine's server-side session).
-6. On HTTP 200: advance the watermark to the newest `start_timestamp` seen,
-   append a line to `history.log`, and the workflow commits both files back.
-   On non-200 (incl. 429): nothing is committed, the job fails, and the same
-   window is retried tomorrow.
+6. On HTTP 200: append a line to `history.log` and the workflow commits it back.
+   On non-200 (incl. 429): nothing is committed and the job fails (visible in the
+   Actions tab); the same window is naturally re-covered on the next run.
+
+## Why no watermark / stored state?
+
+An earlier design tracked a watermark (`last_run.txt`) committed back to main to
+get "exactly-once" reads. It was dropped because it bought very little:
+
+- **It does not suppress recurring errors.** A chronic error emits *new rows with
+  new timestamps* every day, which clear any watermark, so the routine fires
+  daily regardless. The thing that actually suppresses known noise is
+  `ignore_signatures.txt` — not a watermark.
+- The watermark's only real value was avoiding re-reading the *same* rows and
+  gap-free coverage after multi-day outages — minor for a once-daily job — while
+  it introduced a fragile 24h boundary (it once *missed* a real alert sitting
+  right on the edge) plus a whole commit-back-to-main machinery.
+
+A fixed lookback with a buffer is simpler, never misses a boundary event, and
+needs no state. Worst case, an event in the overlap buffer fires on two
+consecutive days (at most one duplicate). The Actions run log is itself the audit
+of every run; `history.log` additionally records the fires in-repo.
 
 ## Why `SOURCES` is in the script, not fetched live
 
@@ -68,6 +86,7 @@ Repo **secrets**:
 
 Optional repo **variable** `LOGFIRE_BASE` (defaults to
 `https://logfire-us.pydantic.dev`; set to `https://logfire-eu.pydantic.dev` for EU).
+The lookback is overridable via a `LOOKBACK_HOURS` env var (defaults to 28).
 
 ```bash
 gh secret set LOGFIRE_GHA_TOKEN  --repo emilioesposito/portfolio --body '<logfire read token>'
@@ -80,13 +99,13 @@ gh variable set LOGFIRE_BASE     --repo emilioesposito/portfolio --body 'https:/
 ## Manual run / dry run
 
 Trigger from the Actions tab (`workflow_dispatch`) with **dry_run = true** to
-print the batched payload without firing or advancing the watermark. The script
-also accepts `--dry-run` directly.
+print the batched payload without firing. The script also accepts `--dry-run`.
 
-## Note on the watermark commit
+## Note on the history.log commit
 
-When a routine fires, the workflow commits `last_run.txt` + `history.log` back to
-the branch it ran on (the default branch for scheduled runs) as
-`github-actions[bot]`, with `[skip ci]`. If the default branch has protection
-requiring PR review, this direct push will be rejected and the watermark won't
-advance — loosen protection for the bot, or switch the commit step to open a PR.
+When a routine fires, the workflow appends to `history.log` and commits it to the
+branch it ran on (the default branch for scheduled runs) as `github-actions[bot]`,
+with `[skip ci]`. If the default branch later gains protection requiring PR
+review, this direct push would be rejected (the fire still happened; only the
+in-repo audit line would be lost) — loosen protection for the bot or switch the
+commit step to open a PR.

--- a/.github/logfire-investigate/investigate.py
+++ b/.github/logfire-investigate/investigate.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-"""Pull new Logfire exceptions and fire a Claude Code routine once per run.
+"""Pull recent Logfire exceptions and fire a Claude Code routine once per run.
 
 Pull model only (no webhooks). Designed to run once per day from a GitHub
 Actions cron. On any given run it:
 
-  1. Reads the stored watermark (``last_run.txt`` beside this script); defaults
-     to now-24h.
-  2. Runs every query in SOURCES against Logfire /v1/query (rows newer than the
-     watermark) and unions the results. SOURCES mirrors both the auto "Issues"
+  1. Computes a fixed lookback window: min_timestamp = now - LOOKBACK_HOURS
+     (default 28h = the daily cron period plus a safety buffer, so a slow/late
+     run can never skip past an event on the 24h boundary). No stored state.
+  2. Runs every query in SOURCES against Logfire /v1/query (rows within the
+     window) and unions the results. SOURCES mirrors both the auto "Issues"
      fingerprint stream AND my explicitly-defined SQL alerts, because the read
      token cannot reach the OAuth2-only alerts management API to live-fetch them.
   3. Groups rows by Logfire exception fingerprint (with a
@@ -15,21 +16,23 @@ Actions cron. On any given run it:
   4. Drops groups matching an entry in ``ignore_signatures.txt``
      (case-insensitive substring vs type/service/label/fingerprint) -- this
      stands in for Logfire's own "Ignored" issue state, which is not exposed
-     to read tokens via the API.
+     to read tokens via the API. This (not a watermark) is what suppresses
+     recurring/known noise.
   5. If anything remains, fires the Claude Code routine EXACTLY ONCE with a
-     single batched payload (an extra turn appended to the routine's session),
-     and only then advances the watermark.
+     single batched payload (an extra turn appended to the routine's session).
 
-The watermark is advanced (and committed back by the workflow) ONLY when a
-routine was actually fired and the fire returned HTTP 200. No fire => no
-watermark change => the same window is re-read next run.
+Why no watermark? Recurring errors emit new rows daily, so they would clear any
+watermark and fire anyway -- the watermark only avoided re-reading the *same*
+rows, at the cost of a fragile boundary and a commit-back-to-main step. A fixed
+lookback with a buffer is simpler and never misses a boundary event. The only
+persisted state is ``history.log`` (append-only audit of actual fires), which the
+workflow commits back when (and only when) a routine fired.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
-import re
 import sys
 from datetime import datetime, timedelta, timezone
 
@@ -46,13 +49,14 @@ ANTHROPIC_BETA = "experimental-cc-routine-2026-04-01"
 
 # State files live alongside this script (self-contained GHA folder).
 HERE = os.path.dirname(os.path.abspath(__file__))
-WATERMARK_FILE = os.path.join(HERE, "last_run.txt")
 IGNORE_FILE = os.path.join(HERE, "ignore_signatures.txt")
 HISTORY_FILE = os.path.join(HERE, "history.log")
 
 MAX_PAYLOAD_CHARS = 60000  # well under the 65536 API ceiling
 MAX_SAMPLE_TRACES = 5
-LOOKBACK_HOURS = 24
+# Daily cron period (24h) + 4h buffer so a late run never skips a boundary
+# event. Overridable via the LOOKBACK_HOURS env var.
+LOOKBACK_HOURS = 28
 HTTP_TIMEOUT = 60
 
 # --- Source queries ---------------------------------------------------------
@@ -156,35 +160,13 @@ def set_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
-def parse_ts(value: str):
-    """Best-effort parse of an ISO8601 timestamp into an aware datetime."""
-    if not value:
-        return None
-    s = value.strip()
-    if s.endswith("Z"):
-        s = s[:-1] + "+00:00"
-    # Python's fromisoformat tops out at microseconds; trim extra precision.
-    s = re.sub(r"(\.\d{6})\d+", r"\1", s)
+def window_start() -> str:
+    """Return the start of the lookback window (ISO8601 UTC). Stateless."""
     try:
-        dt = datetime.fromisoformat(s)
+        hours = float(os.environ.get("LOOKBACK_HOURS", "") or LOOKBACK_HOURS)
     except ValueError:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
-
-
-def read_watermark() -> str:
-    """Return the stored watermark, or now-24h (ISO8601 UTC) if absent/empty."""
-    try:
-        with open(WATERMARK_FILE, encoding="utf-8") as f:
-            value = f.read().strip()
-    except FileNotFoundError:
-        value = ""
-    if value:
-        return value
-    default = datetime.now(timezone.utc) - timedelta(hours=LOOKBACK_HOURS)
-    return default.isoformat()
+        hours = LOOKBACK_HOURS
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
 
 
 def load_ignore_patterns() -> list[str]:
@@ -342,24 +324,11 @@ def group_rows(rows: list[dict]) -> list[dict]:
     return list(groups.values())
 
 
-def newest_timestamp(rows: list[dict]) -> str | None:
-    """Return the raw start_timestamp string of the newest returned row."""
-    best_dt = None
-    best_raw = None
-    for r in rows:
-        raw = (r.get("start_timestamp") or "").strip()
-        dt = parse_ts(raw)
-        if dt and (best_dt is None or dt > best_dt):
-            best_dt = dt
-            best_raw = raw
-    return best_raw
-
-
-def build_payload(groups: list[dict]) -> str:
+def build_payload(groups: list[dict], window_hours: float) -> str:
     # The routine already holds the standing instructions server-side; this
     # text is the extra turn appended to the session, so it is pure context.
     lines = [
-        "New Logfire exceptions since the last run "
+        f"Logfire exceptions from the last {window_hours:g}h "
         "(grouped by Logfire fingerprint; investigate each via its trace):",
         "",
     ]
@@ -407,8 +376,8 @@ def main() -> int:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Do everything EXCEPT the fire POST and watermark write; just "
-        "print the payload that would be sent.",
+        help="Do everything EXCEPT the fire POST; just print the payload that "
+        "would be sent.",
     )
     args = parser.parse_args()
 
@@ -425,22 +394,20 @@ def main() -> int:
         set_output("fired", "0")
         return 1
 
-    watermark = read_watermark()
+    min_timestamp = window_start()
+    window_hours = (datetime.now(timezone.utc) - datetime.fromisoformat(min_timestamp)).total_seconds() / 3600
     log(f"Logfire base:   {base}")
-    log(f"Watermark (min_timestamp): {watermark}")
+    log(f"Window start (min_timestamp): {min_timestamp}  (~{window_hours:g}h lookback)")
     log(f"Dry run:        {dry_run}")
 
     try:
-        rows = collect_rows(base, read_token, watermark)
+        rows = collect_rows(base, read_token, min_timestamp)
     except requests.RequestException as exc:
         log(f"ERROR: Logfire query failed: {exc}")
         set_output("fired", "0")
         return 1
 
     log(f"Total unique rows across sources: {len(rows)}")
-
-    # New watermark candidate is computed across ALL returned rows (pre-filter).
-    new_watermark = newest_timestamp(rows)
 
     groups = group_rows(rows)
     patterns = load_ignore_patterns()
@@ -457,11 +424,11 @@ def main() -> int:
         return 0
 
     total_hits = sum(g["hits"] for g in groups)
-    payload = build_payload(groups)
+    payload = build_payload(groups, window_hours)
     log(f"Groups to report: {len(groups)}  total hits: {total_hits}")
 
     if dry_run:
-        log("DRY RUN - payload that WOULD be sent (not firing, not advancing watermark):")
+        log("DRY RUN - payload that WOULD be sent (not firing):")
         log("-" * 72)
         log(payload)
         log("-" * 72)
@@ -478,13 +445,6 @@ def main() -> int:
         body = resp.json()
         session_id = body.get("claude_code_session_id", "")
         session_url = body.get("claude_code_session_url", "")
-        # Advance the watermark only now that the fire succeeded.
-        if new_watermark:
-            with open(WATERMARK_FILE, "w", encoding="utf-8") as f:
-                f.write(new_watermark + "\n")
-            log(f"Advanced watermark -> {new_watermark}")
-        else:
-            log("WARN: no parseable timestamp in returned rows; watermark unchanged")
         now = datetime.now(timezone.utc).isoformat()
         append_history(
             f"{now}  fired  session={session_id}  groups={len(groups)}  hits={total_hits}"

--- a/.github/workflows/logfire_investigate.yml
+++ b/.github/workflows/logfire_investigate.yml
@@ -7,18 +7,18 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry run: build and print the payload but do NOT fire the routine or advance the watermark"
+        description: "Dry run: build and print the payload but do NOT fire the routine"
         type: boolean
         default: false
 
-# Serialize runs so a manual run and the cron run can never clobber each
-# other's watermark commit.
+# Serialize runs so a manual run and the cron run never overlap (and so the
+# history.log commit below can't race itself).
 concurrency:
   group: logfire-investigate
   cancel-in-progress: false
 
 permissions:
-  contents: write # needed to commit the advanced watermark
+  contents: write # needed to commit the history.log audit entry
 
 jobs:
   investigate:
@@ -44,27 +44,27 @@ jobs:
           CC_ROUTINE_TOKEN: ${{ secrets.CC_ROUTINE_TOKEN }}
           CC_ROUTINE_ID: ${{ secrets.CC_ROUTINE_ID }}
 
-      - name: Commit advanced watermark
+      - name: Commit history.log audit entry
         if: steps.run.outputs.fired == '1'
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .github/logfire-investigate/last_run.txt .github/logfire-investigate/history.log
+          git add .github/logfire-investigate/history.log
           if git diff --cached --quiet; then
-            echo "No watermark changes to commit"
+            echo "No history changes to commit"
             exit 0
           fi
-          git commit -m "chore(logfire): advance watermark after routine fire [skip ci]"
-          # Rebase on latest before pushing so concurrent runs don't clobber the
-          # watermark. Never force-push. Retry with exponential backoff.
+          git commit -m "chore(logfire): record routine fire in history.log [skip ci]"
+          # Rebase before pushing so a concurrent run can't clobber the log.
+          # Never force-push. Retry with exponential backoff.
           for attempt in 1 2 3 4; do
             if git pull --rebase origin "${GITHUB_REF_NAME}" && git push origin "HEAD:${GITHUB_REF_NAME}"; then
-              echo "Watermark pushed."
+              echo "History pushed."
               exit 0
             fi
             echo "Push attempt ${attempt} failed; retrying..."
             sleep $((2 ** attempt))
           done
-          echo "Failed to push watermark after retries." >&2
+          echo "Failed to push history.log after retries." >&2
           exit 1


### PR DESCRIPTION
Follow-up to #254 (merged). Simplifies the logfire-investigate job by removing the watermark.

## Why

The watermark (`last_run.txt`, committed back to main) was meant to give exactly-once reads, but in practice it bought very little and caused a real miss:

- **It does not suppress recurring errors.** A chronic error emits *new rows with new timestamps* every day, which clear any watermark — so the routine fires daily regardless. What actually suppresses known noise is `ignore_signatures.txt`, not the watermark.
- **It introduced a fragile 24h boundary.** It missed a genuine error-level alert (trace `019e78f85e0dd5f32aa11fd5b8914840` — the OpenPhone 429 retries) that landed right on the edge of the window.
- It dragged in commit-back-to-main machinery (`contents: write`, rebase/retry push) for "don't re-read the same couple of hours."

## What changed

- **Stateless fixed lookback**: `min_timestamp = now − LOOKBACK_HOURS` (default **28h** = 24h cron period + 4h buffer, overridable via `LOOKBACK_HOURS` env). A late run can never skip a boundary event; worst case an event in the buffer fires on two consecutive days (≤1 duplicate).
- **Removed** `last_run.txt`, `read_watermark()`, `newest_timestamp()`, and the watermark write/commit. Dropped the now-unused `re`/`parse_ts`.
- **Kept** `history.log` as the only persisted state — an append-only audit of actual fires, committed back **only when a routine fired**. (The Actions run log is itself the per-run audit.)
- Payload header now reads "Logfire exceptions from the last 28h" instead of "since the last run".
- README rewritten with a "Why no watermark / stored state?" section.

Everything else from #254 is unchanged: A+B source union, fingerprint grouping with fallback, `(trace_id, span_id)` dedup, ignore-list suppression, single fire per run.

## Testing
End-to-end with mocked `requests`: 28h window confirmed; the previously-missed 429 boundary event is now inside the window; fires **exactly once**; cross-source dedup intact; `history.log` audit line written; `fired=1`. Script compiles clean with no unused imports.

https://claude.ai/code/session_01FBiPoJvRWbSqipzxnEHjb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBiPoJvRWbSqipzxnEHjb1)_