### PR TITLE
fix(sernia-chat): sync chat from DB so responses appear without a page refresh

### DIFF
--- a/apps/web-react-router/app/components/chat/tool-cards.tsx
+++ b/apps/web-react-router/app/components/chat/tool-cards.tsx
@@ -433,7 +433,7 @@ function ApprovalItem({
                   </Button>
                 </div>
               ) : (
-                <p className="p-2 bg-muted/50 rounded border text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                <p className="p-2 bg-muted/50 rounded border text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">
                   {msgValue}
                 </p>
               )}

--- a/apps/web-react-router/app/components/chat/tool-cards.tsx
+++ b/apps/web-react-router/app/components/chat/tool-cards.tsx
@@ -433,7 +433,7 @@ function ApprovalItem({
                   </Button>
                 </div>
               ) : (
-                <p className="p-2 bg-muted/50 rounded border text-sm whitespace-pre-wrap">
+                <p className="p-2 bg-muted/50 rounded border text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
                   {msgValue}
                 </p>
               )}

--- a/apps/web-react-router/app/components/markdown.tsx
+++ b/apps/web-react-router/app/components/markdown.tsx
@@ -61,7 +61,6 @@ const NonMemoizedMarkdown = ({ children }: { children: string }) => {
     },
     a: ({ node, children, ...props }) => {
       return (
-        // @ts-expect-error
         <a
           className="text-blue-500 hover:underline break-all"
           target="_blank"

--- a/apps/web-react-router/app/hooks/use-scroll-to-bottom.tsx
+++ b/apps/web-react-router/app/hooks/use-scroll-to-bottom.tsx
@@ -12,6 +12,12 @@ export function useScrollToBottom<T extends HTMLElement>(): [
     const end = endRef.current;
 
     if (container && end) {
+      // Start at the bottom when mounting with existing history — the
+      // MutationObserver below only reacts to later changes.
+      if (container.scrollHeight > container.clientHeight) {
+        end.scrollIntoView({ behavior: "auto", block: "end" });
+      }
+
       const observer = new MutationObserver((mutations) => {
         // Ignore mutations from form/textarea elements (e.g. textarea auto-resize
         // changes style.height, which shouldn't trigger auto-scroll)

--- a/apps/web-react-router/app/routes/chat-emilio.tsx
+++ b/apps/web-react-router/app/routes/chat-emilio.tsx
@@ -261,7 +261,7 @@ export default function ChatEmilioPage() {
                   if (part.type === "file") {
                     fileSegments.push({
                       type: "file",
-                      mediaType: part.mediaType || part.mimeType || "",
+                      mediaType: part.mediaType || "",
                       filename: part.filename,
                       url: part.url || "",
                     });

--- a/apps/web-react-router/app/routes/chat-emilio.tsx
+++ b/apps/web-react-router/app/routes/chat-emilio.tsx
@@ -311,8 +311,8 @@ export default function ChatEmilioPage() {
                       <>
                         <FileMessageDisplay files={fileSegments} />
                         {textContent && (
-                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm">
-                            <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
+                            <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{textContent}</p>
                           </div>
                         )}
                       </>

--- a/apps/web-react-router/app/routes/chat-emilio.tsx
+++ b/apps/web-react-router/app/routes/chat-emilio.tsx
@@ -311,8 +311,8 @@ export default function ChatEmilioPage() {
                       <>
                         <FileMessageDisplay files={fileSegments} />
                         {textContent && (
-                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
-                            <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{textContent}</p>
+                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden max-w-full">
+                            <p className="text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">{textContent}</p>
                           </div>
                         )}
                       </>

--- a/apps/web-react-router/app/routes/chat-weather.tsx
+++ b/apps/web-react-router/app/routes/chat-weather.tsx
@@ -339,8 +339,8 @@ export default function ChatWeatherPage() {
                     )}
                   >
                     {message.role === "user" ? (
-                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm">
-                        <p className="text-sm whitespace-pre-wrap">
+                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
+                        <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
                           {textContent}
                         </p>
                       </div>

--- a/apps/web-react-router/app/routes/chat-weather.tsx
+++ b/apps/web-react-router/app/routes/chat-weather.tsx
@@ -339,8 +339,8 @@ export default function ChatWeatherPage() {
                     )}
                   >
                     {message.role === "user" ? (
-                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
-                        <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden max-w-full">
+                        <p className="text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">
                           {textContent}
                         </p>
                       </div>

--- a/apps/web-react-router/app/routes/hitl-agent-chat.tsx
+++ b/apps/web-react-router/app/routes/hitl-agent-chat.tsx
@@ -1020,8 +1020,8 @@ export default function HITLAgentChatPage() {
 
                   <div className={cn("flex flex-col gap-2 max-w-[85%]", message.role === "user" && "items-end")}>
                     {message.role === "user" ? (
-                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm">
-                        <p className="text-sm whitespace-pre-wrap">{textContent}</p>
+                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
+                        <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{textContent}</p>
                       </div>
                     ) : (
                       <>

--- a/apps/web-react-router/app/routes/hitl-agent-chat.tsx
+++ b/apps/web-react-router/app/routes/hitl-agent-chat.tsx
@@ -1020,8 +1020,8 @@ export default function HITLAgentChatPage() {
 
                   <div className={cn("flex flex-col gap-2 max-w-[85%]", message.role === "user" && "items-end")}>
                     {message.role === "user" ? (
-                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
-                        <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{textContent}</p>
+                      <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden max-w-full">
+                        <p className="text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">{textContent}</p>
                       </div>
                     ) : (
                       <>

--- a/apps/web-react-router/app/routes/multi-agent-chat.tsx
+++ b/apps/web-react-router/app/routes/multi-agent-chat.tsx
@@ -369,8 +369,8 @@ export default function MultiAgentChatPage() {
                       <>
                         <FileMessageDisplay files={fileSegments} />
                         {textContent && (
-                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm">
-                            <p className="text-sm whitespace-pre-wrap">
+                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
+                            <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
                               {textContent}
                             </p>
                           </div>

--- a/apps/web-react-router/app/routes/multi-agent-chat.tsx
+++ b/apps/web-react-router/app/routes/multi-agent-chat.tsx
@@ -369,8 +369,8 @@ export default function MultiAgentChatPage() {
                       <>
                         <FileMessageDisplay files={fileSegments} />
                         {textContent && (
-                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
-                            <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden max-w-full">
+                            <p className="text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">
                               {textContent}
                             </p>
                           </div>

--- a/apps/web-react-router/app/routes/sernia-admin.tsx
+++ b/apps/web-react-router/app/routes/sernia-admin.tsx
@@ -341,8 +341,8 @@ function ConversationDetail({
                       }
                     />
                     {segments.some((s) => s.type === "text") && (
-                      <div className="bg-primary text-primary-foreground rounded-2xl px-3 py-2 shadow-sm">
-                        <p className="text-sm whitespace-pre-wrap">
+                      <div className="bg-primary text-primary-foreground rounded-2xl px-3 py-2 shadow-sm overflow-hidden min-w-0">
+                        <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
                           {segments.find((s) => s.type === "text")?.type ===
                           "text"
                             ? (
@@ -360,7 +360,7 @@ function ConversationDetail({
                         key={i}
                         className="bg-muted/50 rounded-2xl px-3 py-2 shadow-sm overflow-hidden"
                       >
-                        <div className="text-sm prose prose-sm dark:prose-invert max-w-none break-words">
+                        <div className="text-sm prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
                           <Markdown>{seg.content}</Markdown>
                         </div>
                       </div>

--- a/apps/web-react-router/app/routes/sernia-admin.tsx
+++ b/apps/web-react-router/app/routes/sernia-admin.tsx
@@ -341,8 +341,8 @@ function ConversationDetail({
                       }
                     />
                     {segments.some((s) => s.type === "text") && (
-                      <div className="bg-primary text-primary-foreground rounded-2xl px-3 py-2 shadow-sm overflow-hidden min-w-0">
-                        <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                      <div className="bg-primary text-primary-foreground rounded-2xl px-3 py-2 shadow-sm overflow-hidden max-w-full">
+                        <p className="text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">
                           {segments.find((s) => s.type === "text")?.type ===
                           "text"
                             ? (
@@ -360,7 +360,7 @@ function ConversationDetail({
                         key={i}
                         className="bg-muted/50 rounded-2xl px-3 py-2 shadow-sm overflow-hidden"
                       >
-                        <div className="text-sm prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
+                        <div className="text-sm prose prose-sm dark:prose-invert max-w-none [overflow-wrap:anywhere]">
                           <Markdown>{seg.content}</Markdown>
                         </div>
                       </div>

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -23,6 +23,7 @@ import {
   TabsContent,
 } from "~/components/ui/tabs";
 import {
+  AlertCircle,
   Building,
   StopCircle,
   Send,
@@ -118,6 +119,42 @@ function TypingIndicator() {
       </div>
     </div>
   );
+}
+
+// Backend error responses are JSON bodies like {"error": "friendly message"}.
+// The AI SDK surfaces the raw body as the Error message — unwrap it so users
+// see the friendly text instead of JSON.
+function formatStreamError(error: Error | undefined): string {
+  const fallback = "The response was interrupted.";
+  if (!error?.message) return fallback;
+  try {
+    const parsed = JSON.parse(error.message);
+    return parsed.error || fallback;
+  } catch {
+    return error.message;
+  }
+}
+
+// Lightweight signature for change detection between the rendered messages
+// and the DB copy. Streamed and DB-dumped messages carry different ids for
+// the same content, so compare role + visible content (text, tool call ids
+// and states) instead of ids.
+function messagesSignature(msgs: any[]): string {
+  return msgs
+    .map((m: any) => {
+      const parts = Array.isArray(m.parts) ? m.parts : [];
+      const content = parts
+        .map((p: any) =>
+          p.type === "text"
+            ? p.text
+            : p.toolCallId
+              ? `${p.toolCallId}:${p.state ?? ""}`
+              : p.type
+        )
+        .join("\u0000");
+      return `${m.role}:${content}`;
+    })
+    .join("\u0001");
 }
 
 // ---------------------------------------------------------------------------
@@ -226,11 +263,79 @@ function ChatView({
     })
   ).current;
 
-  const { messages, sendMessage, status, stop, setMessages } = useChat({
-    id: conversationId,
-    messages: initialMessages,
-    transport,
-  });
+  const { messages, sendMessage, status, stop, setMessages, error, clearError } =
+    useChat({
+      id: conversationId,
+      messages: initialMessages,
+      transport,
+    });
+
+  // Refs so async callbacks can read the latest values without re-subscribing
+  const statusRef = useRef(status);
+  statusRef.current = status;
+  const isProcessingApprovalRef = useRef(isProcessingApproval);
+  isProcessingApprovalRef.current = isProcessingApproval;
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
+  // Re-sync the chat from the DB (the authoritative source). useChat only
+  // reads its `messages` option at mount, so without this any response that
+  // finishes after the stream dies client-side (mobile tab suspension,
+  // network blip, provider error) stays invisible until a full page reload.
+  const syncFromServer = useCallback(async () => {
+    const busy = () =>
+      statusRef.current === "submitted" ||
+      statusRef.current === "streaming" ||
+      isProcessingApprovalRef.current;
+    if (busy()) return;
+    try {
+      const token = await getToken();
+      const res = await fetch(
+        `${API_BASE}/conversation/${conversationId}/messages`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!res.ok) return;
+      const data = await res.json();
+      // Re-check after the awaits — the user may have hit send meanwhile.
+      if (busy()) return;
+      const serverMessages: any[] = data.messages || [];
+      // Empty server copy = nothing persisted yet; keep local state.
+      if (serverMessages.length === 0) return;
+      if (
+        messagesSignature(serverMessages) !==
+        messagesSignature(messagesRef.current)
+      ) {
+        setMessages(serverMessages);
+        const allPending = convertAllPendingFromApi(data.pending);
+        setPendingApproval(allPending[0] ?? null);
+        setAllPendingApprovals(allPending);
+      }
+    } catch {
+      // Network failure — keep whatever we have.
+    }
+  }, [conversationId, getToken, setMessages]);
+
+  // Sync when the tab regains visibility or the network comes back.
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") syncFromServer();
+    };
+    const handleOnline = () => syncFromServer();
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("online", handleOnline);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("online", handleOnline);
+    };
+  }, [syncFromServer]);
+
+  // If the stream errors, the run may still have completed server-side (the
+  // backend persists via on_complete) — pull the authoritative copy.
+  useEffect(() => {
+    if (status === "error") {
+      syncFromServer();
+    }
+  }, [status, syncFromServer]);
 
   // Extract ALL pending approvals from latest assistant message
   // PydanticAI requires results for all deferred tool calls, so we need to track all of them
@@ -341,7 +446,7 @@ function ChatView({
       })),
     ];
     if (text) {
-      parts.push({ type: "text", text: input });
+      parts.push({ type: "text", text });
     }
     setPendingApproval(null);
     setAllPendingApprovals([]);
@@ -603,6 +708,29 @@ function ChatView({
               (status === "streaming" &&
                 messages[messages.length - 1]?.role !== "assistant")) && (
               <TypingIndicator />
+            )}
+            {status === "error" && (
+              <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:bg-red-950/20 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+                <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <p>{formatStreamError(error)}</p>
+                  <p className="text-xs opacity-80 mt-1">
+                    If the response finished in the background, reloading will
+                    show it.
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="shrink-0"
+                  onClick={() => {
+                    clearError();
+                    syncFromServer();
+                  }}
+                >
+                  Reload messages
+                </Button>
+              </div>
             )}
             <div
               ref={messagesEndRef}
@@ -1187,12 +1315,10 @@ export default function SerniaChatPage() {
   const loadConversation = useCallback(
     async (
       convId: string,
-      opts?: { updateUrl?: boolean; modality?: string; silent?: boolean }
+      opts?: { updateUrl?: boolean; modality?: string }
     ) => {
       if (!isSignedIn) return;
-      if (!opts?.silent) {
-        setLoadedMessages(null);
-      }
+      setLoadedMessages(null);
 
       try {
         const token = await getToken();
@@ -1203,10 +1329,8 @@ export default function SerniaChatPage() {
 
         if (!res.ok) {
           console.error("Failed to load conversation");
-          if (!opts?.silent) {
-            navigate("/sernia-chat", { replace: true });
-            setLoadedMessages([]);
-          }
+          navigate("/sernia-chat", { replace: true });
+          setLoadedMessages([]);
           return;
         }
 
@@ -1226,10 +1350,8 @@ export default function SerniaChatPage() {
         }
       } catch (err) {
         console.error("Failed to load conversation:", err);
-        if (!opts?.silent) {
-          navigate("/sernia-chat", { replace: true });
-          setLoadedMessages([]);
-        }
+        navigate("/sernia-chat", { replace: true });
+        setLoadedMessages([]);
       }
     },
     [isSignedIn, getToken, navigate]
@@ -1250,21 +1372,10 @@ export default function SerniaChatPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSignedIn, urlConversationId]);
 
-  // Re-fetch conversation when page regains visibility
-  useEffect(() => {
-    const handleVisibility = () => {
-      if (
-        document.visibilityState === "visible" &&
-        isSignedIn &&
-        conversationId
-      ) {
-        loadConversation(conversationId, { updateUrl: false, silent: true });
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
-    return () =>
-      document.removeEventListener("visibilitychange", handleVisibility);
-  }, [isSignedIn, conversationId, loadConversation]);
+  // NOTE: re-syncing the open conversation on visibility regain lives inside
+  // ChatView (which owns the useChat state) — useChat only reads its
+  // `messages` option at mount, so updating loadedMessages here wouldn't
+  // reach the rendered chat.
 
   // Listen for service worker messages (notification click)
   useEffect(() => {

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -646,8 +646,8 @@ function ChatView({
                           files={segments.filter((s) => s.type === "file") as any}
                         />
                         {segments.some((s) => s.type === "text") && (
-                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm">
-                            <p className="text-sm whitespace-pre-wrap">
+                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
+                            <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
                               {segments.find((s) => s.type === "text")?.type === "text"
                                 ? (segments.find((s) => s.type === "text") as any).content
                                 : ""}

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -646,8 +646,8 @@ function ChatView({
                           files={segments.filter((s) => s.type === "file") as any}
                         />
                         {segments.some((s) => s.type === "text") && (
-                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
-                            <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                          <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden max-w-full">
+                            <p className="text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">
                               {segments.find((s) => s.type === "text")?.type === "text"
                                 ? (segments.find((s) => s.type === "text") as any).content
                                 : ""}
@@ -660,7 +660,7 @@ function ChatView({
                         {segments.map((seg, i) =>
                           seg.type === "text" ? (
                             <div key={i} className="bg-muted/50 rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
-                              <div className="text-sm prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
+                              <div className="text-sm prose prose-sm dark:prose-invert max-w-none [overflow-wrap:anywhere]">
                                 <Markdown>{seg.content}</Markdown>
                               </div>
                             </div>


### PR DESCRIPTION
**Preview:** https://react-router-portfolio-pr-267.up.railway.app/

## The bug ("sometimes I need to refresh to see the model message")

Two compounding issues in `sernia-chat.tsx`:

1. **The visibility-regain refetch never reached the rendered chat.** `useChat` (AI SDK v5) only reads its `messages` option when the Chat instance is created (mount / id change). The page-level `visibilitychange` handler refetched from the DB and called `setLoadedMessages`, but that prop update is ignored after mount — so any response that finished after the client stream died (mobile tab suspension, network blip, provider 529) stayed invisible until a full page reload.
2. **Stream errors were completely silent.** `useChat`'s `error` / `status === "error"` were never rendered — the typing indicator just vanished with no message.

## Fixes

- **DB re-sync now lives inside `ChatView`** where it can apply via `setMessages`. It fires on tab visibility regain, network `online`, and automatically after a stream error (the backend persists the run via `on_complete`, so the response is usually recoverable). Guards prevent clobbering an active stream or in-flight approval round, and a content signature comparison avoids pointless re-renders when nothing changed. Bonus: SMS conversations viewed in web chat now pick up new messages on refocus too.
- **Error banner** with the backend's friendly error text (unwrapped from the JSON body) and a "Reload messages" action.
- **Initial scroll-to-bottom** when opening a conversation with history (`use-scroll-to-bottom` previously only reacted to mutations, so old conversations opened scrolled to the top — benefits all chat pages).
- **Minor:** trimmed input text is now what gets sent; fixed two pre-existing typecheck errors (stale `@ts-expect-error` in `markdown.tsx`, nonexistent `FileUIPart.mimeType` in `chat-emilio.tsx`). `pnpm typecheck` is now clean.

## Verification

- `pnpm typecheck` passes (was failing on main with 2 errors)
- `pnpm build` passes
- Dev server smoke test: `/sernia-chat` SSR renders (HTTP 200)

https://claude.ai/code/session_01HXUtPgBQmrisDidSgAGVow