### PR TITLE
Meta: credential-free green test suite, first CI test workflow, dev sample data, AGENTS.md

### DIFF
--- a/.claude/prep_claude_remote_env_var.py
+++ b/.claude/prep_claude_remote_env_var.py
@@ -15,9 +15,10 @@ ZPROFILE_KEYS = [
 ]
 
 # Keys from .env that must NOT be injected into the Claude Code remote env.
-# Empty by default — our app's Anthropic key lives under SERNIA_ANTHROPIC_API_KEY
-# (see api/index.py for the bridge to ANTHROPIC_API_KEY) so it no longer
-# collides with the ANTHROPIC_API_KEY Claude Cloud injects for itself.
+# Empty by default — our app's Anthropic key lives under
+# ANTHROPIC_API_KEY_PORTFOLIO (see api/__init__.py for the bridge to
+# ANTHROPIC_API_KEY) so it doesn't collide with the ANTHROPIC_API_KEY Claude
+# Cloud uses for the session itself.
 SKIP_KEYS: set[str] = set()
 
 

--- a/.claude/prep_claude_remote_env_var.py
+++ b/.claude/prep_claude_remote_env_var.py
@@ -16,7 +16,7 @@ ZPROFILE_KEYS = [
 
 # Keys from .env that must NOT be injected into the Claude Code remote env.
 # Empty by default — our app's Anthropic key lives under
-# ANTHROPIC_API_KEY_PORTFOLIO (see api/__init__.py for the bridge to
+# SERNIA_ANTHROPIC_API_KEY (see api/__init__.py for the bridge to
 # ANTHROPIC_API_KEY) so it doesn't collide with the ANTHROPIC_API_KEY Claude
 # Cloud uses for the session itself.
 SKIP_KEYS: set[str] = set()

--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,11 @@
 # Get your OpenAI API Key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=****
 
-# Anthropic API key — named ANTHROPIC_API_KEY_PORTFOLIO (not ANTHROPIC_API_KEY)
+# Anthropic API key — named SERNIA_ANTHROPIC_API_KEY (not ANTHROPIC_API_KEY)
 # because a var literally named ANTHROPIC_API_KEY breaks Claude Code cloud
 # sessions. api/__init__.py bridges this to ANTHROPIC_API_KEY at import time
-# so the Anthropic SDK auto-discovers it. (SERNIA_ANTHROPIC_API_KEY is the
-# deprecated former name, still honored as a fallback.)
-ANTHROPIC_API_KEY_PORTFOLIO=****
+# so the Anthropic SDK auto-discovers it.
+SERNIA_ANTHROPIC_API_KEY=****
 
 CRON_SECRET=****
 OPEN_PHONE_WEBHOOK_WEBHOOK_SECRET=****

--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,12 @@
 # Get your OpenAI API Key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=****
 
-# Anthropic API key — named SERNIA_ANTHROPIC_API_KEY (not ANTHROPIC_API_KEY)
-# to avoid colliding with the ANTHROPIC_API_KEY that Claude Cloud injects for
-# the Claude Code session in remote dev environments. api/index.py bridges
-# this to ANTHROPIC_API_KEY at startup so the Anthropic SDK auto-discovers it.
-SERNIA_ANTHROPIC_API_KEY=****
+# Anthropic API key — named ANTHROPIC_API_KEY_PORTFOLIO (not ANTHROPIC_API_KEY)
+# because a var literally named ANTHROPIC_API_KEY breaks Claude Code cloud
+# sessions. api/__init__.py bridges this to ANTHROPIC_API_KEY at import time
+# so the Anthropic SDK auto-discovers it. (SERNIA_ANTHROPIC_API_KEY is the
+# deprecated former name, still honored as a fallback.)
+ANTHROPIC_API_KEY_PORTFOLIO=****
 
 CRON_SECRET=****
 OPEN_PHONE_WEBHOOK_WEBHOOK_SECRET=****

--- a/.github/workflows/logfire_investigate.yml
+++ b/.github/workflows/logfire_investigate.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/neon_workflow.yml
+++ b/.github/workflows/neon_workflow.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get branch expiration date as an env variable (2 weeks from now)
         id: get_expiration_date
         run: echo "expires_at=$(date -u --date '+14 days' +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -11,7 +11,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,10 +41,10 @@ jobs:
       ANTHROPIC_API_KEY: test-anthropic-key
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,61 @@
+name: Tests
+
+# Unit test suite for the FastAPI backend. Excludes `live` tests (real
+# third-party APIs) per pytest.ini addopts, so no real credentials are
+# needed: the root conftest.py provides dummy AI keys, and Postgres runs
+# as a service container (mirrors .claude/setup_remote.sh).
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    name: pytest (not live)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: portfolio
+          POSTGRES_PASSWORD: portfolio
+          POSTGRES_DB: portfolio
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://portfolio:portfolio@localhost:5432/portfolio
+      DATABASE_URL_UNPOOLED: postgresql://portfolio:portfolio@localhost:5432/portfolio
+      DATABASE_REQUIRE_SSL: "false"
+      # Dummy keys: pydantic-ai validates provider keys at Agent construction
+      # (import time). conftest.py also sets these, but exporting here covers
+      # non-pytest entry points like alembic/seed.
+      OPENAI_API_KEY: test-openai-key
+      ANTHROPIC_API_KEY: test-anthropic-key
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync -p 3.11
+
+      - name: Run migrations
+        run: uv run alembic upgrade head
+
+      - name: Seed database
+        run: uv run python api/seed_db.py
+
+      - name: Run tests
+        run: uv run pytest -p no:cacheprovider --tb=short -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ When running in Claude Code's cloud environment (`CLAUDE_CODE_REMOTE=true`), a *
 
 **Known environment constraints** (Claude Code on web):
 - **Postgres can stop mid-session** (long sessions). If DB tests fail with "connection refused", run `sudo service postgresql start` and retry.
-- **No `ANTHROPIC_API_KEY`** is configured (OPENAI is). Live Anthropic tests can't run; the root `conftest.py` provides dummy keys so imports/collection work.
+- **Anthropic key naming**: the app's key is `ANTHROPIC_API_KEY_PORTFOLIO` — never name an env var `ANTHROPIC_API_KEY` (it breaks Claude Code cloud sessions). `api/__init__.py` bridges it to `ANTHROPIC_API_KEY` inside app/test processes for SDK auto-discovery. If `ANTHROPIC_API_KEY_PORTFOLIO` is absent in this sandbox, live Anthropic tests can't run; the root `conftest.py` provides dummy keys so imports/collection work.
 - **Outbound port 5432 is blocked** — remote Neon Postgres is unreachable from the sandbox; use the local Postgres (default) or the Neon MCP tools for read access to real environments.
 - **Gitignored fixture dirs** (`api/src/tests/requests/`, `api/src/tests/sensitive/`) are absent — tests depending on them auto-skip.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md - AI Assistant Guide
 
-> **Last Updated**: 2025-12-29
+> **Last Updated**: 2026-06-10
+> `AGENTS.md` is a symlink to this file so non-Claude agent tools pick it up too.
 
 ---
 
@@ -33,11 +34,17 @@ When running in Claude Code's cloud environment (`CLAUDE_CODE_REMOTE=true`), a *
 1. Creates Python venv and installs dependencies (`uv sync`)
 2. Starts local PostgreSQL and configures authentication
 3. Runs database migrations (`alembic upgrade head`)
-4. Seeds the database
+4. Seeds the database (contacts, default `model_config` app setting, and — on non-production — demo Sernia conversations so the chat UI and `db_*` search tools have data; see `api/seed_db.py`)
 5. Installs pnpm dependencies and builds React Router app
 6. Bridges `RAILWAY_MCP_TOKEN` → `RAILWAY_API_TOKEN` and pre-links the portfolio project to `development/fastapi` (not production - safer default). Switch envs/services with the `link-environment` / `link-service` MCP tools. **PR environments:** Named `portfolio-pr-<number>` (e.g., `portfolio-pr-248`). List all with `railway environment list --json`.
 
 **Verification**: Check `/tmp/.claude_remote_setup_ran` exists to confirm the hook ran.
+
+**Known environment constraints** (Claude Code on web):
+- **Postgres can stop mid-session** (long sessions). If DB tests fail with "connection refused", run `sudo service postgresql start` and retry.
+- **No `ANTHROPIC_API_KEY`** is configured (OPENAI is). Live Anthropic tests can't run; the root `conftest.py` provides dummy keys so imports/collection work.
+- **Outbound port 5432 is blocked** — remote Neon Postgres is unreachable from the sandbox; use the local Postgres (default) or the Neon MCP tools for read access to real environments.
+- **Gitignored fixture dirs** (`api/src/tests/requests/`, `api/src/tests/sensitive/`) are absent — tests depending on them auto-skip.
 
 **After setup, start servers with**:
 ```bash
@@ -66,7 +73,7 @@ Requires manual setup - see [Initial Setup](#initial-setup) below. Uses remote N
 ### Backend
 - FastAPI + Hypercorn (ASGI) + Python 3.11+
 - SQLAlchemy 2.0 + Alembic + Neon Postgres
-- PydanticAI with Graph Beta API for multi-agent AI
+- PydanticAI (>=1.106, capabilities API: `WebSearch`/`WebFetch`/`ProcessHistory`/`Instrumentation`; graph API for multi-agent demos). Note: pydantic-ai validates provider API keys at `Agent()` construction — agents built at import time need keys (or the conftest dummies) present.
 - APScheduler for scheduled jobs + Logfire observability
 - DBOS workflows (currently disabled - see below)
 
@@ -168,12 +175,24 @@ pnpm approve-builds <package-name>  # Updates pnpm-workspace.yaml allowBuilds
 
 ### Testing Conventions
 
+- **The default `pytest` run must pass with NO third-party credentials** — only a local Postgres. This is enforced: CI (`.github/workflows/tests.yml`) and Claude Code on web both run the default suite without real keys. If you add a test that needs a real API, mark it `live`.
 - **Default `pytest` run** excludes tests marked `live` (see `pytest.ini` `addopts`).
-- **`live` marker**: Tests that hit real third-party APIs (ClickUp, OpenPhone, etc.). Run explicitly with `pytest -m live <file>`. Require API keys in `.env`.
+- **`live` marker**: Tests that hit real third-party APIs (ClickUp, OpenPhone, Google, real LLM calls, etc.). Run explicitly with `pytest -m live <file>`. Require API keys in `.env`.
+- **Dummy AI keys**: the root `conftest.py` sets placeholder `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` if absent — pydantic-ai validates provider keys when an `Agent` is constructed (import time), so collection would otherwise fail without keys.
+- **Gitignored fixtures**: tests that need local-only files (`api/src/tests/requests/`, `api/src/tests/sensitive/`) must `skipif` when the files are missing — see `test_open_phone.py` for the pattern.
 - **Smoke tests** (`TestSmoke` classes): Fast import/wiring checks that verify modules load correctly and components are connected (e.g., agent has history processors wired, sub-agent models configured). No API keys needed.
 - **Unit tests**: Mock all external calls. Use realistic tool result data matching actual output formats (ClickUp task dumps, Gmail search results, etc.), not dummy strings.
 - **SMS test safety**: NEVER create live tests that send real SMS to external contacts (tenants, vendors, etc.). External SMS tests must ALWAYS mock the send. Only `send_internal_sms` may be tested live against real internal numbers. If a dedicated test phone number is provided in the future, it will be explicitly configured — do not guess or use tenant numbers.
-- **Test location**: `api/src/tests/`
+- **Test location**: `api/src/tests/` (but `pytest.ini` collects `test_*` functions from EVERY `*.py` file under `api/` — see gotchas below).
+
+### Pytest Gotchas (learned the hard way)
+
+- `pytest.ini` sets `python_files = *.py`, so inline tests in service modules are collected too. Consequences:
+  - A FastAPI route handler named `test_*` gets collected as a test — set `handler.__test__ = False` (see `sernia_ai/push/routes.py`).
+  - Every package dir under `api/` needs an `__init__.py`, or pytest imports the file under a second top-level module name and SQLAlchemy models get double-registered ("Table already defined").
+- **Event loop scope is `session`** (`pytest.ini`): the app uses module-level async engines (asyncpg pools). Per-test loops cause order-dependent "Event loop is closed" failures. Don't change this back to `function`.
+- **Module-level caches leak between tests** — e.g. the tool-result summary cache keyed by `tool_call_id`. Clear them in autouse fixtures when tests reuse short ids (see `test_history_processors.py`).
+- **`TestModel` does not support native tools** (WebSearch/WebFetch). To run `sernia_agent` against `TestModel`, use `with sernia_agent.override(native_tools=[]):` and pass `output_type=str` (the structured output spec needs tool-mode output, which `custom_output_text` can't produce). See `test_sernia_agent_wiring.py`.
 
 ---
 
@@ -306,7 +325,8 @@ Example: PR #235 → `https://react-router-portfolio-pr-235.up.railway.app/`
 ### Claude Code on Web
 - **Hook didn't run?** Check if `/tmp/.claude_remote_setup_ran` exists
 - **Logfire warnings?** Expected - proxy restrictions, non-blocking
-- **Database issues?** Verify PostgreSQL is running: `pg_isready -h localhost`
+- **Database issues?** Verify PostgreSQL is running: `pg_isready -h localhost`. It can stop mid-session — restart with `sudo service postgresql start`.
+- **"Event loop is closed" in async DB tests?** A test changed the event-loop scope — it must stay `session` (see pytest.ini comment).
 
 ### Local CLI
 - **SSL errors?** Ensure `DATABASE_REQUIRE_SSL=true` for Neon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ When running in Claude Code's cloud environment (`CLAUDE_CODE_REMOTE=true`), a *
 
 **Known environment constraints** (Claude Code on web):
 - **Postgres can stop mid-session** (long sessions). If DB tests fail with "connection refused", run `sudo service postgresql start` and retry.
-- **Anthropic key naming**: the app's key is `ANTHROPIC_API_KEY_PORTFOLIO` — never name an env var `ANTHROPIC_API_KEY` (it breaks Claude Code cloud sessions). `api/__init__.py` bridges it to `ANTHROPIC_API_KEY` inside app/test processes for SDK auto-discovery. If `ANTHROPIC_API_KEY_PORTFOLIO` is absent in this sandbox, live Anthropic tests can't run; the root `conftest.py` provides dummy keys so imports/collection work.
+- **Anthropic key naming**: the app's key is `SERNIA_ANTHROPIC_API_KEY` — never name an env var `ANTHROPIC_API_KEY` (it breaks Claude Code cloud sessions). `api/__init__.py` bridges it to `ANTHROPIC_API_KEY` inside app/test processes for SDK auto-discovery. If `SERNIA_ANTHROPIC_API_KEY` is absent in this sandbox, live Anthropic tests can't run; the root `conftest.py` provides dummy keys so imports/collection work.
 - **Outbound port 5432 is blocked** — remote Neon Postgres is unreachable from the sandbox; use the local Postgres (default) or the Neon MCP tools for read access to real environments.
 - **Gitignored fixture dirs** (`api/src/tests/requests/`, `api/src/tests/sensitive/`) are absent — tests depending on them auto-skip.
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,21 @@ grep -q '^CUSTOM_RAILWAY_BACKEND_URL=' .env \
 ```
 
 
+## Sanitized Seed Data (dev environments)
+
+Dev/PR/Claude-Code environments use a local or branched database with seeded
+demo data (`api/seed_db.py`). To give them *realistic* data, export a
+sanitized snapshot of recent Sernia conversations from the real DB:
+
+```bash
+# Run locally (where .env points at Neon). Redacts phones/emails automatically.
+uv run python scripts/export_seed_fixture.py --limit 10
+
+# REVIEW api/seed_fixtures/agent_conversations.json for names/addresses the
+# regexes can't catch, then commit it. seed_db.py loads it automatically in
+# every non-production environment.
+```
+
 ## 3rd Party Stuff
 
 Quo (fka OpenPhone) and Google PubSub webhooks are pointing to the production environment. Use `ngrok http 8000` to test the webhooks locally. 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,29 @@
+"""Package init — runs before anything under `api.*` is imported.
+
+Bridges ANTHROPIC_API_KEY_PORTFOLIO -> ANTHROPIC_API_KEY for the Anthropic
+SDK and pydantic-ai (both discover the key implicitly via ANTHROPIC_API_KEY).
+The app's key is stored under an explicit name because a variable literally
+named ANTHROPIC_API_KEY breaks Claude Code cloud sessions — it overrides the
+session's own authentication.
+
+This lives in the package __init__ (not api/index.py) so EVERY entry point
+gets it: the FastAPI app, pytest (pytest.ini collects inline tests from all
+api/ modules, many of which construct Agents at import), seed_db.py, and ad
+hoc scripts.
+
+SERNIA_ANTHROPIC_API_KEY is the deprecated former name — honored as a
+fallback until all environments (Railway, local .env files) are renamed.
+"""
+import os
+
+from dotenv import load_dotenv
+
+# Local CLI keeps keys in .env; Railway/cloud inject real env vars. load_dotenv
+# never overrides variables that are already set, so this is safe everywhere.
+load_dotenv()
+
+_portfolio_anthropic_key = os.environ.get("ANTHROPIC_API_KEY_PORTFOLIO") or os.environ.get(
+    "SERNIA_ANTHROPIC_API_KEY"  # deprecated name
+)
+if _portfolio_anthropic_key:
+    os.environ["ANTHROPIC_API_KEY"] = _portfolio_anthropic_key

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,7 +1,7 @@
 """Package init — runs before anything under `api.*` is imported.
 
-Bridges ANTHROPIC_API_KEY_PORTFOLIO -> ANTHROPIC_API_KEY for the Anthropic
-SDK and pydantic-ai (both discover the key implicitly via ANTHROPIC_API_KEY).
+Bridges SERNIA_ANTHROPIC_API_KEY -> ANTHROPIC_API_KEY for the Anthropic SDK
+and pydantic-ai (both discover the key implicitly via ANTHROPIC_API_KEY).
 The app's key is stored under an explicit name because a variable literally
 named ANTHROPIC_API_KEY breaks Claude Code cloud sessions — it overrides the
 session's own authentication.
@@ -10,9 +10,6 @@ This lives in the package __init__ (not api/index.py) so EVERY entry point
 gets it: the FastAPI app, pytest (pytest.ini collects inline tests from all
 api/ modules, many of which construct Agents at import), seed_db.py, and ad
 hoc scripts.
-
-SERNIA_ANTHROPIC_API_KEY is the deprecated former name — honored as a
-fallback until all environments (Railway, local .env files) are renamed.
 """
 import os
 
@@ -22,8 +19,6 @@ from dotenv import load_dotenv
 # never overrides variables that are already set, so this is safe everywhere.
 load_dotenv()
 
-_portfolio_anthropic_key = os.environ.get("ANTHROPIC_API_KEY_PORTFOLIO") or os.environ.get(
-    "SERNIA_ANTHROPIC_API_KEY"  # deprecated name
-)
-if _portfolio_anthropic_key:
-    os.environ["ANTHROPIC_API_KEY"] = _portfolio_anthropic_key
+_sernia_anthropic_key = os.environ.get("SERNIA_ANTHROPIC_API_KEY")
+if _sernia_anthropic_key:
+    os.environ["ANTHROPIC_API_KEY"] = _sernia_anthropic_key

--- a/api/index.py
+++ b/api/index.py
@@ -4,7 +4,7 @@ import json
 import logfire
 import os
 
-# NOTE: the ANTHROPIC_API_KEY_PORTFOLIO -> ANTHROPIC_API_KEY bridge lives in
+# NOTE: the SERNIA_ANTHROPIC_API_KEY -> ANTHROPIC_API_KEY bridge lives in
 # api/__init__.py so every entry point (app, pytest, scripts) gets it.
 
 import logfire

--- a/api/index.py
+++ b/api/index.py
@@ -4,12 +4,8 @@ import json
 import logfire
 import os
 
-# Bridge SERNIA_ANTHROPIC_API_KEY -> ANTHROPIC_API_KEY for the Anthropic SDK.
-# Renamed to avoid colliding with the ANTHROPIC_API_KEY that Claude Cloud
-# injects for the Claude Code session in the remote dev environment.
-_sernia_anthropic_key = os.environ.get("SERNIA_ANTHROPIC_API_KEY")
-if _sernia_anthropic_key:
-    os.environ["ANTHROPIC_API_KEY"] = _sernia_anthropic_key
+# NOTE: the ANTHROPIC_API_KEY_PORTFOLIO -> ANTHROPIC_API_KEY bridge lives in
+# api/__init__.py so every entry point (app, pytest, scripts) gets it.
 
 import logfire
 from api.src.utils.logfire_config import ensure_logfire_configured

--- a/api/seed_db.py
+++ b/api/seed_db.py
@@ -311,6 +311,62 @@ async def seed_sample_conversations(dry_run: bool = False) -> None:
             log_info(f"✓ Created conversation '{sample['conversation_id']}'")
 
 
+FIXTURE_PATH = "api/seed_fixtures/agent_conversations.json"
+
+
+async def seed_fixture_conversations(dry_run: bool = False) -> None:
+    """Load sanitized real conversations exported by scripts/export_seed_fixture.py.
+
+    The fixture is optional — when the file is absent (it hasn't been
+    exported/committed yet) this is a no-op. Non-production only, idempotent
+    via the fixture's stable ``fixture_*`` ids.
+    """
+    import json
+    from pathlib import Path
+
+    if os.getenv("RAILWAY_ENVIRONMENT_NAME", "") == "production":
+        log_info("Skipping fixture conversations (production environment)")
+        return
+
+    fixture_file = Path(FIXTURE_PATH)
+    if not fixture_file.exists():
+        log_info(f"No fixture file at {FIXTURE_PATH} — skipping (run scripts/export_seed_fixture.py to create one)")
+        return
+
+    from sqlalchemy import select
+
+    from api.src.ai_demos.models import AgentConversation
+    from api.src.database.database import AsyncSessionFactory
+
+    rows = json.loads(fixture_file.read_text())
+    async with AsyncSessionFactory() as session:
+        for row in rows:
+            existing = (
+                await session.execute(
+                    select(AgentConversation.id).where(AgentConversation.id == row["id"])
+                )
+            ).scalar_one_or_none()
+            if existing:
+                log_info(f"✓ Fixture conversation '{row['id']}' already exists")
+                continue
+            if dry_run:
+                log_info(f"[DRY RUN] Would create fixture conversation '{row['id']}'")
+                continue
+            session.add(
+                AgentConversation(
+                    id=row["id"],
+                    agent_name=row["agent_name"],
+                    clerk_user_id=None,  # shared team access
+                    messages=row["messages"],
+                    metadata_=row.get("metadata_") or {},
+                    modality=row.get("modality"),
+                    contact_identifier=row.get("contact_identifier"),
+                )
+            )
+            await session.commit()
+            log_info(f"✓ Created fixture conversation '{row['id']}'")
+
+
 async def main(dry_run: bool = False) -> None:
     """Main entry point for seeding the database."""
     log_info("=" * 50)
@@ -331,6 +387,10 @@ async def main(dry_run: bool = False) -> None:
     log_info("")
     log_info("Seeding sample conversations (non-production only)...")
     await seed_sample_conversations(dry_run=dry_run)
+
+    log_info("")
+    log_info("Seeding fixture conversations (non-production only)...")
+    await seed_fixture_conversations(dry_run=dry_run)
 
     log_info("")
     log_info("=" * 50)

--- a/api/seed_db.py
+++ b/api/seed_db.py
@@ -128,6 +128,189 @@ async def seed_contacts(dry_run: bool = False) -> None:
                 raise
 
 
+async def seed_app_settings(dry_run: bool = False) -> None:
+    """Seed a default ``model_config`` app setting so /sernia-settings renders.
+
+    Only writes when the row is missing — never overrides a real configuration.
+    """
+    from sqlalchemy import select
+
+    from api.src.database.database import AsyncSessionFactory
+    from api.src.sernia_ai.models import AppSetting
+
+    async with AsyncSessionFactory() as session:
+        existing = (
+            await session.execute(select(AppSetting).where(AppSetting.key == "model_config"))
+        ).scalar_one_or_none()
+        if existing:
+            log_info("✓ app_setting 'model_config' already exists")
+            return
+        if dry_run:
+            log_info("[DRY RUN] Would create app_setting 'model_config'")
+            return
+        session.add(AppSetting(key="model_config", value={"model_key": "gpt-5.4", "thinking_effort": "medium"}))
+        await session.commit()
+        log_info("✓ Created app_setting 'model_config' (gpt-5.4 / medium)")
+
+
+def _build_sample_conversations() -> list[dict]:
+    """Synthetic but realistically-shaped Sernia conversations.
+
+    Messages are built from real pydantic-ai message objects (not hand-written
+    JSON), so they always match the persistence format the UI and history
+    loaders expect — including tool call/return pairs.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        TextPart,
+        ToolCallPart,
+        ToolReturnPart,
+        UserPromptPart,
+    )
+
+    now = datetime.now(timezone.utc)
+
+    web_chat_messages = [
+        ModelRequest(parts=[UserPromptPart(
+            content="What maintenance tasks are open at 320?",
+            timestamp=now - timedelta(hours=3),
+        )]),
+        ModelResponse(parts=[ToolCallPart(
+            tool_name="clickup_search_tasks",
+            args={"query": "320 maintenance", "include_closed": False},
+            tool_call_id="seed_call_clickup_1",
+        )]),
+        ModelRequest(parts=[ToolReturnPart(
+            tool_name="clickup_search_tasks",
+            content=(
+                "- Task: Fix dripping faucet Unit 02 (id: seed0001)\n"
+                "  Status: in progress | Priority: normal | Due: 2026-06-15\n"
+                "  Assignees: John\n"
+                "- Task: Replace hallway light bulb (id: seed0002)\n"
+                "  Status: to do | Priority: low | Due: 2026-06-20\n"
+                "  Assignees: Emilio"
+            ),
+            tool_call_id="seed_call_clickup_1",
+            timestamp=now - timedelta(hours=3),
+        )]),
+        ModelResponse(parts=[TextPart(
+            content=(
+                "Two open maintenance tasks at 320:\n\n"
+                "1. **Dripping faucet, Unit 02** — in progress, assigned to John, due Jun 15\n"
+                "2. **Hallway light bulb** — to do, assigned to Emilio, due Jun 20"
+            ),
+        )]),
+    ]
+
+    sms_messages = [
+        ModelRequest(parts=[UserPromptPart(
+            content="did the plumber confirm for tomorrow?",
+            timestamp=now - timedelta(hours=1),
+        )]),
+        ModelResponse(parts=[TextPart(
+            content="Yes — confirmed for 9am tomorrow at 320 Unit 02. He'll text when en route.",
+        )]),
+    ]
+
+    memory_messages = [
+        ModelRequest(parts=[UserPromptPart(
+            content="Remember that the new dishwasher for Unit 05 arrives June 18.",
+            timestamp=now - timedelta(days=1),
+        )]),
+        ModelResponse(parts=[ToolCallPart(
+            tool_name="workspace_write_file",
+            args={
+                "path": "/workspace/daily_notes/2026-06-09_unit05-dishwasher.md",
+                "content": "Dishwasher delivery for Unit 05 scheduled June 18.",
+            },
+            tool_call_id="seed_call_ws_1",
+        )]),
+        ModelRequest(parts=[ToolReturnPart(
+            tool_name="workspace_write_file",
+            content="Wrote 52 chars to /workspace/daily_notes/2026-06-09_unit05-dishwasher.md",
+            tool_call_id="seed_call_ws_1",
+            timestamp=now - timedelta(days=1),
+        )]),
+        ModelResponse(parts=[TextPart(
+            content="Noted — I saved the June 18 dishwasher delivery for Unit 05 to my daily notes.",
+        )]),
+    ]
+
+    return [
+        {
+            "conversation_id": "seed_demo_web_chat_maintenance",
+            "messages": web_chat_messages,
+            "modality": "web_chat",
+            "contact_identifier": None,
+            "metadata": {"seed": True, "description": "Demo web chat with ClickUp tool round-trip"},
+        },
+        {
+            "conversation_id": "seed_demo_sms_plumber",
+            "messages": sms_messages,
+            "modality": "sms",
+            "contact_identifier": "+14125550100",
+            "metadata": {"seed": True, "description": "Demo SMS thread"},
+        },
+        {
+            "conversation_id": "seed_demo_memory_note",
+            "messages": memory_messages,
+            "modality": "web_chat",
+            "contact_identifier": None,
+            "metadata": {"seed": True, "description": "Demo workspace-memory write"},
+        },
+    ]
+
+
+async def seed_sample_conversations(dry_run: bool = False) -> None:
+    """Seed demo Sernia conversations so the chat UI and DB-search tools have data.
+
+    Non-production only: gives dev / PR / Claude-Code-on-web environments a
+    usable app out of the box (conversation list, message rendering with tool
+    calls, `db_search_conversations` results) without touching real data.
+    Idempotent via fixed conversation IDs.
+    """
+    if os.getenv("RAILWAY_ENVIRONMENT_NAME", "") == "production":
+        log_info("Skipping sample conversations (production environment)")
+        return
+
+    from sqlalchemy import select
+
+    from api.src.ai_demos.models import AgentConversation, save_agent_conversation
+    from api.src.database.database import AsyncSessionFactory
+    from api.src.sernia_ai.config import AGENT_NAME
+
+    samples = _build_sample_conversations()
+
+    async with AsyncSessionFactory() as session:
+        for sample in samples:
+            existing = (
+                await session.execute(
+                    select(AgentConversation.id).where(AgentConversation.id == sample["conversation_id"])
+                )
+            ).scalar_one_or_none()
+            if existing:
+                log_info(f"✓ Conversation '{sample['conversation_id']}' already exists")
+                continue
+            if dry_run:
+                log_info(f"[DRY RUN] Would create conversation '{sample['conversation_id']}'")
+                continue
+            await save_agent_conversation(
+                session=session,
+                conversation_id=sample["conversation_id"],
+                agent_name=AGENT_NAME,
+                messages=sample["messages"],
+                clerk_user_id=None,  # shared team access, matches Sernia convention
+                metadata=sample["metadata"],
+                modality=sample["modality"],
+                contact_identifier=sample["contact_identifier"],
+            )
+            await session.commit()
+            log_info(f"✓ Created conversation '{sample['conversation_id']}'")
+
+
 async def main(dry_run: bool = False) -> None:
     """Main entry point for seeding the database."""
     log_info("=" * 50)
@@ -140,6 +323,14 @@ async def main(dry_run: bool = False) -> None:
     log_info("")
     log_info("Seeding contacts...")
     await seed_contacts(dry_run=dry_run)
+
+    log_info("")
+    log_info("Seeding app settings...")
+    await seed_app_settings(dry_run=dry_run)
+
+    log_info("")
+    log_info("Seeding sample conversations (non-production only)...")
+    await seed_sample_conversations(dry_run=dry_run)
 
     log_info("")
     log_info("=" * 50)

--- a/api/src/ai_demos/agent_run_patching.py
+++ b/api/src/ai_demos/agent_run_patching.py
@@ -36,6 +36,7 @@ def patch_run_with_persistence(agent):
     agent.run = MethodType(run, agent)
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_agent_run_with_persistence():
     agent = Agent(

--- a/api/src/ai_demos/chat_emilio/agent.py
+++ b/api/src/ai_demos/chat_emilio/agent.py
@@ -87,6 +87,7 @@ async def get_emilio_links(ctx: RunContext[PortfolioContext]) -> dict:
     return EMILIO_LINKS
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_agent():
     """Test the agent locally"""

--- a/api/src/ai_demos/chat_weather/agent.py
+++ b/api/src/ai_demos/chat_weather/agent.py
@@ -57,6 +57,7 @@ async def get_current_weather(ctx: RunContext[ChatContext], latitude: float, lon
         logfire.error(f"Error fetching weather data: {e}")
         return {"error": f"Failed to fetch weather data: {str(e)}"}
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_agent():
     """Test the agent directly"""

--- a/api/src/ai_demos/multi_agent_chat/decision_agent.py
+++ b/api/src/ai_demos/multi_agent_chat/decision_agent.py
@@ -54,6 +54,7 @@ router_agent = Agent(
     retries=2,
 )
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_router_agent_routes_to_weather():
     """Test that router agent routes weather-related questions to weather agent"""

--- a/api/src/ai_demos/multi_agent_chat/graph.py
+++ b/api/src/ai_demos/multi_agent_chat/graph.py
@@ -189,6 +189,7 @@ g.add(
 multi_agent_graph = g.build()
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_multi_agent_graph_routes_to_weather():
     """Test that multi-agent graph routes weather questions to weather agent"""
@@ -201,6 +202,7 @@ async def test_multi_agent_graph_routes_to_weather():
     print(result.response)
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_multi_agent_graph_routes_to_weather_vercel_ai():
     """Test that multi-agent graph routes weather questions to weather agent"""

--- a/api/src/apscheduler_service/routes.py
+++ b/api/src/apscheduler_service/routes.py
@@ -47,6 +47,7 @@ async def get_jobs():
     return [job_to_dict(job) for job in jobs]
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_get_jobs():
 
@@ -102,6 +103,7 @@ async def delete_job(job_id: str):
         raise HTTPException(status_code=500, detail=f"Failed to delete job {job_id}: {str(e)}")
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_run_job_now():
     scheduler = get_scheduler()

--- a/api/src/apscheduler_service/service.py
+++ b/api/src/apscheduler_service/service.py
@@ -271,6 +271,7 @@ async def schedule_sms(
     return is_scheduled
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_schedule_sms():
     scheduler = get_scheduler()
@@ -361,6 +362,7 @@ def register_hello_apscheduler_jobs():
     )
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_schedule_email():
     scheduler = get_scheduler()
@@ -422,6 +424,7 @@ async def schedule_push(
     return is_scheduled
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_schedule_push():
     scheduler = get_scheduler()
@@ -475,6 +478,7 @@ async def run_hello_world(name: str):
   logfire.info(f"Hello {name} from apscheduler run_hello_world executed at {datetime.now()}")
 
 
+@pytest.mark.live
 def test_run_hello_world():
     # This function demonstrates adding a job and running the scheduler directly.
     # In the main app, scheduler.start() and scheduler.shutdown() are called by lifespan events.
@@ -538,6 +542,7 @@ async def job_that_will_fail():
     raise ValueError("This job is designed to fail for testing the error handler.")
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_job_that_will_fail():
     logfire.info("--- test_job_that_will_fail START ---")

--- a/api/src/database/database.py
+++ b/api/src/database/database.py
@@ -267,6 +267,12 @@ def wait_for_db(max_retries=10, delay=1):
 @logfire.instrument("test-async-engine-select-one")
 async def test_async_engine_select_one():
     """Run a SELECT 1 from the async engine to verify it's working."""
+    # The module-level engine's pool can hold connections bound to a previous
+    # test's (now closed) event loop — pytest-asyncio uses one loop per test.
+    # Dispose first so the pool reconnects on the current loop; otherwise this
+    # fails with "Event loop is closed" whenever another async test touched
+    # the engine earlier in the run.
+    await engine.dispose()
     try:
         async with engine.connect() as conn:
             result = await conn.execute(text("SELECT 1"))

--- a/api/src/google/calendar/service.py
+++ b/api/src/google/calendar/service.py
@@ -216,6 +216,7 @@ async def delete_calendar_event(service, event_id: str):
 # ------------------------------------------------------------------------------------------------
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_query_calendar_events():
     service = await get_calendar_service(user_email="emilio@serniacapital.com")
@@ -238,6 +239,7 @@ async def test_query_calendar_events():
     assert len(events) == 3
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_create_calendar_event():
     service = await get_calendar_service(user_email="all@serniacapital.com")

--- a/api/src/google/common/service_account_auth.py
+++ b/api/src/google/common/service_account_auth.py
@@ -2,6 +2,7 @@
 Shared authentication utilities for Google APIs.
 """
 
+import pytest
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv('.env'))
 from google.oauth2 import service_account
@@ -92,6 +93,7 @@ def get_service_credentials(scopes: Optional[List[str]] = None) -> service_accou
             detail=f"Failed to initialize Google service account credentials: {str(e)}"
         )
     
+@pytest.mark.live
 def test_get_service_credentials():
     creds = get_service_credentials()
     print(creds)

--- a/api/src/google/gmail/service.py
+++ b/api/src/google/gmail/service.py
@@ -204,6 +204,7 @@ async def send_email(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to send email: {str(e)}")
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_send_email():
     await send_email(

--- a/api/src/google/gmail/tests.py
+++ b/api/src/google/gmail/tests.py
@@ -3,6 +3,7 @@ from api.src.tests.conftest import *
 import os
 import logfire
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_get_zillow_emails(client):
     """Test the /gmail/get_zillow_emails endpoint"""

--- a/api/src/google/sheets/service.py
+++ b/api/src/google/sheets/service.py
@@ -108,6 +108,7 @@ def get_sheet_as_json(spreadsheet_id: str, sheet_name: str = 'Sheet1') -> List[D
             detail=f"Failed to convert sheet to JSON: {str(e)}"
         ) 
 
+@pytest.mark.live
 def test_get_contacts_sheet_as_json():
     spreadsheet_id = '1Gi0Wrkwm-gfCnAxycuTzHMjdebkB5cDt8wwimdYOr_M'
     return get_sheet_as_json(spreadsheet_id, sheet_name="OpenPhone")

--- a/api/src/oauth/service.py
+++ b/api/src/oauth/service.py
@@ -1,3 +1,5 @@
+import os
+
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -94,6 +96,10 @@ async def save_oauth_credentials(
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.path.exists("api/src/tests/sensitive/creds_response.pkl"),
+    reason="requires gitignored local fixture api/src/tests/sensitive/creds_response.pkl",
+)
 async def test_save_oauth_credentials():
     import pickle
 

--- a/api/src/open_phone/escalate.py
+++ b/api/src/open_phone/escalate.py
@@ -303,6 +303,7 @@ async def analyze_for_twilio_escalation(
     return successful_escalations
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_explicit_keyword_escalation():
     """
@@ -324,6 +325,7 @@ async def test_explicit_keyword_escalation():
     assert successful_escalations == 1
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_ai_escalation_positive():
     open_phone_event = {

--- a/api/src/open_phone/service.py
+++ b/api/src/open_phone/service.py
@@ -237,6 +237,7 @@ async def upsert_openphone_contact(contact_create: ContactCreate):
         
     return final_response
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_upsert_openphone_contact():
     contact_create = ContactCreate(

--- a/api/src/sernia_ai/PLAN.md
+++ b/api/src/sernia_ai/PLAN.md
@@ -528,7 +528,7 @@ Core function shared by all triggers:
 
 | Variable | Purpose |
 |----------|---------|
-| `SERNIA_ANTHROPIC_API_KEY` | Main + sub-agent LLM calls (bridged to `ANTHROPIC_API_KEY` at startup; renamed to avoid colliding with the key Claude Cloud injects in remote dev) |
+| `ANTHROPIC_API_KEY_PORTFOLIO` | Main + sub-agent LLM calls (bridged to `ANTHROPIC_API_KEY` in `api/__init__.py`; explicit name avoids colliding with Claude Code cloud sessions; `SERNIA_ANTHROPIC_API_KEY` is the deprecated fallback) |
 | `OPEN_PHONE_API_KEY` | Quo/OpenPhone API access |
 | `OPEN_PHONE_WEBHOOK_SECRET` | HMAC signature verification |
 | `VAPID_PRIVATE_KEY` / `VAPID_PUBLIC_KEY` | Web Push signing |

--- a/api/src/sernia_ai/PLAN.md
+++ b/api/src/sernia_ai/PLAN.md
@@ -528,7 +528,7 @@ Core function shared by all triggers:
 
 | Variable | Purpose |
 |----------|---------|
-| `ANTHROPIC_API_KEY_PORTFOLIO` | Main + sub-agent LLM calls (bridged to `ANTHROPIC_API_KEY` in `api/__init__.py`; explicit name avoids colliding with Claude Code cloud sessions; `SERNIA_ANTHROPIC_API_KEY` is the deprecated fallback) |
+| `SERNIA_ANTHROPIC_API_KEY` | Main + sub-agent LLM calls (bridged to `ANTHROPIC_API_KEY` in `api/__init__.py`; explicit name avoids colliding with Claude Code cloud sessions) |
 | `OPEN_PHONE_API_KEY` | Quo/OpenPhone API access |
 | `OPEN_PHONE_WEBHOOK_SECRET` | HMAC signature verification |
 | `VAPID_PRIVATE_KEY` / `VAPID_PUBLIC_KEY` | Web Push signing |

--- a/api/src/sernia_ai/push/routes.py
+++ b/api/src/sernia_ai/push/routes.py
@@ -92,3 +92,8 @@ async def test_push(
         data={"url": "/sernia-chat", "conversation_id": "test"},
     )
     return {"status": "sent"}
+
+
+# FastAPI route handler, not a pytest test — pytest.ini collects every
+# *.py file, so without this flag pytest tries to run the endpoint.
+test_push.__test__ = False

--- a/api/src/tests/test_ai_chat_vercel.py
+++ b/api/src/tests/test_ai_chat_vercel.py
@@ -14,6 +14,7 @@ def client():
     return TestClient(app)
 
 
+@pytest.mark.live
 def test_chat_emilio_endpoint_streaming_format(client):
     """
     Test that the /api/ai-demos/chat-emilio endpoint returns properly formatted SSE stream.

--- a/api/src/tests/test_multi_agent_chat_vercel.py
+++ b/api/src/tests/test_multi_agent_chat_vercel.py
@@ -211,6 +211,7 @@ def test_multi_agent_chat_routes_to_emilio(client):
         print(f"\n✓ Emilio routing: Received {len(parsed_events)} events")
 
 
+@pytest.mark.live
 def test_multi_agent_chat_handles_conversation_history(client):
     """Test endpoint handles conversation history"""
     request_body = {
@@ -253,6 +254,7 @@ def test_multi_agent_chat_handles_conversation_history(client):
         assert len(events) > 0
 
 
+@pytest.mark.live
 def test_multi_agent_chat_handles_empty_messages(client):
     """Test endpoint handles empty messages gracefully"""
     request_body = {

--- a/api/src/tests/test_multi_agent_chat_vercel.py
+++ b/api/src/tests/test_multi_agent_chat_vercel.py
@@ -14,6 +14,7 @@ def client():
     return TestClient(app)
 
 
+@pytest.mark.live
 def test_multi_agent_chat_routes_to_weather(client):
     """
     Test that the /api/ai-demos/multi-agent-chat endpoint routes weather questions correctly.
@@ -139,6 +140,7 @@ def test_multi_agent_chat_routes_to_weather(client):
         print(f"✓ Stream format is correct")
 
 
+@pytest.mark.live
 def test_multi_agent_chat_routes_to_emilio(client):
     """
     Test that the /api/ai-demos/multi-agent-chat endpoint routes Emilio questions correctly.

--- a/api/src/tests/test_open_phone.py
+++ b/api/src/tests/test_open_phone.py
@@ -3,6 +3,15 @@ from pprint import pprint
 from fastapi.testclient import TestClient
 from pytest import fixture
 import pytest
+import os
+
+# Payload fixtures are real webhook captures and are gitignored
+# (api/src/tests/requests/* in .gitignore). Skip the whole module where
+# they aren't present (fresh clones, CI, Claude Code on web).
+pytestmark = pytest.mark.skipif(
+    not os.path.isdir("api/src/tests/requests"),
+    reason="requires gitignored fixture payloads in api/src/tests/requests/",
+)
 from unittest.mock import AsyncMock, MagicMock, patch, Mock
 from api.index import app
 from api.src.open_phone.routes import OpenPhoneWebhookPayload, verify_open_phone_signature
@@ -116,6 +125,7 @@ def test_open_phone_webhook_call_transcript_completed(mocked_client):
         raise e
 
 
+@pytest.mark.live
 def test_get_contacts_success(mocked_client):
     """Test successful contact retrieval"""
 

--- a/api/src/utils/logfire_config.py
+++ b/api/src/utils/logfire_config.py
@@ -121,7 +121,11 @@ def ensure_logfire_configured(
         logfire.configure(
             service_name=service_name,
             environment=env_name,
-            send_to_logfire=True,
+            # "if-token-present": identical to True wherever LOGFIRE_TOKEN is
+            # set (Railway, local dev), but doesn't raise in tokenless
+            # environments like GitHub Actions — send_to_logfire=True crashes
+            # at import time there ("You are not logged into Logfire").
+            send_to_logfire="if-token-present",
             distributed_tracing=False,
             sampling=logfire.SamplingOptions(head=1.0, tail=_drop_dbos_sqlalchemy_sys_traces),
         )

--- a/api/src/zillow_email/service.py
+++ b/api/src/zillow_email/service.py
@@ -158,7 +158,7 @@ async def test_has_unreplied_emails():
         'Mon DD, HH12:MIpm'
     ) AS received_date_str;"""
     sent_message_count = await check_unreplied_emails(
-        sql=sql_query, target_slugs=["emilio"]
+        sql=sql_query, target_slugs=["emilio"], mock=True
     )
     assert sent_message_count == 1
 
@@ -173,7 +173,7 @@ async def test_has_no_unreplied_emails():
     ) AS received_date_str
     WHERE 1=0;"""
     sent_message_count = await check_unreplied_emails(
-        sql=sql_query, target_slugs=["emilio"]
+        sql=sql_query, target_slugs=["emilio"], mock=True
     )
     assert sent_message_count == 0
 
@@ -549,6 +549,7 @@ async def check_email_threads(overwrite_calendar_events=False):
                         )
 
 
+@pytest.mark.live
 @pytest.mark.asyncio
 async def test_check_email_threads():
     await check_email_threads(overwrite_calendar_events=True)

--- a/conftest.py
+++ b/conftest.py
@@ -11,3 +11,28 @@ import os
 
 os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-anthropic-key")
+
+# Several modules raise at import time when their service credentials are
+# absent (clerk.py, open_phone/escalate.py, clickup/service.py,
+# user/routes.py). The default suite never calls these services for real
+# (live tests excluded; unit tests mock them), but pytest.ini collects every
+# *.py under api/, so the imports must succeed. Dummies keep collection
+# working in credential-less environments (CI, fresh clones); setdefault
+# keeps real values intact when present.
+os.environ.setdefault("CLERK_SECRET_KEY", "test-clerk-secret")
+os.environ.setdefault("DEV_CLERK_WEBHOOK_SECRET", "test-clerk-webhook")
+os.environ.setdefault("PROD_CLERK_WEBHOOK_SECRET", "test-clerk-webhook")
+os.environ.setdefault("TWILIO_ACCOUNT_SID", "test-twilio-sid")
+os.environ.setdefault("TWILIO_AUTH_TOKEN", "test-twilio-token")
+os.environ.setdefault("CLICKUP_API_KEY", "test-clickup-key")
+# api/index.py's startup check (required_env_vars) — needed because the test
+# conftest imports `app`.
+os.environ.setdefault("SESSION_SECRET_KEY", "test-session-secret")
+os.environ.setdefault("GOOGLE_OAUTH_CLIENT_ID", "test-google-client-id")
+os.environ.setdefault("GOOGLE_OAUTH_CLIENT_SECRET", "test-google-client-secret")
+os.environ.setdefault("GOOGLE_OAUTH_REDIRECT_URI", "http://localhost:8000/api/oauth/callback")
+os.environ.setdefault("OPEN_PHONE_WEBHOOK_SECRET", "test-openphone-webhook")
+# utils/password.py unit test — any salt/hash works (it only asserts that
+# wrong passwords fail).
+os.environ.setdefault("ADMIN_PASSWORD_SALT", "test-salt")
+os.environ.setdefault("ADMIN_PASSWORD_HASH", "not-a-real-hash")

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,12 @@ markers =
 pythonpath = .
 testpaths = api
 asyncio_mode = strict
-asyncio_default_fixture_loop_scope = function
+; Session-scoped loop: the app uses module-level async engines (asyncpg pools).
+; With per-test loops, a pool created in one test holds connections bound to a
+; closed loop when the next test runs -> "Event loop is closed" failures that
+; depend on test order. One shared loop keeps the global pools valid all run.
+asyncio_default_fixture_loop_scope = session
+asyncio_default_test_loop_scope = session
 
 # logging
 log_cli = True

--- a/scripts/export_seed_fixture.py
+++ b/scripts/export_seed_fixture.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Export sanitized Sernia conversations as a committed seed fixture.
+
+Run this LOCALLY against the real database (Neon) — dev environments can't
+reach it. It pulls the most recent Sernia conversations, redacts PII
+(phone numbers and email addresses, deterministically so threads stay
+internally consistent), and writes a JSON fixture that `api/seed_db.py`
+loads into any non-production database.
+
+Usage (from repo root, with .env pointing at the source DB):
+    uv run python scripts/export_seed_fixture.py            # 10 most recent
+    uv run python scripts/export_seed_fixture.py --limit 25
+
+ALWAYS review the output file for PII the regexes missed (names, addresses
+in free text) BEFORE committing:
+    api/seed_fixtures/agent_conversations.json
+"""
+import argparse
+import asyncio
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+OUTPUT_PATH = Path("api/seed_fixtures/agent_conversations.json")
+
+# Phone numbers: +1 412 555 0100 / (412) 555-0100 / 4125550100 / +14125550100
+_PHONE_RE = re.compile(r"\+?1?[\s.\-(]*\d{3}[\s.\-)]*\d{3}[\s.\-]*\d{4}\b")
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@([A-Za-z0-9.\-]+\.[A-Za-z]{2,})")
+
+
+def _digest(value: str, n: int = 7) -> str:
+    """Deterministic short numeric digest so the same input maps to the same fake."""
+    return str(int(hashlib.sha256(value.encode()).hexdigest(), 16))[-n:]
+
+
+def _redact_phone(match: re.Match) -> str:
+    digits = re.sub(r"\D", "", match.group(0))
+    return f"+1555{_digest(digits)}"
+
+
+def _redact_email(match: re.Match) -> str:
+    domain = match.group(1).lower()
+    if domain == "serniacapital.com":
+        # Keep the internal domain — internal/external routing logic depends on it.
+        return f"internal-{_digest(match.group(0))}@serniacapital.com"
+    return f"user-{_digest(match.group(0))}@example.com"
+
+
+def sanitize_text(text: str) -> str:
+    text = _PHONE_RE.sub(_redact_phone, text)
+    text = _EMAIL_RE.sub(_redact_email, text)
+    return text
+
+
+def sanitize_value(value):
+    """Recursively sanitize strings inside any JSON-ish structure."""
+    if isinstance(value, str):
+        return sanitize_text(value)
+    if isinstance(value, list):
+        return [sanitize_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: sanitize_value(v) for k, v in value.items()}
+    return value
+
+
+async def export(limit: int) -> None:
+    from sqlalchemy import select
+
+    from api.src.ai_demos.models import AgentConversation
+    from api.src.database.database import AsyncSessionFactory
+
+    async with AsyncSessionFactory() as session:
+        result = await session.execute(
+            select(AgentConversation)
+            .where(AgentConversation.agent_name == "sernia")
+            .order_by(AgentConversation.updated_at.desc())
+            .limit(limit)
+        )
+        conversations = result.scalars().all()
+
+    rows = []
+    for conv in conversations:
+        rows.append(
+            {
+                # Stable fixture id namespace — never collides with real rows
+                # when the fixture is loaded back into another environment.
+                "id": f"fixture_{_digest(conv.id, 10)}",
+                "agent_name": conv.agent_name,
+                "messages": sanitize_value(conv.messages),
+                "metadata_": sanitize_value(conv.metadata_ or {}) | {"seed_fixture": True},
+                "modality": conv.modality,
+                "contact_identifier": sanitize_text(conv.contact_identifier)
+                if conv.contact_identifier
+                else None,
+            }
+        )
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(rows, indent=2, default=str) + "\n")
+    print(f"Wrote {len(rows)} sanitized conversations to {OUTPUT_PATH}")
+    print(
+        "\nIMPORTANT: phones/emails are redacted automatically, but names and "
+        "addresses inside free text are NOT.\nReview the file before committing."
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=10, help="How many recent conversations to export")
+    args = parser.parse_args()
+    try:
+        asyncio.run(export(args.limit))
+    except Exception as e:
+        print(f"Export failed: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Meta improvements to make agent-driven development faster and more reliable, following up on #268.

## ⚡ Actions for Emilio (after merge)

1. **Export the sanitized seed fixture** (one-time, locally where `.env` points at Neon):
   ```bash
   uv run python scripts/export_seed_fixture.py --limit 10
   # review api/seed_fixtures/agent_conversations.json for names/addresses, then commit it
   ```
   Phones/emails are auto-redacted; free-text names are not — review before committing.
2. **Optional**: add `SERNIA_ANTHROPIC_API_KEY` to the Claude Code environment config so cloud sessions can run live Anthropic tests (safe — the bridge keeps it away from the session's own `ANTHROPIC_API_KEY`).

## 1. The default test suite is now green with ZERO credentials

`pytest` (default, excludes `live`) previously had **26 failures** in any environment without real Google/OpenPhone/Anthropic keys — including Claude Code on web and fresh clones. Now: **366 passed, 4 skipped, 0 failed** with only local Postgres — verified in both a credential-scrubbed environment and a full dev environment.

- **26 tests marked `live`** (real APIs: Google Calendar/Gmail/Sheets, OpenPhone, real LLM calls in chat/streaming/router/escalation tests, APScheduler jobs). They still run via `pytest -m live <file>` — nothing deleted. Several were silently making paid OpenAI calls on every default test run.
- **🚨 Safety fix**: `zillow_email` unreplied tests were sending a **real SMS to Emilio on every default test run** (`mock` defaulted to `False`). Now `mock=True`. The schedule_sms/email/push tests that deliver real messages are `live`-only.
- **Bug fix**: `sernia_ai/push/routes.py`'s `/test` route handler is named `test_push`, so pytest was *executing the endpoint* (attempting a push broadcast). Flagged `__test__ = False`.
- **Bug fix**: order-dependent `"Event loop is closed"` failures — module-level asyncpg pools held connections bound to closed per-test loops. Fixed via session-scoped asyncio loop in `pytest.ini`.
- Root `conftest.py` provides dummy env vars for everything that raises at import time (Clerk, Twilio, ClickUp, `api/index.py`'s required-vars check, AI keys) — `setdefault`, so real values always win.
- Tests needing gitignored local fixtures (`tests/requests/`, `tests/sensitive/`) now `skipif` cleanly.

## 2. CI now actually runs tests

The repo had **no pytest in CI at all**. New `.github/workflows/tests.yml`: postgres:16 service container, `uv sync`, `alembic upgrade head`, seed, `pytest` (not live) — on every PR and push to main. Its first three runs each caught a real latent bug (Logfire crashing at import in tokenless envs → now `send_to_logfire="if-token-present"`; import-time credential requirements; hidden paid API calls in tests).

## 3. Anthropic key bridge hardened (name unchanged)

`SERNIA_ANTHROPIC_API_KEY` stays the canonical name. The bridge to `ANTHROPIC_API_KEY` (SDK auto-discovery) moved from `api/index.py` to `api/__init__.py` so **every** entry point gets it — FastAPI, pytest's inline-test collection, seed/CLI scripts — and `load_dotenv` now runs before bridging so local `.env` keys work too. No env var changes needed anywhere.

## 4. Richer sample data for dev environments

- `api/seed_db.py` seeds a default `model_config` app setting + three demo Sernia conversations built from **real pydantic-ai message objects** (web chat with ClickUp tool round-trip, SMS thread, workspace-memory write). Non-production only, idempotent.
- **New**: `scripts/export_seed_fixture.py` exports recent real Sernia conversations with deterministic phone/email redaction into `api/seed_fixtures/agent_conversations.json`; `seed_db.py` auto-loads the fixture in non-production environments (no-op until exported). Round-trip tested.

## 5. AGENTS.md + CLAUDE.md learnings

- `AGENTS.md` → symlink to `CLAUDE.md` (picked up by non-Claude agent tools).
- CLAUDE.md: the enforced "default suite needs no credentials" policy, pytest gotchas (`python_files = *.py` collection side-effects, `__init__.py` requirement, TestModel native-tool constraints, loop scope), Claude-Code-on-web environment constraints, and the Anthropic key naming rule.

## 6. GitHub Actions Node-24 bumps

`actions/checkout@v5`, `astral-sh/setup-uv@v6`, `actions/setup-python@v6` across all workflows (GitHub forces Node 24 on runners starting June 16, 2026).

## Preview

https://react-router-portfolio-pr-269.up.railway.app/

https://claude.ai/code/session_019XG83gyFp6fUKn4fEGV4zW