### PR TITLE
fix(gmail): explicit history-fetch timeout + stop benign "no history" reading as a failure

### DIFF
--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -9,3 +9,4 @@
 2026-06-21T17:33:04.268488+00:00  fired  session=session_011faXq51tj5WXUZvDEjPnkF  groups=3  hits=3
 2026-06-21T22:52:29.157799+00:00  fired  session=session_01ViuPc4ngWvCBcVvfHQrqmz  groups=3  hits=3
 2026-06-22T14:55:50.970727+00:00  fired  session=session_018KnNB6yWvBScb9VhQ1iLvT  groups=3  hits=3
+2026-06-23T13:53:19.084485+00:00  fired  session=session_01G9wGcudFfDe4etftiFVcYs  groups=1  hits=1

--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -11,3 +11,4 @@
 2026-06-22T14:55:50.970727+00:00  fired  session=session_018KnNB6yWvBScb9VhQ1iLvT  groups=3  hits=3
 2026-06-23T13:53:19.084485+00:00  fired  session=session_01G9wGcudFfDe4etftiFVcYs  groups=1  hits=1
 2026-06-23T22:53:52.564359+00:00  fired  session=session_016fida4zUzU8s8aMinaappR  groups=1  hits=1
+2026-06-24T13:44:41.021174+00:00  fired  session=session_014uHEWQeMC38YcuHpGjQuHD  groups=1  hits=1

--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -8,3 +8,4 @@
 2026-06-08T23:01:03.758694+00:00  fired  session=session_012z9tZN4KmsaTi5uogZKhap  groups=4  hits=4
 2026-06-21T17:33:04.268488+00:00  fired  session=session_011faXq51tj5WXUZvDEjPnkF  groups=3  hits=3
 2026-06-21T22:52:29.157799+00:00  fired  session=session_01ViuPc4ngWvCBcVvfHQrqmz  groups=3  hits=3
+2026-06-22T14:55:50.970727+00:00  fired  session=session_018KnNB6yWvBScb9VhQ1iLvT  groups=3  hits=3

--- a/.github/logfire-investigate/history.log
+++ b/.github/logfire-investigate/history.log
@@ -10,3 +10,4 @@
 2026-06-21T22:52:29.157799+00:00  fired  session=session_01ViuPc4ngWvCBcVvfHQrqmz  groups=3  hits=3
 2026-06-22T14:55:50.970727+00:00  fired  session=session_018KnNB6yWvBScb9VhQ1iLvT  groups=3  hits=3
 2026-06-23T13:53:19.084485+00:00  fired  session=session_01G9wGcudFfDe4etftiFVcYs  groups=1  hits=1
+2026-06-23T22:53:52.564359+00:00  fired  session=session_016fida4zUzU8s8aMinaappR  groups=1  hits=1

--- a/api/src/google/gmail/service.py
+++ b/api/src/google/gmail/service.py
@@ -3,6 +3,8 @@ Gmail service functionality for interacting with Gmail API.
 """
 
 from googleapiclient.discovery import build
+import httplib2
+import google_auth_httplib2
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import base64
@@ -36,15 +38,30 @@ SCOPES = [
 ]
 
 
+# Hard ceiling on a single Gmail API HTTP request. google-api-python-client builds
+# on httplib2, whose default socket timeout is None — so a stalled connection can hang
+# indefinitely (we observed a ~60s OS-level stall), blocking the request and the
+# Pub/Sub retry path. An explicit timeout makes a genuine hang fail fast so redelivery
+# can react. Generous enough not to trip on normal Gmail latency.
+GMAIL_HTTP_TIMEOUT_SECONDS = 30
+
+
 def get_gmail_service(credentials: Union[Credentials, service_account.Credentials]):
     """
     Creates and returns an authorized Gmail API service instance.
