### PR TITLE
Make calendar event reminders push-only (no email)

### DIFF
--- a/api/src/google/calendar/service.py
+++ b/api/src/google/calendar/service.py
@@ -37,8 +37,10 @@ class CalendarReminder(BaseModel):
     minutes: int = Field(description="Minutes before the event to trigger the reminder.")
 
 
+# Reminders are push-only (popup). We intentionally avoid email reminders so
+# calendar invites only generate push notifications, not emails.
 DEFAULT_REMINDERS = [
-    CalendarReminder(method=ReminderMethod.EMAIL, minutes=24 * 60),
+    CalendarReminder(method=ReminderMethod.POPUP, minutes=24 * 60),
     CalendarReminder(method=ReminderMethod.POPUP, minutes=60),
 ]
 
@@ -71,7 +73,7 @@ class CalendarEventInput(BaseModel):
     )
     reminders: list[CalendarReminder] | None = Field(
         default=None,
-        description="Custom reminders. Defaults to email 1 day before + popup 1 hour before.",
+        description="Custom reminders. Defaults to push (popup) 1 day before + 1 hour before. Use popup, not email.",
     )
     guests_can_see_other_guests: bool = Field(
         default=True,

--- a/api/src/sernia_ai/tools/google_tools.py
+++ b/api/src/sernia_ai/tools/google_tools.py
@@ -760,7 +760,7 @@ async def create_calendar_event(
     """Create a Google Calendar event. Requires approval if any attendee is external.
 
     Always include all attendees explicitly — no one is auto-added.
-    Reminders default to email 1 day before + popup 1 hour before.
+    Reminders default to push (popup) 1 day before + 1 hour before (never email).
     Default timezone is US/Eastern.
     """
     if _has_external_attendee(event.attendees) and not ctx.tool_call_approved:

--- a/api/src/zillow_email/service.py
+++ b/api/src/zillow_email/service.py
@@ -518,7 +518,7 @@ async def check_email_threads(overwrite_calendar_events=False):
                                     CalendarAttendee(email="jackie@serniacapital.com"),
                                 ],
                                 reminders=[
-                                    CalendarReminder(method=ReminderMethod.EMAIL, minutes=24 * 60),
+                                    CalendarReminder(method=ReminderMethod.POPUP, minutes=24 * 60),
                                     CalendarReminder(method=ReminderMethod.POPUP, minutes=120),
                                 ],
                             )


### PR DESCRIPTION
## Summary

Calendar invites previously defaulted to an **email** reminder 1 day before plus a **popup** reminder 1 hour before. This switches all reminder defaults to **push (popup) notifications only**, removing email reminders everywhere we create calendar events.

## Changes

- **`api/src/google/calendar/service.py`** — `DEFAULT_REMINDERS` now uses two `POPUP` reminders (1 day + 1 hour before) instead of email + popup. This is the shared service used by both Sernia AI's `create_calendar_event` tool and the Sernia MCP (its calendar functions route through this service). Updated the `reminders` field description accordingly.
- **`api/src/zillow_email/service.py`** — the Zillow appointment flow set an explicit email reminder; switched it to popup (1 day + 2 hours before).
- **`api/src/sernia_ai/tools/google_tools.py`** — updated the `create_calendar_event` tool docstring so the agent knows reminders default to push, never email.

The `ReminderMethod.EMAIL` enum value is retained so a caller can still opt into email explicitly, but no code path does so anymore.

## Verification

Confirmed `DEFAULT_REMINDERS` serializes to popup-only and the API body emits `{"useDefault": False, "overrides": [{"method": "popup", ...}]}` with no email method.

🔗 Railway preview: https://react-router-portfolio-pr-262.up.railway.app/

https://claude.ai/code/session_01SfXyFw8hSFU36TeAv7eH21