### PR TITLE
fix(gmail): diagnosable + faster Zillow email fetch (TimeoutError)

### DIFF
--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -3,3 +3,4 @@
 2026-06-01T15:06:45.255317+00:00  fired  session=session_01UJi3KgictJ8bjCsfpy1xHF  groups=4  hits=4
 2026-06-05T13:58:51.955448+00:00  fired  session=session_01UWJ39QtJp9qKgvWrmryvKt  groups=1  hits=1
 2026-06-06T13:34:00.794574+00:00  fired  session=session_018BkwGEGL4PLEsfkgie9Lmv  groups=1  hits=1
+2026-06-07T23:36:57.633352+00:00  fired  session=session_01MRCqAxuA83EeTvtUnfT1HL  groups=4  hits=4

--- a/api/src/google/gmail/routes.py
+++ b/api/src/google/gmail/routes.py
@@ -2,11 +2,13 @@
 FastAPI routes for Gmail-specific endpoints.
 """
 
+from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, HTTPException, Depends
 from typing import Dict, Any, List
 import logfire
 from openai import AsyncOpenAI
 from sqlalchemy import select, func
+from sqlalchemy.orm import aliased
 from api.src.utils.dependencies import verify_cron_or_admin
 from api.src.database.database import DBSession
 from api.src.google.gmail.service import (
@@ -39,18 +41,33 @@ async def get_zillow_emails(session: DBSession) -> List[ZillowEmailResponse]:
     excluding daily listing emails.
     """
     try:
-        # Construct the query
-        query = (
+        # Pre-filter to a small, bounded subset BEFORE randomizing. ORDER BY
+        # random() forces a full sort of every matching row, so running it over
+        # the entire (leading-wildcard ILIKE) match set caused query timeouts as
+        # email_messages grew. Instead, take the 500 most recent matching
+        # inquiries from the trailing year, then randomize within that subset.
+        one_year_ago = datetime.now(timezone.utc) - timedelta(days=365)
+
+        prefiltered = (
             select(EmailMessage)
             .where(
                 EmailMessage.body_html.ilike('%zillow%'),
                 EmailMessage.subject.like('%is requesting%'),  # Only inquiries
-                ~EmailMessage.subject.like('Re%')  # is NOT a reply
+                ~EmailMessage.subject.like('Re%'),  # is NOT a reply
+                EmailMessage.received_date >= one_year_ago,
             )
+            .order_by(EmailMessage.received_date.desc())
+            .limit(500)
+            .subquery()
+        )
+
+        recent_email = aliased(EmailMessage, prefiltered)
+        query = (
+            select(recent_email)
             .order_by(func.random())
             .limit(5)
         )
-        
+
         # Execute the query
         result = await session.execute(query)
         emails = result.scalars().all()

--- a/api/src/google/gmail/routes.py
+++ b/api/src/google/gmail/routes.py
@@ -68,10 +68,16 @@ async def get_zillow_emails(session: DBSession) -> List[ZillowEmailResponse]:
         ]
     
     except Exception as e:
-        logfire.error(f"Error fetching Zillow emails: {str(e)}")
+        # Some exceptions (e.g. asyncpg TimeoutError on a slow query) have an
+        # empty str(), which previously rendered as a blank, undiagnosable
+        # "Failed to fetch Zillow emails: ". Fall back to repr() so the
+        # exception type is always captured. logfire.exception also attaches
+        # the active traceback.
+        error_detail = str(e) or repr(e)
+        logfire.exception(f"Error fetching Zillow emails: {error_detail}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch Zillow emails: {str(e)}"
+            detail=f"Failed to fetch Zillow emails: {error_detail}"
         )
 
 @router.post("/generate_email_response")


### PR DESCRIPTION
## What fired

Logfire **Error-level records (non-local)** alert / issue fingerprint `25851362ed27712cf483798b1d270f68f9cd92c4265ff9d0f94134c3176c6dd9`.

A single production occurrence on `GET /api/google/gmail/get_zillow_emails` (trace `019ea3b04741298a3f414c9acb69dee2`, 2026-06-07 ~20:05 UTC) surfaced as four grouped exceptions, all from the **same trace** — a `500: Failed to fetch Zillow emails: ` with a **blank** detail.

## Root cause

The underlying exception is an **asyncpg `TimeoutError`** — the SQLAlchemy query timed out (~11s gap in the trace before failing). Two defects:
1. `str(TimeoutError())` is the empty string, so logs + HTTP `detail` rendered blank and undiagnosable.
2. `ORDER BY func.random()` forces a full sort of **every** row matching the leading-wildcard `body_html ILIKE '%zillow%'` scan — gets slower as `email_messages` grows, eventually timing out.

## Fix

**1. Observability** (`get_zillow_emails` error handler): fall back to `repr(e)` when `str(e)` is empty and use `logfire.exception`, so empty-`str()` exceptions (`TimeoutError`, `CancelledError`, …) are always diagnosable.

**2. Performance** — pre-filter to a bounded subset *before* randomizing:
- Take the **500 most recent** matching inquiries from the **trailing 1 year** (`received_date >= now - 365d`, ordered `received_date DESC`).
- Then `ORDER BY random()` and `LIMIT 5` within that ≤500-row subset.

The expensive random sort now runs over at most 500 rows instead of the entire match set. Behavior change: results are drawn from the past year's inquiries (oldest >1yr excluded) — intended.

Validated: query compiles and executes against the local DB via the `aliased(EmailMessage, subquery)` pattern.

Single occurrence so far; low-traffic demo endpoint.

Preview: https://react-router-portfolio-pr-264.up.railway.app/

🤖 Generated during automated Logfire alert triage.
https://claude.ai/code/session_01MRCqAxuA83EeTvtUnfT1HL