### PR TITLE
ci(logfire): surface Claude session link in the GHA run

### DIFF
--- a/.github/logfire-investigate/investigate.py
+++ b/.github/logfire-investigate/investigate.py
@@ -167,6 +167,27 @@ def set_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
+def write_summary(session_url: str, session_id: str, groups: int, hits: int) -> None:
+    """Append a Markdown blurb (with the clickable Claude session link) to the
+    GitHub Actions run summary, so the session is one click from the run page
+    instead of buried in step logs. No-op outside Actions / defensive on error."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    lines = ["### Logfire investigate — routine fired", ""]
+    if session_url:
+        lines.append(f"**Claude session:** [{session_url}]({session_url})")
+    elif session_id:
+        lines.append(f"**Claude session id:** `{session_id}`")
+    lines.append("")
+    lines.append(f"Reported **{groups}** group(s), **{hits}** total hit(s).")
+    try:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except OSError as exc:  # pragma: no cover - defensive
+        log(f"WARN: could not write step summary ({exc})")
+
+
 def window_start() -> str:
     """Return the start of the lookback window (ISO8601 UTC). Stateless."""
     try:
@@ -523,12 +544,18 @@ def main() -> int:
         body = resp.json()
         session_id = body.get("claude_code_session_id", "")
         session_url = body.get("claude_code_session_url", "")
+        # Fall back to constructing the URL from the id if the API omits it.
+        if not session_url and session_id:
+            session_url = f"https://claude.ai/code/{session_id}"
         now = datetime.now(timezone.utc).isoformat()
         append_history(
             f"{now}  fired  session={session_id}  groups={len(groups)}  hits={total_hits}"
         )
         log(f"Fired routine. Session: {session_url}")
         set_output("fired", "1")
+        set_output("session_id", session_id)
+        set_output("session_url", session_url)
+        write_summary(session_url, session_id, len(groups), total_hits)
         return 0
 
     log(f"ERROR: routine fire failed: HTTP {resp.status_code}")

--- a/.github/workflows/logfire_investigate.yml
+++ b/.github/workflows/logfire_investigate.yml
@@ -46,6 +46,12 @@ jobs:
           CC_ROUTINE_TOKEN: ${{ secrets.CC_ROUTINE_TOKEN }}
           CC_ROUTINE_ID: ${{ secrets.CC_ROUTINE_ID }}
 
+      - name: Show Claude session link
+        if: steps.run.outputs.fired == '1'
+        run: |
+          echo "Claude Code session: ${{ steps.run.outputs.session_url }}"
+          echo "Session id:          ${{ steps.run.outputs.session_id }}"
+
       - name: Commit history.log audit entry
         if: steps.run.outputs.fired == '1'
         run: |


### PR DESCRIPTION
## Why

The `logfire-investigate` workflow fires a Claude Code routine, and the fire API response **already returns** `claude_code_session_url` (e.g. `https://claude.ai/code/session_01MRC...`). But the script only `log()`s it inside the "Run Logfire investigate" step, so the session link is buried in raw step logs — you have to expand the step and scan for it.

## What

`.github/logfire-investigate/investigate.py`:
- Export `session_url` and `session_id` as **step outputs** (alongside the existing `fired`).
- Write a clickable session link to the **GitHub Actions run summary** (`$GITHUB_STEP_SUMMARY`), so it shows on the run's summary page.
- Fall back to constructing the URL from the session id if the API ever omits the URL field.

`.github/workflows/logfire_investigate.yml`:
- Add a dedicated **`Show Claude session link`** step (runs only when a routine fired) that echoes the URL + id, so it appears as its own named step.

## Result
After a fire, the session is one click from the run page (summary), visible as a standalone step, and reusable by any downstream step via `steps.run.outputs.session_url`. No behavior change when nothing fires.

Smoke-tested locally: outputs and summary render correctly, including the id→URL fallback.

🤖 Follow-up requested during automated Logfire alert triage.
https://claude.ai/code/session_01MRCqAxuA83EeTvtUnfT1HL

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRCqAxuA83EeTvtUnfT1HL)_