### PR TITLE
Release: dev → main (Zillow email timeout fix + Logfire session link in CI)

### DIFF
--- a/.github/logfire-investigate/investigate.py
+++ b/.github/logfire-investigate/investigate.py
@@ -167,6 +167,27 @@ def set_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
+def write_summary(session_url: str, session_id: str, groups: int, hits: int) -> None:
+    """Append a Markdown blurb (with the clickable Claude session link) to the
+    GitHub Actions run summary, so the session is one click from the run page
+    instead of buried in step logs. No-op outside Actions / defensive on error."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    lines = ["### Logfire investigate — routine fired", ""]
+    if session_url:
+        lines.append(f"**Claude session:** [{session_url}]({session_url})")
+    elif session_id:
+        lines.append(f"**Claude session id:** `{session_id}`")
+    lines.append("")
+    lines.append(f"Reported **{groups}** group(s), **{hits}** total hit(s).")
+    try:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except OSError as exc:  # pragma: no cover - defensive
+        log(f"WARN: could not write step summary ({exc})")
+
+
 def window_start() -> str:
     """Return the start of the lookback window (ISO8601 UTC). Stateless."""
     try:
@@ -523,12 +544,18 @@ def main() -> int:
         body = resp.json()
         session_id = body.get("claude_code_session_id", "")
         session_url = body.get("claude_code_session_url", "")
+        # Fall back to constructing the URL from the id if the API omits it.
+        if not session_url and session_id:
+            session_url = f"https://claude.ai/code/{session_id}"
         now = datetime.now(timezone.utc).isoformat()
         append_history(
             f"{now}  fired  session={session_id}  groups={len(groups)}  hits={total_hits}"
         )
         log(f"Fired routine. Session: {session_url}")
         set_output("fired", "1")
+        set_output("session_id", session_id)
+        set_output("session_url", session_url)
+        write_summary(session_url, session_id, len(groups), total_hits)
         return 0
 
     log(f"ERROR: routine fire failed: HTTP {resp.status_code}")

--- a/.github/workflows/logfire_investigate.yml
+++ b/.github/workflows/logfire_investigate.yml
@@ -46,6 +46,12 @@ jobs:
           CC_ROUTINE_TOKEN: ${{ secrets.CC_ROUTINE_TOKEN }}
           CC_ROUTINE_ID: ${{ secrets.CC_ROUTINE_ID }}
 
+      - name: Show Claude session link
+        if: steps.run.outputs.fired == '1'
+        run: |
+          echo "Claude Code session: ${{ steps.run.outputs.session_url }}"
+          echo "Session id:          ${{ steps.run.outputs.session_id }}"
+
       - name: Commit history.log audit entry
         if: steps.run.outputs.fired == '1'
         run: |

--- a/api/src/google/gmail/routes.py
+++ b/api/src/google/gmail/routes.py
@@ -35,26 +35,49 @@ router = APIRouter(prefix="/gmail", tags=["gmail"])
 @router.get("/get_zillow_emails")
 async def get_zillow_emails(session: DBSession) -> List[ZillowEmailResponse]:
     """
