### PR TITLE
Upgrade pydantic-ai 1.77 → 1.106: migrate Sernia AI to core capabilities API

### DIFF
--- a/api/src/ai_demos/chat_emilio/agent.py
+++ b/api/src/ai_demos/chat_emilio/agent.py
@@ -7,6 +7,7 @@ Each information source has its own tool that fetches from a specific URL.
 import logfire
 from dataclasses import dataclass
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities import Instrumentation
 from dotenv import load_dotenv
 import httpx
 import pytest
@@ -34,7 +35,7 @@ agent = Agent(
     "anthropic:claude-haiku-4-5-20251001",
     system_prompt=SYSTEM_INSTRUCTIONS,
     retries=3,
-    instrument=True,
+    capabilities=[Instrumentation()],
     name="chat_emilio",
 )
 

--- a/api/src/ai_demos/hitl_agents/hitl_sms_agent.py
+++ b/api/src/ai_demos/hitl_agents/hitl_sms_agent.py
@@ -13,6 +13,7 @@ import logfire
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, AgentRunResult, DeferredToolRequests
+from pydantic_ai.capabilities import Instrumentation
 from pydantic_ai.durable_exec.dbos import DBOSAgent
 from dbos import DBOS
 from pydantic_ai.models.openai import OpenAIChatModel
@@ -48,7 +49,7 @@ The default recipient is Emilio unless otherwise specified.
 Do not ask for confirmation - the tool has approval safeguards built in.""",
     output_type=[str, DeferredToolRequests],
     retries=2,
-    instrument=True,
+    capabilities=[Instrumentation()],
 )
 
 @DBOS.step()

--- a/api/src/ai_demos/hitl_agents/offline_examples/hitl_agent1_simplest.py
+++ b/api/src/ai_demos/hitl_agents/offline_examples/hitl_agent1_simplest.py
@@ -26,6 +26,7 @@ from pydantic_ai import (
     ApprovalRequired,
     AgentRunResult,
 )
+from pydantic_ai.capabilities import Instrumentation
 from pydantic_core import to_jsonable_python
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.messages import ModelMessagesTypeAdapter
@@ -49,7 +50,7 @@ The default recipient will be Emilio unless otherwise specified.
 Do not ask for confirmation - the tool has approval safeguards.""",
     output_type=[str, DeferredToolRequests],
     retries=2,
-    instrument=True,
+    capabilities=[Instrumentation()],
 )
 
 

--- a/api/src/ai_demos/hitl_agents/offline_examples/hitl_agent2_dbos.py
+++ b/api/src/ai_demos/hitl_agents/offline_examples/hitl_agent2_dbos.py
@@ -25,6 +25,7 @@ from pydantic_ai import (
     ApprovalRequired, 
     AgentRunResult,
 )
+from pydantic_ai.capabilities import Instrumentation
 from pydantic_ai.durable_exec.dbos import DBOSAgent
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.messages import ModelMessagesTypeAdapter
@@ -47,7 +48,7 @@ The default recipient will be Emilio unless otherwise specified.
 Do not ask for confirmation - the tool has approval safeguards.""",
     output_type=[str, DeferredToolRequests],
     retries=2,
-    instrument=True,
+    capabilities=[Instrumentation()],
 )
 
 

--- a/api/src/ai_demos/hitl_utils.py
+++ b/api/src/ai_demos/hitl_utils.py
@@ -8,8 +8,6 @@ import dataclasses
 import json
 from dataclasses import dataclass
 
-from collections.abc import Sequence
-
 from pydantic_ai import (
     Agent,
     AgentRunResult,
@@ -18,7 +16,6 @@ from pydantic_ai import (
     ToolApproved,
     ToolDenied,
 )
-from pydantic_ai.builtin_tools import AbstractBuiltinTool
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -119,7 +116,6 @@ async def resume_with_approvals(
     user_message: str | None = None,
     model: Model | KnownModelName | str | None = None,
     model_settings: ModelSettings | None = None,
-    builtin_tools: Sequence[AbstractBuiltinTool] | None = None,
 ) -> AgentRunResult:
     """
     Resume a paused agent with approval decisions. Agent-agnostic.
