### PR TITLE
fix(gmail): downgrade expired-historyId 404 from error to warning

### DIFF
--- a/api/src/google/gmail/service.py
+++ b/api/src/google/gmail/service.py
@@ -298,6 +298,24 @@ async def get_email_changes(gmail_service, history_id: str, user_id: str = "me")
                     await asyncio.sleep(wait_time)
                     wait_time *= 2  # Exponential backoff
                 continue
+            elif getattr(getattr(e, "resp", None), "status", None) == 404 or "notFound" in str(e):
+                # Expected, self-healing Gmail behavior: a startHistoryId that is too
+                # old (Gmail only retains ~1 week of history) returns HTTP 404
+                # "notFound". Per Google's docs the correct response is to perform a
+                # full sync, which happens automatically on the next notification with
+                # a fresh historyId. Log at warning (not error) so this expected,
+                # recoverable condition does not trip error-level alerts.
+                # https://developers.google.com/gmail/api/guides/sync#partial_synchronization
+                logfire.warn(
+                    f"History ID {history_id} expired (HTTP 404 notFound); skipping — "
+                    f"next notification will provide a fresh historyId. Detail: {str(e)}"
+                )
+                return {
+                    "status": "retry_needed",
+                    "email_message_ids": [],
+                    "added_message_ids": [],
+                    "reason": f"History ID expired (404 notFound): {str(e)}",
+                }
             else:
                 logfire.error(f"Failed to fetch history: {str(e)}")
                 return {


### PR DESCRIPTION
## Summary

Addresses the Logfire exception **`Failed to fetch history`** (service: `fastapi`) surfaced by the daily alert triage.

Gmail's History API returns **HTTP 404 `notFound`** when a `startHistoryId` is too old — Gmail only retains roughly a week of mailbox history. This is an **expected, self-healing condition**: per [Google's sync docs](https://developers.google.com/gmail/api/guides/sync#partial_synchronization), the correct response is to perform a full sync, which happens automatically on the next Gmail push notification with a fresh `historyId`.

Previously, only the `"Invalid history ID"` case was treated as benign (logged at `info`). The 404 `notFound` case fell through to the generic `except` branch and was logged via `logfire.error()`, which:
- polluted the error stream,
- created a tracked Logfire Issue, and
- tripped the **"Error-level records (non-local)"** alert.

## Change

In `get_email_changes` (`api/src/google/gmail/service.py`), handle the 404 explicitly and log at **warning** instead of error. Return behavior is unchanged (`status="retry_needed"`).

## Evidence

- Trace `019e95259c74c56542aed4f914a522a3` (production, 2026-06-05T00:18:51Z): Gmail Pub/Sub notification for `emilio@serniacapital.com`, historyId `7564063` → `HttpError 404 ... reason: notFound` → logged at ERROR.
- Single occurrence in the last 28h; no code fix was previously merged and no open PR addressed it.

## Risk

Low. Only changes the log level / branch for an already-caught exception; no behavioral change to the notification flow or return contract.

🤖 Generated as part of the automated daily Logfire alert triage.

Railway preview: https://react-router-portfolio-pr-260.up.railway.app/