### PR TITLE
fix(gmail): replace removed gpt-4-turbo-preview model in generate_email_response

### DIFF
--- a/api/src/google/gmail/routes.py
+++ b/api/src/google/gmail/routes.py
@@ -116,7 +116,7 @@ Please generate a professional and appropriate response:"""
 
         # Call OpenAI API using async client
         openai_response = await client.chat.completions.create(
-            model="gpt-4-turbo-preview",
+            model="gpt-4o",
             messages=[
                 {"role": "system", "content": "You are a professional real estate assistant."},
                 {"role": "user", "content": prompt}


### PR DESCRIPTION
## Summary

`POST /api/google/gmail/generate_email_response` was failing in production with HTTP 500s caused by an OpenAI `404 model_not_found`:

```
The model `gpt-4-turbo-preview` does not exist or you do not have access to it.
```

OpenAI no longer serves `gpt-4-turbo-preview`. This PR switches the call to `gpt-4o`, which is current and consistent with the rest of the codebase (the `gpt-4o` / `gpt-4o-mini` family is used in `zillow_email`, `ai_demos`, `open_phone`, etc.).

## Alert addressed

Logfire alert **"Error-level records (non-local)"** — fired 2026-06-21 ~14:52 UTC (trace `019eeaab36d2ef10874326e7bee197f3`, env `production`).

## Testing

Single-line model name change; no logic change. The endpoint's surrounding error handling is unchanged.

Preview: https://react-router-portfolio-pr-273.up.railway.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)