### PR TITLE
fix(gmail): avoid full-table TOAST scan in get_zillow_emails (Logfire timeout alert)

### DIFF
--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -1,2 +1,3 @@
 2026-05-31T14:12:52.974289+00:00  fired  session=session_01Jmo3jKJrS6J3L8TAkK9XoP  groups=1  hits=4
 2026-05-31T14:38:51.082256+00:00  fired  session=session_01LFRvFjSXBwgZFL7HGkTKs4  groups=1  hits=4
+2026-06-01T15:06:45.255317+00:00  fired  session=session_01UJi3KgictJ8bjCsfpy1xHF  groups=4  hits=4

--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -1,1 +1,2 @@
 2026-05-31T14:12:52.974289+00:00  fired  session=session_01Jmo3jKJrS6J3L8TAkK9XoP  groups=1  hits=4
+2026-05-31T14:38:51.082256+00:00  fired  session=session_01LFRvFjSXBwgZFL7HGkTKs4  groups=1  hits=4

--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -1,0 +1,1 @@
+2026-05-31T14:12:52.974289+00:00  fired  session=session_01Jmo3jKJrS6J3L8TAkK9XoP  groups=1  hits=4

--- a/api/src/google/gmail/routes.py
+++ b/api/src/google/gmail/routes.py
@@ -35,26 +35,49 @@ router = APIRouter(prefix="/gmail", tags=["gmail"])
 @router.get("/get_zillow_emails")
 async def get_zillow_emails(session: DBSession) -> List[ZillowEmailResponse]:
     """
-    Fetch 10 random email messages containing 'zillow' in the body HTML,
-    excluding daily listing emails.
+    Fetch 5 random Zillow inquiry emails, excluding daily listing emails.
+
+    Implemented as two cheap queries instead of one. A single query that
+    filters `body_html ILIKE '%zillow%'` across the whole table forces a
+    sequential scan that de-TOASTs every row's large `body_html`/payload
+    (~318 MB of buffers for ~10k rows). On a cold Neon compute that scan
+    exceeds the statement timeout (~10s) and the endpoint 500s.
+
+    Step 1 narrows to inquiry candidates using only the inline `subject`
+    column (no TOAST reads). Step 2 fetches those candidates by primary key
+    and applies the `body_html` filter, so only the candidate rows are
+    de-TOASTed (PK index scan, ~30 MB). A trigram index does not help here:
+    the planner under-costs TOAST reads and ignores it.
     """
     try:
-        # Construct the query
+        # Step 1: cheap candidate lookup on the inline `subject` column only.
+        candidate_ids = (
+            await session.execute(
+                select(EmailMessage.id).where(
+                    EmailMessage.subject.like('%is requesting%'),  # Only inquiries
+                    ~EmailMessage.subject.like('Re%'),  # is NOT a reply
+                )
+            )
+        ).scalars().all()
+
+        if not candidate_ids:
+            return []
+
+        # Step 2: fetch candidates by primary key and apply the body_html
+        # filter. The PK index scan de-TOASTs only the candidate rows.
         query = (
             select(EmailMessage)
             .where(
+                EmailMessage.id.in_(candidate_ids),
                 EmailMessage.body_html.ilike('%zillow%'),
-                EmailMessage.subject.like('%is requesting%'),  # Only inquiries
-                ~EmailMessage.subject.like('Re%')  # is NOT a reply
             )
             .order_by(func.random())
             .limit(5)
         )
-        
-        # Execute the query
+
         result = await session.execute(query)
         emails = result.scalars().all()
-        
+
         # Format the response to match frontend expectations
         return [
             {
@@ -66,12 +89,15 @@ async def get_zillow_emails(session: DBSession) -> List[ZillowEmailResponse]:
             }
             for email in emails
         ]
-    
+
     except Exception as e:
-        logfire.error(f"Error fetching Zillow emails: {str(e)}")
+        # Use logfire.exception so the real exception type/stacktrace is
+        # captured. The previous str(e) was empty for the timeout error,
+        # producing a blank "Failed to fetch Zillow emails: " message.
+        logfire.exception("Error fetching Zillow emails")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch Zillow emails: {str(e)}"
+            detail=f"Failed to fetch Zillow emails: {e!r}"
         )
 
 @router.post("/generate_email_response")


### PR DESCRIPTION
## What fired

The Logfire alert **"Error-level records (non-local)"** fired in production (07:52 & 07:57 UTC, 2026-06-01) for `GET /api/google/gmail/get_zillow_emails` returning **500**. Trace: [`019e822843dc2cd1f0cd5618aa440a15`](https://logfire-us.pydantic.dev/espo412/portfolio?q=trace_id%3D%27019e822843dc2cd1f0cd5618aa440a15%27). All four grouped exceptions in the alert are the same single trace.

## Root cause (verified against prod data)

The endpoint ran one query filtering `body_html ILIKE '%zillow%'` across the whole `email_messages` table. Because `body_html` is a large, TOASTed column, this forces a **sequential scan that de-TOASTs every row**.

Measured on a throwaway Neon branch of production data (~10k rows, `body_html` avg 17 KB / max 305 KB):

| Variant | Plan | Buffers | Time |
|---|---|---|---|
| Current single query | Seq Scan, de-TOASTs all rows | 40,691 (~318 MB) | **10,465 ms cold** |
| Two-query rewrite (this PR) | Index Scan on PK | ~3,600 (~30 MB) | **~36 ms** |

The 10.5 s cold-cache time on a 0.25 CU compute exceeds the statement timeout, producing the 500. A trigram GIN index does **not** fix this — the planner under-costs TOAST reads and ignores the index (confirmed via EXPLAIN ANALYZE), so no migration is warranted.

## The fix

Split into two cheap queries:
1. **Candidate lookup** on the inline `subject` column only (`LIKE '%is requesting%'` and not a `Re%` reply) — no TOAST reads.
2. **Fetch by primary key** (`id IN (...)`) with the `body_html ILIKE '%zillow%'` filter — a PK index scan that de-TOASTs only the ~458 candidate rows.

Result semantics are unchanged (same 424 matching rows, same random sample of 5).

Also fixes **blank error logging**: switched to `logfire.exception(...)` + `repr(e)` in the detail. The timeout exception's `str(e)` was empty, which is why the original alert/log message was a useless `"Failed to fetch Zillow emails: "`.

## Testing

- `pytest api/src/google/gmail/tests.py` passes.
- Manually exercised against a local DB with seeded rows: correctly returns inquiry emails, excludes `Re:` replies and non-Zillow-body emails, and returns `[]` when no candidates exist.
- Query plans validated on a disposable Neon branch of prod data (branch deleted after).

## Preview

https://react-router-portfolio-pr-259.up.railway.app/

Addresses Logfire alert: **Error-level records (non-local)**.

https://claude.ai/code/session_01UJi3KgictJ8bjCsfpy1xHF