-    Fetch 10 random email messages containing 'zillow' in the body HTML,
-    excluding daily listing emails.
+    Fetch 5 random Zillow inquiry emails, excluding daily listing emails.
+
+    Implemented as two cheap queries instead of one. A single query that
+    filters `body_html ILIKE '%zillow%'` across the whole table forces a
+    sequential scan that de-TOASTs every row's large `body_html`/payload
+    (~318 MB of buffers for ~10k rows). On a cold Neon compute that scan
+    exceeds the statement timeout (~10s) and the endpoint 500s.
+
+    Step 1 narrows to inquiry candidates using only the inline `subject`
+    column (no TOAST reads). Step 2 fetches those candidates by primary key
+    and applies the `body_html` filter, so only the candidate rows are
+    de-TOASTed (PK index scan, ~30 MB). A trigram index does not help here:
+    the planner under-costs TOAST reads and ignores it.
     """
     try:
-        # Construct the query
+        # Step 1: cheap candidate lookup on the inline `subject` column only.
+        candidate_ids = (
+            await session.execute(
+                select(EmailMessage.id).where(
+                    EmailMessage.subject.like('%is requesting%'),  # Only inquiries
+                    ~EmailMessage.subject.like('Re%'),  # is NOT a reply
+                )
+            )
+        ).scalars().all()
+
+        if not candidate_ids:
+            return []
+
+        # Step 2: fetch candidates by primary key and apply the body_html
+        # filter. The PK index scan de-TOASTs only the candidate rows.
         query = (
             select(EmailMessage)
             .where(
+                EmailMessage.id.in_(candidate_ids),
                 EmailMessage.body_html.ilike('%zillow%'),
-                EmailMessage.subject.like('%is requesting%'),  # Only inquiries
-                ~EmailMessage.subject.like('Re%')  # is NOT a reply
             )
             .order_by(func.random())
             .limit(5)
         )
-        
-        # Execute the query
+
         result = await session.execute(query)
         emails = result.scalars().all()
-        
+
         # Format the response to match frontend expectations
         return [
             {
@@ -66,12 +89,15 @@ async def get_zillow_emails(session: DBSession) -> List[ZillowEmailResponse]:
             }
             for email in emails
         ]
-    
+
     except Exception as e:
-        logfire.error(f"Error fetching Zillow emails: {str(e)}")
+        # Use logfire.exception so the real exception type/stacktrace is
+        # captured. The previous str(e) was empty for the timeout error,
+        # producing a blank "Failed to fetch Zillow emails: " message.
+        logfire.exception("Error fetching Zillow emails")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch Zillow emails: {str(e)}"
+            detail=f"Failed to fetch Zillow emails: {e!r}"
         )
 
 @router.post("/generate_email_response")


### PR DESCRIPTION
Promotes the current `dev` to `main`. Two changes, three files (`+70 / -11`).

---

### 1. `fix(gmail): avoid full-table TOAST scan in get_zillow_emails` (#259, `e491834`)

**Problem:** `GET /api/google/gmail/get_zillow_emails` intermittently timed out (~10s → 500) on cold Neon computes. The single query filtered `body_html ILIKE '%zillow%'` across the whole `email_messages` table, forcing a sequential scan that de-TOASTs every row's large `body_html`/payload (~318 MB of buffers for ~10k rows), exceeding the statement timeout. A trigram index doesn't help — the planner under-costs TOAST reads and ignores it (verified via `EXPLAIN ANALYZE` on a Neon branch of prod data).

**Fix — split into two cheap queries** (`api/src/google/gmail/routes.py`):
- **Step 1:** narrow to inquiry candidates using only the inline `subject` column (no TOAST reads) → list of `id`s.
- **Step 2:** fetch those candidates by primary key and apply the `body_html ILIKE '%zillow%'` filter, so only the candidate rows are de-TOASTed (PK index scan, ~30 MB), then `ORDER BY random() LIMIT 5`.
- Early-return `[]` when there are no candidates.

Result: ~318 MB seq scan → ~30 MB index scan, **10.5s → ~36ms** on a prod-data branch.

**Also includes the observability fix:** the error handler now uses `logfire.exception(...)` and `detail=f"...{e!r}"`, so an empty-`str()` exception (the asyncpg `TimeoutError` that originally fired the Logfire alert) is no longer logged as a blank `"Failed to fetch Zillow emails: "`.

> Note: this supersedes the now-closed #264, which fixed the same bug with a weaker bounded-randomization approach.

---

### 2. `ci(logfire): surface Claude session link in the GHA run` (#265, `02112e9`)

The `logfire-investigate` workflow fires a Claude Code routine, and the fire response already returns `claude_code_session_url` — but it was only logged inside one step. Now (`.github/logfire-investigate/investigate.py`, `.github/workflows/logfire_investigate.yml`):
- Export `session_url` / `session_id` as **step outputs**.
- Write a clickable session link to the **GitHub run summary** (`$GITHUB_STEP_SUMMARY`).
- Add a dedicated **`Show Claude session link`** workflow step.
- Fall back to constructing the URL from the id if the API omits the URL.

No behavior change when nothing fires.

---

### File summary
| File | Change |
|------|--------|
| `api/src/google/gmail/routes.py` | Two-query Zillow fetch + `logfire.exception`/`repr` error handling (#259) |
| `.github/logfire-investigate/investigate.py` | Session link as outputs + run-summary (#265) |
| `.github/workflows/logfire_investigate.yml` | `Show Claude session link` step (#265) |

Both changes were already reviewed/merged into `dev` via #259 and #265.

https://claude.ai/code/session_01MRCqAxuA83EeTvtUnfT1HL

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRCqAxuA83EeTvtUnfT1HL)_