### PR TITLE
Fix deprecated OpenAI model in Gmail email generation endpoint

### DIFF
--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -6,3 +6,4 @@
 2026-06-07T23:36:57.633352+00:00  fired  session=session_01MRCqAxuA83EeTvtUnfT1HL  groups=4  hits=4
 2026-06-08T14:27:14.596947+00:00  fired  session=session_016wZDu6uUXeU4PaYe6CoRCn  groups=4  hits=4
 2026-06-08T23:01:03.758694+00:00  fired  session=session_012z9tZN4KmsaTi5uogZKhap  groups=4  hits=4
+2026-06-21T17:33:04.268488+00:00  fired  session=session_011faXq51tj5WXUZvDEjPnkF  groups=3  hits=3

--- a/api/src/google/gmail/routes.py
+++ b/api/src/google/gmail/routes.py
@@ -116,7 +116,7 @@ Please generate a professional and appropriate response:"""
 
         # Call OpenAI API using async client
         openai_response = await client.chat.completions.create(
-            model="gpt-4o",
+            model="gpt-5.4-mini",
             messages=[
                 {"role": "system", "content": "You are a professional real estate assistant."},
                 {"role": "user", "content": prompt}

--- a/api/src/google/gmail/routes.py
+++ b/api/src/google/gmail/routes.py
@@ -116,7 +116,7 @@ Please generate a professional and appropriate response:"""
 
         # Call OpenAI API using async client
         openai_response = await client.chat.completions.create(
-            model="gpt-4-turbo-preview",
+            model="gpt-4o",
             messages=[
                 {"role": "system", "content": "You are a professional real estate assistant."},
                 {"role": "user", "content": prompt}


### PR DESCRIPTION
## Summary

The `POST /api/google/gmail/generate_email_response` endpoint hardcoded the OpenAI model `gpt-4-turbo-preview`, which OpenAI has retired. Production requests now fail:

```
500: Failed to generate email response: Error code: 404 - {'error': {'message':
'The model `gpt-4-turbo-preview` does not exist or you do not have access to it.',
'type': 'invalid_request_error', 'code': 'model_not_found'}}
```

This change swaps the model to `gpt-5.4-mini`.

## Alert addressed

- **Logfire alert:** "Error-level records (non-local)" / tracked issue
- **Fingerprint:** `afa5bff3...` — `fastapi.exceptions.HTTPException`, first/last seen 2026-06-21T14:52:29Z, production, `service_name=fastapi`
- 1 occurrence so far; this is a hard failure on every call to the endpoint, not transient.

## Preview

https://react-router-portfolio-pr-272.up.railway.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)