@@ -137,10 +133,10 @@ async def resume_with_approvals(
             it persists in history as a normal UserPromptPart. Use this for
             "deny with feedback" flows where the user wants their reply stored
             as a regular message, not just as a tool-denial reason.
-        model, model_settings, builtin_tools: Optional per-run overrides
-            forwarded to agent.run(). Callers needing model switching (e.g.
-            Sernia AI's DB-backed model picker) pass these to override the
-            Agent's construction-time defaults.
+        model, model_settings: Optional per-run overrides forwarded to
+            agent.run(). Callers needing model switching (e.g. Sernia AI's
+            DB-backed model picker) pass these to override the Agent's
+            construction-time defaults.
     """
     async with provide_session(session) as s:
         messages = await get_conversation_messages(conversation_id, clerk_user_id, session=s)
@@ -181,8 +177,6 @@ async def resume_with_approvals(
         run_overrides["model"] = model
     if model_settings is not None:
         run_overrides["model_settings"] = model_settings
-    if builtin_tools is not None:
-        run_overrides["builtin_tools"] = builtin_tools
 
     result = await agent.run(
         user_prompt=user_message,

--- a/api/src/ai_demos/multi_agent_chat/graph.py
+++ b/api/src/ai_demos/multi_agent_chat/graph.py
@@ -10,7 +10,8 @@ from typing import Literal
 import pytest
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict
-from pydantic_graph.beta import GraphBuilder, StepContext
+from pydantic_graph.graph_builder import GraphBuilder
+from pydantic_graph.step import StepContext
 from starlette.requests import Request
 from starlette.responses import Response
 

--- a/api/src/ai_demos/multi_agent_chat/routes.py
+++ b/api/src/ai_demos/multi_agent_chat/routes.py
@@ -150,7 +150,11 @@ async def multi_agent_chat(request: Request) -> Response:
     request._body = json.dumps(sanitized_json).encode()
 
     user_message = _extract_latest_message_text(sanitized_json)
-    message_history = sanitized_json.get("messages") or None
+    # No explicit message_history: VercelAIAdapter parses the full
+    # conversation (history + latest prompt) from the request body itself.
+    # `message_history` is only for *additional* ModelMessage objects (e.g.
+    # DB-loaded history) — raw Vercel UI dicts are rejected by pydantic-ai
+    # >=1.9x ("'dict' object has no attribute 'parts'").
 
     if sanitized_json.get('trigger') == 'submit-message':
         logfire.info(
@@ -164,9 +168,8 @@ async def multi_agent_chat(request: Request) -> Response:
         agent_run_method="vercel_ai",
         vercel_ai_request=request,
         message=user_message,
-        message_history=message_history,
     )
-    input_data = MultiAgentInput(message=user_message, message_history=message_history)
+    input_data = MultiAgentInput(message=user_message)
     graph_result = await multi_agent_graph.run(state=state, inputs=input_data)
 
     response = graph_result.response

--- a/api/src/sernia_ai/PLAN.md
+++ b/api/src/sernia_ai/PLAN.md
@@ -28,15 +28,15 @@
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| **LLM (main agent)** | Runtime-switchable via the `model_config` app_setting (default GPT-5.4). Supported: `openai-responses:gpt-5.4`, `anthropic:claude-sonnet-4-6`, `anthropic:claude-opus-4-7`. See `model_config.py`. | `WebSearchTool` works across all three providers. `WebFetchTool` is Anthropic-only and is added per-run only when an Anthropic model is selected. |
+| **LLM (main agent)** | Runtime-switchable via the `model_config` app_setting (default GPT-5.4). Supported: `openai-responses:gpt-5.4`, `anthropic:claude-sonnet-4-6`, `anthropic:claude-opus-4-7`. See `model_config.py`. | Native web search works across all three providers. Native web fetch is Anthropic-only; the `WebFetch` capability drops it automatically on OpenAI runs. |
 | **LLM (sub-agents)** | Claude Haiku 4.5 (`anthropic:claude-haiku-4-5-20251001`) | Cost savings for summarization/compaction. |
-| **Framework** | PydanticAI (latest stable API) | `instructions` list, `FileSystemToolset`, `builtin_tools`, `history_processors`. |
+| **Framework** | PydanticAI (latest stable API) | `instructions` list, `FileSystemToolset`, capabilities (`WebSearch`/`WebFetch`/`ProcessHistory`/`Instrumentation`/skills). |
 | **Code location** | `api/src/sernia_ai/` | Dedicated module. Imports from existing services. |
 | **Conversation storage** | `agent_conversations` table | Shared with other demo agents. Columns: `modality`, `contact_identifier`, `estimated_tokens`, `metadata_`. |
 | **Quo/OpenPhone** | FastMCP OpenAPI bridge + custom guards | OpenPhone REST API spec → MCP tools. Custom `send_internal_sms` / `send_external_sms` with deterministic contact gates + from-phone enforcement. |
 | **Memory storage** | `pydantic-ai-filesystem-sandbox` `FileSystemToolset` | Sandboxed `.workspace/` with `.md`, `.txt`, `.json` suffixes. Custom `search_files` tool for grep. |
 | **Git sync** | `memory/git_sync.py` | `.workspace/` backed by `EmilioEsposito/sernia-knowledge` GitHub repo via PAT. Clone/pull on startup, commit+push after each agent turn. |
-| **Web research** | PydanticAI `WebSearchTool` + `WebFetchTool` | Domain allowlist in `config.py`. |
+| **Web research** | PydanticAI `WebSearch` + `WebFetch` capabilities | Domain allowlist in `config.py`, enforced natively. |
 | **Push notifications** | W3C Web Push + VAPID | No vendor lock-in. Per-device subscriptions, auto-cleanup of expired endpoints. |
 | **Triggers** | Background agent runs + push notifications | SMS via webhook extension, email via APScheduler. Agent creates web chat conversations when human attention needed. |
 
@@ -113,10 +113,13 @@ sernia_agent = Agent(
     deps_type=SerniaDeps,
     instructions=[STATIC_INSTRUCTIONS, *DYNAMIC_INSTRUCTIONS],
     output_type=[str, NoAction, DeferredToolRequests],
-    builtin_tools=[WebSearchTool(...), WebFetchTool(...)],
     toolsets=[filesystem_toolset, quo_toolset, google_toolset,
              clickup_toolset, db_search_toolset, code_toolset],
-    history_processors=[summarize_tool_results, compact_history],
+    capabilities=[skills_capability,
+                  WebSearch(...), WebFetch(...),
+                  ProcessHistory(summarize_tool_results),
+                  ProcessHistory(compact_history),
+                  Instrumentation()],
 )
 ```
 
@@ -147,7 +150,7 @@ All in `instructions.py`, passed as `instructions=[STATIC_INSTRUCTIONS, *DYNAMIC
 
 ### Token Management
 
-Two `history_processors` run before each model request (order matters):
+Two history processors (wired as `ProcessHistory` capabilities) run before each model request (order matters):
 
 1. **`summarize_tool_results`** — Shrinks oversized `ToolReturnPart`s (>10k chars) in older messages via Haiku sub-agent. Current turn results are never touched.
 2. **`compact_history`** — When input tokens exceed 170k (~85% of 200k window), summarizes older half of conversation into a single summary message via Haiku sub-agent.
@@ -296,7 +299,7 @@ The frontend uses `trigger_source` and `trigger_contact_name` to render icons (P
 | `run_python` | Secure Python sandbox (pydantic-monty). Math, dates, regex. No FS/network. |
 | `search_files` | Case-insensitive grep across workspace files |
 | File tools (`read_file`, `write_file`, `edit_file`, etc.) | Sandboxed `.workspace/` access via `FileSystemToolset` |
-| `WebSearchTool` / `WebFetchTool` | Web research with domain allowlist |
+| `WebSearch` / `WebFetch` capabilities | Web research with domain allowlist |
 
 ---
 
@@ -504,8 +507,8 @@ Core function shared by all triggers:
 | `instructions=[str, *fns]` list | Static + dynamic instructions — functions take `RunContext[SerniaDeps]` |
 | `FileSystemToolset` + `Sandbox` | Sandboxed file access with mount config, suffix allowlist |
 | `FunctionToolset` | Grouping related tools (quo, google, clickup, etc.) |
-| `builtin_tools=[WebSearchTool(), WebFetchTool()]` | Web research with domain filtering (Anthropic-only) |
-| `history_processors=[fn]` | Token-aware compaction before each model call |
+| `WebSearch` / `WebFetch` capabilities | Provider-adaptive web research with domain filtering (fetch is Anthropic-only) |
+| `ProcessHistory(fn)` capabilities | Token-aware compaction before each model call |
 | `FastMCPToolset` | Bridge OpenAPI specs into PydanticAI toolsets (OpenPhone) |
 | `output_type=[str, NoAction, DeferredToolRequests]` | HITL approval flow + silent triggers |
 | `RunContext[SerniaDeps]` | Access deps in tools and instructions |

--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -9,7 +9,7 @@ Built with **PydanticAI** (Graph Beta API), **FastAPI**, and integrated with Ope
 - **Agent** (`agent.py`) — Main PydanticAI agent with tool use, sub-agents, and persistent memory
 - **Instructions** (`instructions.py`) — Static system prompt + dynamic context injection (datetime, memory, filetree, modality, triggers)
 - **Config** (`config.py`) — Phone IDs, rate limits, and other tunables
-- **Model config** (`model_config.py`) — Runtime-switchable main-agent model (GPT-5.4 / Sonnet 4.6 / Opus 4.7), resolved per run via the `model_config` app_setting. `WebFetchTool` is attached only when an Anthropic model is active.
+- **Model config** (`model_config.py`) — Runtime-switchable main-agent model (GPT-5.4 / Sonnet 4.6 / Opus 4.7), resolved per run via the `model_config` app_setting. Web search/fetch live on the agent as provider-adaptive `WebSearch`/`WebFetch` capabilities (native web fetch is Anthropic-only and is dropped automatically on OpenAI runs).
 - **Routes** (`routes.py`) — FastAPI endpoints for chat, conversations, approvals, and admin
 
 ## Documentation

--- a/api/src/sernia_ai/agent.py
+++ b/api/src/sernia_ai/agent.py
@@ -7,12 +7,14 @@ HITL approval flow, and core toolsets (Quo, Gmail, Calendar, ClickUp, DB search)
 Model selection is runtime-configurable via the ``model_config`` app_setting.
 Call sites resolve the active model via ``model_config.resolve_active_run_kwargs()``
 and spread the result into ``agent.run()`` / ``VercelAIAdapter.dispatch_request()``.
-The ``model``/``model_settings`` / extra ``builtin_tools`` passed at run-time
-override what's configured here.
+The ``model``/``model_settings`` passed at run-time override what's configured
+here. Web search/fetch are provider-adaptive capabilities on the agent itself.
 """
 import logfire
 from pydantic import BaseModel
-from pydantic_ai import Agent, DeferredToolRequests, RunContext, WebSearchTool
+from pydantic_ai import Agent, DeferredToolRequests, RunContext
+from pydantic_ai.capabilities import Instrumentation, ProcessHistory, WebFetch, WebSearch
+from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
 from pydantic_ai_filesystem_sandbox import FileSystemToolset, Mount, Sandbox, SandboxConfig
 
 
@@ -79,11 +81,6 @@ sernia_agent = Agent(
     deps_type=SerniaDeps,
     instructions=[STATIC_INSTRUCTIONS, *DYNAMIC_INSTRUCTIONS],
     output_type=[str, NoAction, DeferredToolRequests],  # HITL foundation + silent triggers
-    # Cross-provider baseline: WebSearchTool works on OpenAI Responses,
-    # Anthropic, Google, Groq, xAI, and OpenRouter. Provider-specific builtins
-    # (WebFetchTool on Anthropic) and model_settings come in per-run via
-    # model_config.build_run_kwargs().
-    builtin_tools=[WebSearchTool(allowed_domains=WEB_SEARCH_ALLOWED_DOMAINS)],
     toolsets=[
         ErrorLoggingToolset(filesystem_toolset.prefixed("workspace"), name="workspace"),
         ErrorLoggingToolset(quo_toolset.prefixed("quo"), name="quo"),
@@ -94,9 +91,34 @@ sernia_agent = Agent(
         ErrorLoggingToolset(code_toolset, name="code"),
         ErrorLoggingToolset(duckdb_toolset, name="duckdb"),
     ],
-    capabilities=[skills_capability],
-    history_processors=[summarize_tool_results, compact_history],
-    instrument=True,
+    capabilities=[
+        skills_capability,
+        # Provider-adaptive web tools (pydantic-ai core capabilities). Native
+        # web search works on both OpenAI Responses and Anthropic. Native web
+        # fetch is Anthropic-only — `optional=True` silently drops a tool on
+        # models that don't support it, which replaces the old per-run
+        # WebFetchTool attachment in model_config.build_run_kwargs().
+        # local=False keeps behavior identical to the old builtin_tools
+        # setup: no local fallback tool (allowed_domains is only enforced by
+        # native tools, so a local fallback would bypass the domain
+        # allowlist). The domains are set on the native tool instances, not
+        # the capability, because capability-level domain constraints force
+        # native-required mode, which raises instead of dropping.
+        WebSearch(
+            native=WebSearchTool(allowed_domains=WEB_SEARCH_ALLOWED_DOMAINS, optional=True),
+            local=False,
+        ),
+        WebFetch(
+            native=WebFetchTool(allowed_domains=WEB_SEARCH_ALLOWED_DOMAINS, optional=True),
+            local=False,
+        ),
+        # History processors run in capability order before each model
+        # request: oversized tool-result summarization first, then whole-
+        # history compaction (same order as the old history_processors list).
+        ProcessHistory(summarize_tool_results),
+        ProcessHistory(compact_history),
+        Instrumentation(),
+    ],
     name=AGENT_NAME,
 )
 

--- a/api/src/sernia_ai/config.py
+++ b/api/src/sernia_ai/config.py
@@ -7,8 +7,9 @@ import os
 from pathlib import Path
 
 # Web search / fetch: only these domains are allowed.
-# Used by WebSearchTool (Anthropic, OpenAI Responses, Groq, Google, xAI, OpenRouter)
-# and WebFetchTool (Anthropic, Google) — see pydantic_ai.builtin_tools.
+# Used by the WebSearch (native on Anthropic, OpenAI Responses, Groq, Google,
+# xAI, OpenRouter) and WebFetch (native on Anthropic, Google) capabilities —
+# see pydantic_ai.capabilities and agent.py.
 WEB_SEARCH_ALLOWED_DOMAINS: list[str] = [
     "zillow.com",
     "redfin.com",

--- a/api/src/sernia_ai/model_config.py
+++ b/api/src/sernia_ai/model_config.py
@@ -6,12 +6,19 @@ The main agent model is user-switchable via the ``model_config`` row in
 ``resolve_active_run_kwargs()`` and spread the result into ``agent.run(...)``
 / ``VercelAIAdapter.dispatch_request(...)`` / ``resume_with_approvals(...)``.
 
-Why per-run and not per-agent: builtin tools like ``WebFetchTool`` only work
-on Anthropic/Google, and model settings classes (``AnthropicModelSettings``
-vs ``OpenAIResponsesModelSettings``) are not cross-compatible. PydanticAI
-exposes ``model`` / ``model_settings`` / ``builtin_tools`` on every run
-entrypoint, so one Agent instance with per-run overrides is simpler than
-maintaining one Agent per provider.
+Why per-run and not per-agent: model settings classes
+(``AnthropicModelSettings`` vs ``OpenAIResponsesModelSettings``) are not
+cross-compatible — prompt-cache knobs are provider-specific. PydanticAI
+exposes ``model`` / ``model_settings`` on every run entrypoint, so one Agent
+instance with per-run overrides is simpler than maintaining one Agent per
+provider.
+
+Web search/fetch are no longer attached here: the agent's ``WebSearch`` /
+``WebFetch`` capabilities (see ``agent.py``) adapt to the active provider
+automatically (native web fetch is Anthropic-only and is dropped on OpenAI
+runs). Thinking depth uses the unified ``thinking`` model setting, which
+pydantic-ai maps to adaptive thinking + effort on Anthropic and
+``reasoning_effort`` on OpenAI.
 """
 from __future__ import annotations
 
@@ -19,14 +26,10 @@ from dataclasses import dataclass
 from typing import Literal, cast, get_args
 
 import logfire
-from pydantic_ai import WebFetchTool
-from pydantic_ai.builtin_tools import AbstractBuiltinTool
 from pydantic_ai.models.anthropic import AnthropicModelSettings
 from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 from pydantic_ai.settings import ModelSettings
 from sqlalchemy import select
-
-from api.src.sernia_ai.config import WEB_SEARCH_ALLOWED_DOMAINS
 
 ModelKey = Literal["gpt-5.4", "sonnet-4-6", "opus-4-7"]
 ThinkingEffort = Literal["low", "medium", "high"]
@@ -85,42 +88,39 @@ def get_thinking_effort(value: str | None) -> ThinkingEffort:
 def build_run_kwargs(key: str | None, effort: str | None = None) -> dict:
     """Return kwargs to spread into agent.run() / VercelAIAdapter.dispatch_request().
 
-    Produces ``model``, ``model_settings``, and ``builtin_tools`` suited to the
-    selected provider. ``WebFetchTool`` is added only for Anthropic (OpenAI
-    Responses does not support it and would raise ``UserError``).
+    Produces ``model`` and ``model_settings`` suited to the selected provider.
+    The only provider-specific parts left are the prompt-cache knobs; web
+    search/fetch live on the agent as provider-adaptive capabilities.
 
-    ``effort`` controls reasoning depth — low/medium/high. For Sonnet 4.6 and
-    Opus 4.7 this enables adaptive thinking
+    ``effort`` controls reasoning depth — low/medium/high — via the unified
+    ``thinking`` model setting. On Sonnet 4.6 and Opus 4.7 pydantic-ai maps it
+    to adaptive thinking + effort
     (https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking),
-    where Claude decides per-request whether and how much to think. For
-    GPT-5.4 it maps to ``openai_reasoning_effort``. Defaults to medium.
+    where Claude decides per-request whether and how much to think. On GPT-5.4
+    it maps to ``reasoning_effort``. Defaults to medium.
     """
     choice = get_model_choice(key)
     resolved_effort = get_thinking_effort(effort)
     settings: ModelSettings
-    extra_builtins: list[AbstractBuiltinTool] = []
 
     if choice.provider == "anthropic":
         settings = AnthropicModelSettings(
             anthropic_cache_instructions=True,
             anthropic_cache_tool_definitions=True,
             anthropic_cache_messages=True,
-            anthropic_thinking={"type": "adaptive"},
-            anthropic_effort=resolved_effort,
+            thinking=resolved_effort,
         )
-        extra_builtins.append(WebFetchTool(allowed_domains=WEB_SEARCH_ALLOWED_DOMAINS))
     else:  # openai
         # `openai_prompt_cache_retention="24h"` extends the default ~5–10 min
         # in-memory cache to 24h so infrequent scheduled runs still hit cache.
         settings = OpenAIResponsesModelSettings(
-            openai_reasoning_effort=resolved_effort,
+            thinking=resolved_effort,
             openai_prompt_cache_retention="24h",
         )
 
     return {
         "model": choice.model_string,
         "model_settings": settings,
-        "builtin_tools": extra_builtins,
     }
 
 

--- a/api/src/sernia_ai/routes.py
+++ b/api/src/sernia_ai/routes.py
@@ -636,7 +636,7 @@ async def _resolve_tool_overview(deps: SerniaDeps) -> dict:
 
     Uses ``Toolset.get_tools(ctx)`` — the same call PydanticAI makes when
     packaging tools for the model — so the preview is bit-for-bit what gets
-    injected (modulo per-run builtin_tools added by ``model_config``).
+    injected (native web search/fetch tools are listed separately below).
     """
     from pydantic_ai import RunContext
     from pydantic_ai.usage import RunUsage
@@ -706,14 +706,14 @@ async def _resolve_tool_overview(deps: SerniaDeps) -> dict:
         if content:
             toolset_instructions.append({"label": label, "content": str(content)})
 
-    # Builtin tools (web search/fetch). The agent stores its construction-time
-    # set on a private attr; the active model also adds run-specific builtins
-    # (e.g. WebFetchTool on Anthropic) — surface both for an honest picture.
+    # Native tools (web search/fetch) contributed by the WebSearch/WebFetch
+    # capabilities. The agent collects them on ``_cap_native_tools`` at
+    # construction; which ones actually reach the model is resolved per run
+    # based on provider support (e.g. WebFetchTool is dropped on OpenAI).
     builtins: list[dict] = []
     seen: set[str] = set()
-    base_builtins = getattr(sernia_agent, "_cap_builtin_tools", []) or []
-    run_kwargs = await resolve_active_run_kwargs()
-    for bt in list(base_builtins) + list(run_kwargs.get("builtin_tools") or []):
+    base_builtins = getattr(sernia_agent, "_cap_native_tools", []) or []
+    for bt in list(base_builtins):
         kind = getattr(bt, "kind", type(bt).__name__)
         if kind in seen:
             continue

--- a/api/src/sernia_ai/sub_agents/compact_history.py
+++ b/api/src/sernia_ai/sub_agents/compact_history.py
@@ -8,6 +8,7 @@ then summarizes the older half of the conversation when approaching 85% of the w
 
 import logfire
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities import Instrumentation
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -35,7 +36,7 @@ _compactor = Agent(
         "Be thorough but concise. Use bullet points. "
         "The summary will replace the original messages, so nothing important should be lost."
     ),
-    instrument=True,
+    capabilities=[Instrumentation()],
     name="history_compactor",
 )
 

--- a/api/src/sernia_ai/sub_agents/summarize_tool_results.py
+++ b/api/src/sernia_ai/sub_agents/summarize_tool_results.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 
 import logfire
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities import Instrumentation
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -29,7 +30,7 @@ _summarizer = Agent(
         "Omit boilerplate, repeated headers, and raw formatting. "
         "Keep the summary under 500 words."
     ),
-    instrument=True,
+    capabilities=[Instrumentation()],
     name="tool_result_summarizer",
 )
 

--- a/api/src/sernia_ai/tools/google_tools.py
+++ b/api/src/sernia_ai/tools/google_tools.py
@@ -18,6 +18,7 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload
 import logfire
 from pydantic_ai import Agent, ApprovalRequired, FunctionToolset, RunContext
+from pydantic_ai.capabilities import Instrumentation
 
 from api.src.google.calendar.service import (
     CalendarEventInput,
@@ -203,7 +204,7 @@ _email_summarizer = Agent(
         "Omit boilerplate, disclaimers, and formatting artifacts. "
         "Keep the summary under 300 words."
     ),
-    instrument=True,
+    capabilities=[Instrumentation()],
     name="email_content_summarizer",
 )
 

--- a/api/src/tests/test_history_processors.py
+++ b/api/src/tests/test_history_processors.py
@@ -37,6 +37,22 @@ from api.src.sernia_ai.sub_agents.compact_history import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_summary_cache():
+    """Reset the module-level summary cache between tests.
+
+    In production, tool_call_ids are globally unique so the cache never
+    collides. Tests reuse short ids like "call_1" across cases, so without
+    this reset a summary cached by one test leaks into the next (the source
+    of long-standing order-dependent failures in this file).
+    """
+    from api.src.sernia_ai.sub_agents.summarize_tool_results import _summary_cache
+
+    _summary_cache.clear()
+    yield
+    _summary_cache.clear()
+
+
 # ---------------------------------------------------------------------------
 # Realistic tool result generators
 # ---------------------------------------------------------------------------
@@ -138,10 +154,16 @@ class TestSmoke:
     """Verify that the agent loads with history processors wired up."""
 
     def test_agent_import_and_processors_wired(self):
-        """sernia_agent should import and have both history_processors attached."""
+        """sernia_agent should import with both ProcessHistory capabilities attached."""
+        from pydantic_ai.capabilities import ProcessHistory
+
         from api.src.sernia_ai.agent import sernia_agent
-        processors = sernia_agent.history_processors
-        assert processors is not None
+
+        processors = [
+            cap.processor
+            for cap in sernia_agent.root_capability.capabilities
+            if isinstance(cap, ProcessHistory)
+        ]
         assert len(processors) == 2
         # Order: summarization first, compaction second
         assert processors[0] is summarize_tool_results

--- a/api/src/tests/test_model_config.py
+++ b/api/src/tests/test_model_config.py
@@ -1,19 +1,26 @@
-"""Smoke tests for sernia_ai.model_config — keeps the runtime model picker honest."""
+"""Smoke tests for sernia_ai.model_config — keeps the runtime model picker honest.
+
+Since the pydantic-ai 1.106 upgrade, web search/fetch are provider-adaptive
+capabilities on the agent itself (see test_sernia_agent_wiring.py), and
+thinking depth uses the unified ``thinking`` model setting instead of the
+provider-specific ``anthropic_thinking``/``openai_reasoning_effort`` knobs.
+"""
 import pytest
-from pydantic_ai import WebFetchTool
 
 
-def test_build_run_kwargs_openai_has_no_webfetch():
+def test_build_run_kwargs_openai_shape():
     from api.src.sernia_ai.model_config import build_run_kwargs
 
     kw = build_run_kwargs("gpt-5.4")
     assert kw["model"] == "openai-responses:gpt-5.4"
-    assert kw["builtin_tools"] == []
-    # OpenAI Responses settings include the reasoning + cache retention knobs.
+    # No per-run native tools anymore — web search/fetch live on the agent
+    # as provider-adaptive capabilities.
+    assert "builtin_tools" not in kw
+    # OpenAI Responses settings include the cache retention knob.
     assert kw["model_settings"].get("openai_prompt_cache_retention") == "24h"
 
 
-def test_build_run_kwargs_anthropic_models_get_webfetch():
+def test_build_run_kwargs_anthropic_shape():
     from api.src.sernia_ai.model_config import build_run_kwargs
 
     for key, expected in (
@@ -22,9 +29,7 @@ def test_build_run_kwargs_anthropic_models_get_webfetch():
     ):
         kw = build_run_kwargs(key)
         assert kw["model"] == expected, f"{key}: wrong model string {kw['model']!r}"
-        assert any(isinstance(t, WebFetchTool) for t in kw["builtin_tools"]), (
-            f"{key}: expected a WebFetchTool in builtin_tools"
-        )
+        assert "builtin_tools" not in kw
         # Anthropic caching is enabled on all three layers.
         settings = kw["model_settings"]
         assert settings.get("anthropic_cache_instructions") is True
@@ -46,46 +51,48 @@ def test_default_thinking_effort_is_medium():
     assert DEFAULT_THINKING_EFFORT == "medium"
 
 
-def test_anthropic_models_get_adaptive_thinking_with_default_effort():
-    """Sonnet 4.6 / Opus 4.7 enable adaptive thinking + medium effort by default."""
+@pytest.mark.parametrize("key", ["gpt-5.4", "sonnet-4-6", "opus-4-7"])
+def test_unified_thinking_defaults_to_medium(key: str):
+    """All models get the unified `thinking` setting (pydantic-ai maps it to
+    adaptive thinking + effort on Anthropic, reasoning_effort on OpenAI)."""
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    for key in ("sonnet-4-6", "opus-4-7"):
-        kw = build_run_kwargs(key)
-        settings = kw["model_settings"]
-        assert settings.get("anthropic_thinking") == {"type": "adaptive"}, key
-        assert settings.get("anthropic_effort") == "medium", key
-
-
-def test_openai_uses_reasoning_effort_default_medium():
-    """GPT-5.4 maps the effort knob to openai_reasoning_effort, defaulting to medium."""
-    from api.src.sernia_ai.model_config import build_run_kwargs
-
-    kw = build_run_kwargs("gpt-5.4")
-    settings = kw["model_settings"]
-    assert settings.get("openai_reasoning_effort") == "medium"
+    kw = build_run_kwargs(key)
+    assert kw["model_settings"].get("thinking") == "medium", key
 
 
 @pytest.mark.parametrize("effort", ["low", "medium", "high"])
 def test_explicit_effort_threads_through_for_both_providers(effort: str):
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    openai = build_run_kwargs("gpt-5.4", effort)
-    assert openai["model_settings"].get("openai_reasoning_effort") == effort
+    assert build_run_kwargs("gpt-5.4", effort)["model_settings"].get("thinking") == effort
+    assert build_run_kwargs("sonnet-4-6", effort)["model_settings"].get("thinking") == effort
 
-    anthropic = build_run_kwargs("sonnet-4-6", effort)
-    assert anthropic["model_settings"].get("anthropic_effort") == effort
-    assert anthropic["model_settings"].get("anthropic_thinking") == {"type": "adaptive"}
+
+def test_unified_thinking_maps_to_adaptive_on_anthropic():
+    """Guard the provider translation we rely on: with no explicit
+    `anthropic_thinking`, pydantic-ai turns unified thinking into adaptive
+    thinking + effort on models that support it (Sonnet 4.6 / Opus 4.7)."""
+    from pydantic_ai.models.anthropic import AnthropicModel
+    from pydantic_ai.models import ModelRequestParameters
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+    from api.src.sernia_ai.model_config import build_run_kwargs
+
+    kw = build_run_kwargs("sonnet-4-6", "high")
+    model = AnthropicModel(
+        "claude-sonnet-4-6", provider=AnthropicProvider(api_key="test-key")
+    )
+    params = ModelRequestParameters(thinking=kw["model_settings"].get("thinking"))
+    translated = model._translate_thinking(kw["model_settings"], params)  # noqa: SLF001
+    assert translated == {"type": "adaptive"}
 
 
 def test_unknown_effort_falls_back_to_medium():
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    kw = build_run_kwargs("sonnet-4-6", "ultra")
-    assert kw["model_settings"].get("anthropic_effort") == "medium"
-
-    kw_oai = build_run_kwargs("gpt-5.4", None)
-    assert kw_oai["model_settings"].get("openai_reasoning_effort") == "medium"
+    assert build_run_kwargs("sonnet-4-6", "ultra")["model_settings"].get("thinking") == "medium"
+    assert build_run_kwargs("gpt-5.4", None)["model_settings"].get("thinking") == "medium"
 
 
 def test_available_models_cover_all_keys():

--- a/api/src/tests/test_sernia_agent_wiring.py
+++ b/api/src/tests/test_sernia_agent_wiring.py
@@ -1,0 +1,189 @@
+"""Wiring tests for the sernia_agent capability migration (pydantic-ai 1.106).
+
+The agent moved from `builtin_tools=` / `history_processors=` / `instrument=`
+to the core capabilities API:
+
+- `WebSearch` / `WebFetch` capabilities replace the per-run
+  `builtin_tools` juggling that lived in `model_config.build_run_kwargs()`.
+  They adapt per provider: native web fetch is Anthropic-only and is dropped
+  automatically on OpenAI runs (no local fallback — `local=False` — because
+  the domain allowlist is only enforced natively).
+- `ProcessHistory` wraps the existing custom history processors
+  (summarize_tool_results, compact_history) unchanged.
+- `Instrumentation` replaces `instrument=True`.
+
+These tests guard the wiring and the provider-adaptive behavior we rely on,
+plus a synthetic end-to-end run (TestModel, no network) that exercises the
+full pipeline: dynamic instructions, capabilities, and output handling.
+"""
+import dataclasses
+from pathlib import Path
+
+import pytest
+from pydantic_ai.capabilities import Instrumentation, ProcessHistory, WebFetch, WebSearch
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
+
+from api.src.sernia_ai.agent import sernia_agent
+from api.src.sernia_ai.config import WEB_SEARCH_ALLOWED_DOMAINS
+from api.src.sernia_ai.sub_agents import compact_history, summarize_tool_results
+
+
+def _agent_capabilities() -> list:
+    return list(sernia_agent.root_capability.capabilities)
+
+
+def _single(caps: list, cls: type):
+    matches = [c for c in caps if isinstance(c, cls)]
+    assert len(matches) == 1, f"expected exactly one {cls.__name__}, got {len(matches)}"
+    return matches[0]
+
+
+class TestCapabilityWiring:
+    def test_web_search_capability_configured(self):
+        ws = _single(_agent_capabilities(), WebSearch)
+        assert ws.native.allowed_domains == WEB_SEARCH_ALLOWED_DOMAINS
+        # optional=True: silently dropped on models without native support
+        # (parity with the old per-run builtin_tools attachment).
+        assert ws.native.optional is True
+        # No local fallback: the allowlist is only enforced by native tools.
+        assert ws.local is False
+
+    def test_web_fetch_capability_configured(self):
+        wf = _single(_agent_capabilities(), WebFetch)
+        assert wf.native.allowed_domains == WEB_SEARCH_ALLOWED_DOMAINS
+        assert wf.native.optional is True
+        assert wf.local is False
+
+    def test_history_processors_wired_in_order(self):
+        processors = [
+            c.processor for c in _agent_capabilities() if isinstance(c, ProcessHistory)
+        ]
+        assert processors == [summarize_tool_results, compact_history]
+
+    def test_instrumentation_enabled(self):
+        _single(_agent_capabilities(), Instrumentation)
+
+    def test_native_tools_collected(self):
+        kinds = {type(t) for t in sernia_agent._cap_native_tools}  # noqa: SLF001
+        assert WebSearchTool in kinds
+        assert WebFetchTool in kinds
+
+
+class TestProviderAdaptiveNativeTools:
+    """Guard the provider behavior that replaced per-run WebFetchTool attachment.
+
+    `model_config.build_run_kwargs()` used to add WebFetchTool only on
+    Anthropic runs because OpenAI Responses raises UserError on it. The
+    WebFetch capability now handles this by checking the model profile —
+    these tests pin the profile facts that make that safe.
+    """
+
+    def test_openai_responses_supports_search_but_not_fetch(self):
+        from pydantic_ai.models.openai import OpenAIResponsesModel
+        from pydantic_ai.providers.openai import OpenAIProvider
+
+        model = OpenAIResponsesModel("gpt-5.4", provider=OpenAIProvider(api_key="test-key"))
+        assert WebSearchTool in model.profile.supported_native_tools
+        assert WebFetchTool not in model.profile.supported_native_tools
+
+    @pytest.mark.parametrize("model_name", ["claude-sonnet-4-6", "claude-opus-4-7"])
+    def test_anthropic_supports_search_and_fetch(self, model_name: str):
+        from pydantic_ai.models.anthropic import AnthropicModel
+        from pydantic_ai.providers.anthropic import AnthropicProvider
+
+        model = AnthropicModel(model_name, provider=AnthropicProvider(api_key="test-key"))
+        assert WebSearchTool in model.profile.supported_native_tools
+        assert WebFetchTool in model.profile.supported_native_tools
+
+
+class TestSyntheticRun:
+    """End-to-end agent run against TestModel — no network, no API keys.
+
+    Exercises the full pipeline the way a real run does: dynamic instruction
+    resolution (memory, filetree, modality), capability setup (native tools
+    are dropped on TestModel, which supports none), history processing, and
+    string output.
+    """
+
+    @pytest.fixture
+    def deps(self, tmp_path: Path):
+        from api.src.sernia_ai.deps import SerniaDeps
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "MEMORY.md").write_text("Sernia owns the 320 Main St building.")
+        (workspace / "areas").mkdir()
+        (workspace / "areas" / "topic.md").write_text("notes")
+        return SerniaDeps(
+            db_session=None,  # type: ignore[arg-type] — no tool in this run touches the DB
+            conversation_id="test-wiring-conv",
+            user_identifier="user_test",
+            user_name="Test User",
+            user_email="test@serniacapital.com",
+            modality="web_chat",
+            workspace_path=workspace,
+        )
+
+    @pytest.mark.asyncio
+    async def test_agent_runs_end_to_end_with_test_model(self, deps):
+        # TestModel rejects native tools outright (it can't search the web),
+        # so strip them for the run — same as the old builtin_tools days.
+        # output_type=str: the agent's structured output spec (NoAction /
+        # DeferredToolRequests) requires tool-mode output, which TestModel's
+        # canned text can't produce.
+        with sernia_agent.override(native_tools=[]):
+            result = await sernia_agent.run(
+                "Say hello.",
+                deps=deps,
+                model=TestModel(call_tools=[], custom_output_text="Hello from Sernia AI."),
+                output_type=str,
+            )
+        assert result.output == "Hello from Sernia AI."
+
+        # Dynamic instructions resolved into the first request.
+        request = result.all_messages()[0]
+        instructions = request.instructions or ""
+        assert "Sernia owns the 320 Main St building." in instructions  # inject_memory
+        assert "## Workspace Files" in instructions  # inject_filetree
+        assert "web chat" in instructions.lower()  # inject_modality_guidance
+        assert "Test User" in instructions  # inject_context
+
+    @pytest.mark.asyncio
+    async def test_history_processors_run_during_agent_run(self, deps, monkeypatch):
+        """The ProcessHistory capabilities must actually execute per request."""
+        from pydantic_ai import RunContext
+        from pydantic_ai.capabilities import ProcessHistory
+        from pydantic_ai.messages import ModelMessage
+
+        calls: list[str] = []
+
+        # The RunContext annotation matters: ProcessHistory uses it to decide
+        # whether to pass ctx to the processor.
+        async def fake_summarize(
+            ctx: RunContext, messages: list[ModelMessage]
+        ) -> list[ModelMessage]:
+            calls.append("summarize")
+            return messages
+
+        async def fake_compact(
+            ctx: RunContext, messages: list[ModelMessage]
+        ) -> list[ModelMessage]:
+            calls.append("compact")
+            return messages
+
+        for cap in sernia_agent.root_capability.capabilities:
+            if isinstance(cap, ProcessHistory):
+                if cap.processor is summarize_tool_results:
+                    monkeypatch.setattr(cap, "processor", fake_summarize)
+                elif cap.processor is compact_history:
+                    monkeypatch.setattr(cap, "processor", fake_compact)
+
+        with sernia_agent.override(native_tools=[]):
+            await sernia_agent.run(
+                "Hi.",
+                deps=deps,
+                model=TestModel(call_tools=[], custom_output_text="ok"),
+                output_type=str,
+            )
+        assert calls == ["summarize", "compact"]

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+"""Root pytest conftest — runs before any test module is imported.
+
+pydantic-ai >=1.9x validates provider API keys when an Agent is constructed
+(previously deferred to the first model request). Several agents are built at
+import time (chat_emilio, sernia_agent), so test collection fails in
+environments without real keys. Default test runs never hit real model APIs
+(`live` tests are excluded via pytest.ini addopts), so dummy fallbacks are
+safe. `setdefault` keeps real keys intact when present (needed for -m live).
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-anthropic-key")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     # AI / LLM
     "openai>=1.77.0",
     "pydantic>=2.11.2",
-    "pydantic-ai[dbos]>=1.62.0",
+    # >=1.106: core capabilities API (WebSearch/WebFetch/Thinking) + harness-ready (>=1.95.1)
+    "pydantic-ai[dbos]>=1.106.0",
     "pydantic-ai-filesystem-sandbox>=0.9.0",
     "pydantic-monty>=0.0.7",
     "fastmcp[apps]>=3.2.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.89.0"
+version = "0.109.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -231,9 +231,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/af/862e216dd6c5e9bc02fb374eeaaa19017c51b90ddfa5692668a3811947bd/anthropic-0.89.0.tar.gz", hash = "sha256:f3d75b8ccef4b35f3702639519e461eba437d4bcdfabb69378c65a02ab7bda66", size = 596758, upload-time = "2026-04-03T18:57:01.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/0b/ce24a4f275573f5e436ca954faca60c759d58ed152b8fa36a1e3b888e261/anthropic-0.109.1.tar.gz", hash = "sha256:83e06b3d9d40ff5898f588020e0cc4e42187de954549a3b5fbe6e2685a09c785", size = 927569, upload-time = "2026-06-09T23:55:24.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/ba/9f973f22abb512d5d17428a76e4ecbc8d49b9dd1b5a1152576d48c24dc1d/anthropic-0.89.0-py3-none-any.whl", hash = "sha256:c6d23854af798f2471ca3bc653cca394d392cc272fe803d3da9d63575b8445f0", size = 478847, upload-time = "2026-04-03T18:56:59.54Z" },
+    { url = "https://files.pythonhosted.org/packages/91/0f/a6110d713370bc92f074a622f8a5ebdec7e92360149b1048dca258a07b2f/anthropic-0.109.1-py3-none-any.whl", hash = "sha256:ce7d94a7657f2aa29338cca448945eac621b4f62c1794cf461cb32847223e9b8", size = 923851, upload-time = "2026-06-09T23:55:23.348Z" },
 ]
 
 [[package]]
@@ -395,14 +395,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -1139,40 +1140,73 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.4"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+]
+
+[package.optional-dependencies]
+apps = [
+    { name = "fastmcp-slim", extra = ["apps"] },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+]
+
+[package.optional-dependencies]
+apps = [
+    { name = "prefab-ui" },
+]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
-]
-
-[package.optional-dependencies]
-apps = [
-    { name = "prefab-ui" },
 ]
 
 [[package]]
@@ -2058,6 +2092,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]
@@ -3136,7 +3182,7 @@ requires-dist = [
     { name = "prefect", specifier = ">=3.4.24" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2.11.2" },
-    { name = "pydantic-ai", extras = ["dbos"], specifier = ">=1.62.0" },
+    { name = "pydantic-ai", extras = ["dbos"], specifier = ">=1.106.0" },
     { name = "pydantic-ai-filesystem-sandbox", specifier = ">=0.9.0" },
     { name = "pydantic-ai-skills", specifier = ">=0.5.1" },
     { name = "pydantic-monty", specifier = ">=0.0.7" },
@@ -3657,14 +3703,14 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "1.77.0"
+version = "1.106.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "spec", "temporal", "ui", "vertexai", "xai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/d3/b6c452f889c055090924aa62bbb791997caa1cfb2eae40a43c4a6fdc112e/pydantic_ai-1.77.0.tar.gz", hash = "sha256:a9c82be7993471c2b9de654eb4973f1d5385215514cb88b201f082d2976e1ae7", size = 12645, upload-time = "2026-04-03T02:16:52.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/f1/6a0db6d336af199b436caa48d01ff63eeb6dbab14d5c50035ab5393a42f2/pydantic_ai-1.106.0.tar.gz", hash = "sha256:fb2b4bba143f924f2272926428ed173e456b00e0e5b3b125d7fd757f11b21fee", size = 18368, upload-time = "2026-06-05T01:29:06.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/2d/acf07a84ff521607a1e64079cb19a86eafb5bab380aa644644f05fb6493b/pydantic_ai-1.77.0-py3-none-any.whl", hash = "sha256:0a325fc55737dad0beab0ba02a9944fdb290373777de4eabf2763654c7650bba", size = 7551, upload-time = "2026-04-03T02:16:43.839Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ca/bc39ecda2f1aa6544ec8559cfc50405462b241428ad06f77f44c776cdd39/pydantic_ai-1.106.0-py3-none-any.whl", hash = "sha256:c8c93979acab85b087dc3499e40249d5de4333f2212eb792c52a6c05c2448d69", size = 7589, upload-time = "2026-06-05T01:28:56.426Z" },
 ]
 
 [package.optional-dependencies]
@@ -3715,7 +3761,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.77.0"
+version = "1.106.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -3726,9 +3772,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/a7/ad011e626bed1f275fbaf933181573a50b05c2b9a0be927583d46fb8ff13/pydantic_ai_slim-1.77.0.tar.gz", hash = "sha256:a6e7006a4b048193d45b6ba816d301271e3f5ef1cdc4f9fb340617f382c6ce0d", size = 518781, upload-time = "2026-04-03T02:16:54.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/45/2afc9100a7c370d8ac37bdfccfb54f46fc99da3bdce63f07c32c37807ebc/pydantic_ai_slim-1.106.0.tar.gz", hash = "sha256:e265598c8ee0e903ebb02d0494bb232be4cc8aa463ba1a55aa743cf34135dacf", size = 773504, upload-time = "2026-06-05T01:29:09.129Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/c5/5913cc4ae99047901c602f0d8208e3a75a7952b7e57d76169547307d7cea/pydantic_ai_slim-1.77.0-py3-none-any.whl", hash = "sha256:110c516935de384f1beddc36fda04e8df36cdf5bee3a5bfd0da562726182e52b", size = 664494, upload-time = "2026-04-03T02:16:46.668Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d9/a2785c576e3519a72a5bbc0e12027c542b265ef6eea1aa72b9c440ac2531/pydantic_ai_slim-1.106.0-py3-none-any.whl", hash = "sha256:0dd7a99ea3fa89b490098406c2240ba7d75c327eea094c3fd057dd7aa9f3d163", size = 957617, upload-time = "2026-06-05T01:28:59.979Z" },
 ]
 
 [package.optional-dependencies]
@@ -3768,13 +3814,14 @@ groq = [
     { name = "groq" },
 ]
 huggingface = [
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "huggingface-hub" },
 ]
 logfire = [
     { name = "logfire", extra = ["httpx"] },
 ]
 mcp = [
-    { name = "mcp" },
+    { name = "fastmcp-slim", extra = ["client"] },
 ]
 mistral = [
     { name = "mistralai" },
@@ -3903,7 +3950,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.77.0"
+version = "1.106.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3913,9 +3960,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/23/8da617d3803362325790e73e6219dec359559c2ef2350b35dbeb9e39c92f/pydantic_evals-1.77.0.tar.gz", hash = "sha256:64a12324c9a3f4fefa34b5a5eb4c2320c0976e425404372fa69f2872f585c3d0", size = 65811, upload-time = "2026-04-03T02:16:55.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/d0/103e11d2c652980817ddcd874953437cf68d269e6893c9c4faa0b14f3568/pydantic_evals-1.106.0.tar.gz", hash = "sha256:ec870c2e93e2a34aea83468a7d7c21cba3e9dacf62f145eef2229d9fd71b2cac", size = 78539, upload-time = "2026-06-05T01:29:10.538Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/07/b9e6ba4afcce41f70a0f149cd7bc299a0babaf9c62a57d7cb291679a6cc7/pydantic_evals-1.77.0-py3-none-any.whl", hash = "sha256:2b536081e36d70826da216a3a6df8d84e3ac1982fc3b8078c123fd539ce6bfb6", size = 77740, upload-time = "2026-04-03T02:16:48.681Z" },
+    { url = "https://files.pythonhosted.org/packages/33/42/1319fdda0a120de24a544c9a76c2172005a3b53ac8e986ce149507694421/pydantic_evals-1.106.0-py3-none-any.whl", hash = "sha256:7994f8bebfac5e482fe62e5a5434b2e5f94118ca8bd766628635b84835118a78", size = 93528, upload-time = "2026-06-05T01:29:02.407Z" },
 ]
 
 [[package]]
@@ -3933,7 +3980,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.77.0"
+version = "1.106.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3941,9 +3988,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/40/a8b8e256bb90e4e284b35cc1c5e1a8e2724fa88ad89b7eac958fbf85852b/pydantic_graph-1.77.0.tar.gz", hash = "sha256:ba75dbdf221cd7e366e5c5d250f4d9f3138e05400ea52d3f36330772d989deee", size = 58689, upload-time = "2026-04-03T02:16:56.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/9b/dd6826cf21eedd96a7482302be51ba6087095acbe828362135de2a505092/pydantic_graph-1.106.0.tar.gz", hash = "sha256:55afa33df4f699ed5c1185f81b6a06e2161958f1aa0c20742b2dae5745e84cce", size = 62567, upload-time = "2026-06-05T01:29:11.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/09/3c9c3aba8031adbd21d1833e8e4edd749697e50a88fa9bdab641874abe4f/pydantic_graph-1.77.0-py3-none-any.whl", hash = "sha256:063803e87aec901919c2073ccf3fdd6e4fff84e8b05dbfbe8a6c1af63dd12c05", size = 72503, upload-time = "2026-04-03T02:16:49.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e9/0058f0b98f5992e715a0a50128f6c3cc7946cc242d471f6e850efdf03f0c/pydantic_graph-1.106.0-py3-none-any.whl", hash = "sha256:e6bb61aef0fdb49185a81142d311f94fc3315329345471d12cab85ab5845221f", size = 80099, upload-time = "2026-06-05T01:29:04.219Z" },
 ]
 
 [[package]]
@@ -4163,11 +4210,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.24"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/45/e23b5dc14ddb9918ae4a625379506b17b6f8fc56ca1d82db62462f59aea6/python_multipart-0.0.24.tar.gz", hash = "sha256:9574c97e1c026e00bc30340ef7c7d76739512ab4dfd428fec8c330fa6a5cc3c8", size = 37695, upload-time = "2026-04-05T20:49:13.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl", hash = "sha256:9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950", size = 24420, upload-time = "2026-04-05T20:49:12.555Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -4977,15 +5024,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/c4/7d/04fc3aa177403472d
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -5681,7 +5728,7 @@ wheels = [
 
 [[package]]
 name = "xai-sdk"
-version = "1.11.0"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -5693,9 +5740,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/32/bb8385f7a3b05ce406b689aa000c9a34289caa1526f1c093a1cefc0d9695/xai_sdk-1.11.0.tar.gz", hash = "sha256:ca87a830d310fb8e06fba44fb2a8c5cdf0d9f716b61126eddd51b7f416a63932", size = 404313, upload-time = "2026-03-27T18:23:10.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/0a/74a835cff3c2c5135bcbdca152eed1bd0b7b2c9156e457dfc0d9af987df9/xai_sdk-1.15.0.tar.gz", hash = "sha256:6508b702d01da9c55c15cdcb329c4ad58eb9251340b2514d0974bcba11e764e3", size = 433102, upload-time = "2026-05-30T01:42:15.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/76/86d9a3589c725ce825d2ed3e7cb3ecf7f956d3fd015353d52197bb341bcd/xai_sdk-1.11.0-py3-none-any.whl", hash = "sha256:fe58ce6d8f8115ae8bd57ded57bcd847d0bb7cb28bb7b236abefd4626df1ed8d", size = 251388, upload-time = "2026-03-27T18:23:08.573Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/39/7513677c0dafc5171ca4a78f9af3a2acfb9c8798aab62bc4464452ac277f/xai_sdk-1.15.0-py3-none-any.whl", hash = "sha256:de1dcb856941bcbc64c0e61b7202395593c1950e0e00e6aa0ca7657448c03aca", size = 260289, upload-time = "2026-05-30T01:42:14.431Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why this approach (harness evaluation)

The original ask was to evaluate adopting **pydantic-ai-harness** and/or **pydantic-ai v2** to simplify context handling, compaction, and web search. Findings:

- **Harness**: its capability matrix shows context compaction, sliding window, tool-output management, and sub-agents are all 🚧 *unshipped* (open PRs). Only CodeMode/filesystem/shell shipped — we already have equivalents (pydantic-monty `run_python`, filesystem sandbox). Adopting it today gains nothing and adds a 0.x dependency.
- **v2**: still beta (v2.0.0b6) — not appropriate for the production agent yet.
- **Latest v1.x (1.106)** is the right move: it ships the *core* capabilities the harness builds on (provider-adaptive `WebSearch`/`WebFetch`, `ProcessHistory`, `Instrumentation`, unified `thinking` setting), resolves all v2 deprecation warnings (the official migration path), and makes us harness-ready (`>=1.95.1`) for when its context-management capabilities actually ship.

**Core business logic is untouched**: HITL approvals, triggers, SMS gates, history compaction/summarization processors, and the runtime model picker all behave the same.

## What changed

### Agent (behavior-preserving migration)
- `builtin_tools=[WebSearchTool]` → `WebSearch`/`WebFetch` capabilities with `optional=True` native tools. Web fetch is auto-dropped on OpenAI runs — this **deletes the per-run WebFetchTool juggling** from `model_config.build_run_kwargs()`. `local=False` keeps parity (no local fallback; the domain allowlist is only enforced natively).
- `history_processors=[...]` → `ProcessHistory(...)` capabilities, same order. **Custom compaction/summarization kept** — nothing shipped replaces them yet.
- `instrument=True` → `Instrumentation()` capability (agent + all sub-agents).
- `model_config.py`: unified `thinking` setting replaces `anthropic_thinking`/`anthropic_effort`/`openai_reasoning_effort` (pydantic-ai maps it to adaptive thinking + effort on Anthropic, `reasoning_effort` on OpenAI). Run kwargs are now just `{model, model_settings}`.
- Admin tool overview reads `_cap_native_tools` (upstream rename — previously silently returned nothing).

### Fixes required by 1.106
- Multi-agent demo route stopped passing raw Vercel UI dicts as `message_history` (adapter parses the conversation from the request body; dicts now raise `'dict' object has no attribute 'parts'`).
- `pydantic_graph.beta` imports → `graph_builder`/`step`.
- Root `conftest.py` provides dummy API keys (agents built at import time now validate provider keys at construction).
- `__init__.py` added to `ai_demos/` — fixes pre-existing pytest duplicate-table collection errors (double import under two module names).

### Tests (new + updated)
- **New `test_sernia_agent_wiring.py`**: capability wiring assertions, provider-adaptive guards (OpenAI Responses profile supports native search but not fetch; Anthropic supports both), and synthetic end-to-end runs via `TestModel` (no network) that verify dynamic instructions (memory/filetree/modality injection) and that both history processors execute per request.
- `test_model_config.py` rewritten for the new kwargs shape, including a guard that unified thinking translates to `{'type': 'adaptive'}` on Anthropic.
- `test_history_processors.py`: smoke test now reads `ProcessHistory` capabilities; autouse fixture clears the summary cache between tests — **fixes 6 pre-existing order-dependent failures** (tests reuse `tool_call_id`s, which are globally unique in prod).

## Verification

Full suite diffed against the 1.77 baseline in the same environment:
- **Zero new failures.**
- **6 fewer failures** (the order-dependent history-processor tests).
- Remaining failures are pre-existing sandbox credential issues (Google/OpenPhone/Anthropic keys absent), identical on both versions.

## Testing the PR environment

Preview: https://react-router-portfolio-pr-268.up.railway.app/

Suggested manual checks across the full stack:
1. Web chat on GPT-5.4 (default): confirm web search works, normal conversation flow.
2. Switch model to Sonnet 4.6 in `/sernia-settings`: confirm web search **and** web fetch work, plus adaptive thinking.
3. Trigger an HITL approval (e.g. external SMS draft) and approve it — exercises `resume_with_approvals` on the new run-kwargs shape.
4. A long conversation with big tool results (e.g. read a large Google Sheet) to exercise summarization/compaction.

## Follow-ups (not in this PR)
- Watch pydantic-ai-harness: when its context-management capabilities ship, the custom `compact_history`/`summarize_tool_results` processors could be swapped for maintained equivalents.
- v2 migration is now low-risk whenever it goes stable (all deprecations resolved).

https://claude.ai/code/session_019XG83gyFp6fUKn4fEGV4zW