+
+    The underlying httplib2 transport is given an explicit timeout so a stalled
+    connection fails fast instead of hanging indefinitely.
 
     Args:
         credentials: Either service account or OAuth user credentials
     """
     try:
-        service = build("gmail", "v1", credentials=credentials)
+        authed_http = google_auth_httplib2.AuthorizedHttp(
+            credentials,
+            http=httplib2.Http(timeout=GMAIL_HTTP_TIMEOUT_SECONDS),
+        )
+        service = build("gmail", "v1", http=authed_http)
         return service
 
     except Exception as e:
@@ -326,12 +343,21 @@ async def get_email_changes(gmail_service, history_id: str, user_id: str = "me")
                     "reason": f"Exception fetching history: {str(e)}",
                 }
 
-    logfire.warn(f"Failed to retrieve history after {max_retries} retries")
+    # Reaching here means every attempt hit either "no history" or "history not yet
+    # available" — both benign. Genuine API errors (timeouts, etc.) return earlier and
+    # log at error level. This is high-volume, expected Gmail behavior (a watch fires
+    # but history.list has no in-scope changes to return: label-only changes, drafts,
+    # messages outside gmail.readonly), so log at info — NOT as a "failure" — so it does
+    # not masquerade as an outage in alerts/triage. Pub/Sub redelivery still applies.
+    logfire.info(
+        f"No retrievable history for ID {history_id} after {max_retries} attempts "
+        f"(benign: no in-scope changes or history not yet available)"
+    )
     return {
         "status": "retry_needed",
         "email_message_ids": [],
         "added_message_ids": [],
-        "reason": f"Failed to retrieve history after {max_retries} retries",
+        "reason": f"No retrievable history after {max_retries} attempts",
     }
 
 

--- a/api/src/tests/test_gmail_history.py
+++ b/api/src/tests/test_gmail_history.py
@@ -1,0 +1,91 @@
+"""
+Unit tests for Gmail history fetching (``get_email_changes``) and Gmail service
+construction (``get_gmail_service``).
+
+These mock the Gmail API entirely — no credentials or network required, so they
+run in the default (non-live) suite.
+
+Context: a daily Logfire triage once misread the benign, high-volume "no history
+found after N retries" outcome as an outage. That path is benign (a watch fires
+but ``history.list`` has no in-scope changes) and must not be logged as a
+failure. Genuine transport errors (timeouts) are the alertable case. These tests
+pin both behaviors, plus the explicit httplib2 timeout that prevents a stalled
+connection from hanging indefinitely.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.src.google.gmail.service import (
+    GMAIL_HTTP_TIMEOUT_SECONDS,
+    get_email_changes,
+    get_gmail_service,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_email_changes_success_returns_message_ids():
+    """When history.list returns history with messages, status is success."""
+    mock_service = MagicMock()
+    mock_service.users().history().list().execute.return_value = {
+        "history": [
+            {"messages": [{"id": "m1"}, {"id": "m2"}]},
+            {"messagesAdded": [{"message": {"id": "m3"}}]},
+        ]
+    }
+
+    result = await get_email_changes(mock_service, history_id="123")
+
+    assert result["status"] == "success"
+    assert set(result["email_message_ids"]) == {"m1", "m2", "m3"}
+    assert result["added_message_ids"] == ["m3"]
+
+
+@pytest.mark.asyncio
+async def test_get_email_changes_no_history_is_benign_not_failure():
+    """
+    A watch notification that yields no in-scope history must exhaust the retry
+    loop and return retry_needed with a *benign* reason — never a "failure"
+    string. Sleeps are patched so the exponential backoff doesn't actually wait.
+    """
+    mock_service = MagicMock()
+    # No "history" key on every attempt → the benign "no history found" path.
+    mock_service.users().history().list().execute.return_value = {"historyId": "999"}
+
+    with patch("api.src.google.gmail.service.asyncio.sleep", new=AsyncMock()):
+        result = await get_email_changes(mock_service, history_id="123")
+
+    assert result["status"] == "retry_needed"
+    assert result["email_message_ids"] == []
+    assert "No retrievable history" in result["reason"]
+    # Guard against regressing to the old alarming wording that fooled triage.
+    assert "Failed to retrieve history" not in result["reason"]
+
+
+@pytest.mark.asyncio
+async def test_get_email_changes_timeout_is_retry_needed_exception():
+    """A genuine transport error surfaces as retry_needed with an exception reason."""
+    mock_service = MagicMock()
+    mock_service.users().history().list().execute.side_effect = TimeoutError("timed out")
+
+    with patch("api.src.google.gmail.service.asyncio.sleep", new=AsyncMock()):
+        result = await get_email_changes(mock_service, history_id="123")
+
+    assert result["status"] == "retry_needed"
+    assert "Exception fetching history" in result["reason"]
+
+
+def test_get_gmail_service_sets_explicit_timeout():
+    """The Gmail transport must be built with an explicit httplib2 timeout so a
+    stalled connection fails fast instead of hanging indefinitely."""
+    fake_http = MagicMock()
+    with patch("api.src.google.gmail.service.httplib2.Http", return_value=fake_http) as mock_http, \
+         patch("api.src.google.gmail.service.google_auth_httplib2.AuthorizedHttp") as mock_authed, \
+         patch("api.src.google.gmail.service.build") as mock_build:
+        get_gmail_service(MagicMock())
+
+    mock_http.assert_called_once_with(timeout=GMAIL_HTTP_TIMEOUT_SECONDS)
+    # build() must use the authorized http (not the credentials= path) so the
+    # timeout actually takes effect.
+    assert mock_build.call_args.kwargs.get("http") is mock_authed.return_value


### PR DESCRIPTION
## Background

This came out of the daily Logfire triage. The triage initially flagged what looked like a **14h Gmail ingestion outage** — but after pulling a 14-day baseline, that was a **false alarm**:

- The `Failed to retrieve history after 4 retries` logs are **benign steady-state**, not failures. They're the "no history found" path: a Gmail watch notification fires but `history.list` has no in-scope change to return (label-only changes, drafts, messages outside `gmail.readonly`). This runs **56–194/day every day** for the last two weeks; the day in question was *below* average.
- Real history fetches were **completing, not timing out**. The actual socket-timeout error (`timed out`, error level) was **0/day except a single transient hit on 2026-06-23 12:00 UTC**, already cleared.
- The earlier "cert change" hypothesis is **not implicated** — a bad CA bundle throws `CERTIFICATE_VERIFY_FAILED`, not a socket timeout, and there were zero timeouts on the affected day.

So there was no outage. But the episode exposed two real, low-risk things worth fixing forward.

## Changes

**1. Explicit Gmail HTTP timeout (`GMAIL_HTTP_TIMEOUT_SECONDS = 30`).**
`google-api-python-client` builds on `httplib2`, whose default socket timeout is `None` — a stalled connection can hang indefinitely (we saw a ~60s OS-level stall). `get_gmail_service` now builds the service with an `AuthorizedHttp` wrapping `httplib2.Http(timeout=30)`, so a genuine hang fails fast and Pub/Sub redelivery can react.

**2. Stop the benign exhaustion from masquerading as a failure.**
`get_email_changes`' final fallthrough is only reached when *every* attempt was "no history" / "history not yet available" — both benign. It previously logged `warn("Failed to retrieve history after N retries")`, which reads as an outage in alerts/triage. It now logs at `info` with accurate wording. **Genuine transport errors are unchanged** — they still return earlier and log at `error` level (the alertable case), so a real sustained outage would still surface.

No change to return statuses or Pub/Sub behavior.

## Tests

Adds `api/src/tests/test_gmail_history.py` (fully mocked, no creds/network, runs in the default suite): success path, benign no-history path (asserts it does **not** use the old "Failed to retrieve history" wording), timeout path, and the explicit-timeout construction. Existing `test_google_tools.py` / `test_google_ca_bundle.py` still pass (38 passed).

## Alert addressed

Daily Logfire triage — `Failed to fetch history` / Gmail Pub/Sub history-fetch path (the benign-vs-real-failure signal that caused the misclassification).

## Preview

https://react-router-portfolio-pr-275.up.railway.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)