### PR TITLE
Upgrade Sernia AI to GPT-5.6 Luna at max effort

### DIFF
--- a/api/seed_db.py
+++ b/api/seed_db.py
@@ -152,11 +152,12 @@ async def seed_app_settings(dry_run: bool = False) -> None:
             return
         session.add(
             AppSetting(
-                key="model_config", value={"model_key": "gpt-5.4", "thinking_effort": "medium"}
+                key="model_config",
+                value={"model_key": "gpt-5.6-luna", "thinking_effort": "xhigh"},
             )
         )
         await session.commit()
-        log_info("✓ Created app_setting 'model_config' (gpt-5.4 / medium)")
+        log_info("✓ Created app_setting 'model_config' (gpt-5.6-luna / xhigh)")
 
 
 def _build_sample_conversations() -> list[dict]:

--- a/api/src/database/migrations/versions/0030_sernia_model_gpt56_luna.py
+++ b/api/src/database/migrations/versions/0030_sernia_model_gpt56_luna.py
@@ -1,0 +1,55 @@
+"""Upgrade Sernia AI model_config to gpt-5.6-luna at max (xhigh) effort.
+
+The ``gpt-5.4`` model key was retired from ``sernia_ai.model_config.ModelKey``
+in favor of ``gpt-5.6-luna``. Existing environments (production, and Neon PR
+branches that inherit production rows) store ``model_config`` = ``gpt-5.4`` /
+``medium``. This data migration moves those rows onto the new model at maximum
+reasoning effort so the upgrade takes effect on deploy without a manual admin
+edit.
+
+Only rows currently on the retired ``gpt-5.4`` key are touched — deliberate
+Anthropic selections (``sonnet-4-6`` / ``opus-4-7``) are left as-is. If the row
+is missing entirely, it is inserted with the new values.
+
+Revision ID: 0030_sernia_model_gpt56_luna
+Revises: 0029_repair_cost_columns
+Create Date: 2026-07-11 21:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0030_sernia_model_gpt56_luna'
+down_revision: Union[str, None] = '0029_repair_cost_columns'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Insert the row if absent; if present and still on the retired gpt-5.4 key,
+    # move it to gpt-5.6-luna / xhigh. Rows deliberately set to an Anthropic
+    # model are untouched (the DO UPDATE WHERE clause skips them).
+    op.execute(
+        """
+        INSERT INTO app_settings (key, value)
+        VALUES ('model_config', '{"model_key": "gpt-5.6-luna", "thinking_effort": "xhigh"}'::jsonb)
+        ON CONFLICT (key) DO UPDATE
+            SET value = EXCLUDED.value
+            WHERE app_settings.value->>'model_key' = 'gpt-5.4'
+        """
+    )
+
+
+def downgrade() -> None:
+    # Revert rows we moved onto gpt-5.6-luna back to the prior gpt-5.4 / medium.
+    op.execute(
+        """
+        UPDATE app_settings
+        SET value = '{"model_key": "gpt-5.4", "thinking_effort": "medium"}'::jsonb
+        WHERE key = 'model_config'
+          AND value->>'model_key' = 'gpt-5.6-luna'
+        """
+    )

--- a/api/src/sernia_ai/PLAN.md
+++ b/api/src/sernia_ai/PLAN.md
@@ -28,7 +28,7 @@
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| **LLM (main agent)** | Runtime-switchable via the `model_config` app_setting (default GPT-5.4). Supported: `openai-responses:gpt-5.4`, `anthropic:claude-sonnet-4-6`, `anthropic:claude-opus-4-7`. See `model_config.py`. | Native web search works across all three providers. Native web fetch is Anthropic-only; the `WebFetch` capability drops it automatically on OpenAI runs. |
+| **LLM (main agent)** | Runtime-switchable via the `model_config` app_setting (default GPT-5.6 Luna at max effort). Supported: `openai-responses:gpt-5.6-luna`, `anthropic:claude-sonnet-4-6`, `anthropic:claude-opus-4-7`. See `model_config.py`. | Native web search works across all three providers. Native web fetch is Anthropic-only; the `WebFetch` capability drops it automatically on OpenAI runs. |
 | **LLM (sub-agents)** | Claude Haiku 4.5 (`anthropic:claude-haiku-4-5-20251001`) | Cost savings for summarization/compaction. |
 | **Framework** | PydanticAI (latest stable API) | `instructions` list, `FileSystemToolset`, capabilities (`WebSearch`/`WebFetch`/`ProcessHistory`/`Instrumentation`/skills). |
 | **Code location** | `api/src/sernia_ai/` | Dedicated module. Imports from existing services. |

--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -9,7 +9,7 @@ Built with **PydanticAI** (Graph Beta API), **FastAPI**, and integrated with Ope
 - **Agent** (`agent.py`) — Main PydanticAI agent with tool use, sub-agents, and persistent memory
 - **Instructions** (`instructions.py`) — Static system prompt + dynamic context injection (datetime, memory, filetree, modality, triggers)
 - **Config** (`config.py`) — Phone IDs, rate limits, and other tunables
-- **Model config** (`model_config.py`) — Runtime-switchable main-agent model (GPT-5.4 / Sonnet 4.6 / Opus 4.7), resolved per run via the `model_config` app_setting. Web search/fetch live on the agent as provider-adaptive `WebSearch`/`WebFetch` capabilities (native web fetch is Anthropic-only and is dropped automatically on OpenAI runs).
+- **Model config** (`model_config.py`) — Runtime-switchable main-agent model (GPT-5.6 Luna / Sonnet 4.6 / Opus 4.7) and reasoning effort (low / medium / high / Max), resolved per run via the `model_config` app_setting. Web search/fetch live on the agent as provider-adaptive `WebSearch`/`WebFetch` capabilities (native web fetch is Anthropic-only and is dropped automatically on OpenAI runs).
 - **Routes** (`routes.py`) — FastAPI endpoints for chat, conversations, approvals, and admin
 
 ## Documentation

--- a/api/src/sernia_ai/ab_tests/README.md
+++ b/api/src/sernia_ai/ab_tests/README.md
@@ -29,7 +29,7 @@ python -m api.src.sernia_ai.ab_tests.model_comparison_rote
 # Override variants, reasoning, concurrency:
 python -m api.src.sernia_ai.ab_tests.model_comparison_search \
     --variant sonnet=anthropic:claude-sonnet-4-6 \
-    --variant gpt5=openai-responses:gpt-5.4 \
+    --variant gpt5=openai-responses:gpt-5.6-luna \
     --thinking high \
     --max-concurrency 2
 ```
@@ -53,7 +53,7 @@ pydantic-evals inverts the usual data-science terminology — be aware:
 
 | Classical DS | pydantic-evals |
 |---|---|
-| **Experiment** (the A/B test itself: "compare Sonnet vs GPT-5.4 on these prompts") | **Dataset** |
+| **Experiment** (the A/B test itself: "compare Sonnet vs GPT-5.6 Luna on these prompts") | **Dataset** |
 | **Variant / arm** (one model + settings) | **Experiment** |
 
 So the harness sets **`Dataset(name=<experiment_name>)`** to group all variants, and each call to **`evaluate(name=<variant>)`** is one arm. In the Logfire UI, navigate to *Datasets → `<experiment_name>` → Experiments* to see variants side-by-side.

--- a/api/src/sernia_ai/ab_tests/_cli.py
+++ b/api/src/sernia_ai/ab_tests/_cli.py
@@ -29,7 +29,7 @@ def build_parser(description: str, *, default_experiment_prefix: str) -> argpars
         "--variant",
         action="append",
         default=None,
-        help="Variant as name=model_string. Repeat for multiple. Default: sonnet-4-6 + gpt-5.4.",
+        help="Variant as name=model_string. Repeat for multiple. Default: sonnet-4-6 + gpt-5.6-luna.",
     )
     parser.add_argument(
         "--with-tools",

--- a/api/src/sernia_ai/ab_tests/_core.py
+++ b/api/src/sernia_ai/ab_tests/_core.py
@@ -41,7 +41,7 @@ from api.src.sernia_ai.deps import SerniaDeps
 # Use `openai-responses:` (not `openai:`) so WebSearchTool works.
 DEFAULT_VARIANTS: dict[str, str] = {
     "sonnet-4-6": "anthropic:claude-sonnet-4-6",
-    "gpt-5.4": "openai-responses:gpt-5.4",
+    "gpt-5.6-luna": "openai-responses:gpt-5.6-luna",
 }
 
 

--- a/api/src/sernia_ai/config.py
+++ b/api/src/sernia_ai/config.py
@@ -30,8 +30,8 @@ WEB_SEARCH_ALLOWED_DOMAINS: list[str] = [
 ]
 
 # Compaction: trigger at ~85% of context window token estimate.
-# All currently supported models (GPT-5.4, Claude Sonnet 4.6, Claude Opus 4.7)
-# have a 200k context window; adjust if adding a smaller model.
+# All currently supported models (GPT-5.6 Luna, Claude Sonnet 4.6, Claude Opus
+# 4.7) have a 200k context window; adjust if adding a smaller model.
 TOKEN_COMPACTION_THRESHOLD = 170_000
 
 # Summarization: tool results larger than this (chars) get summarized by the sub-agent.
@@ -43,7 +43,7 @@ SUMMARIZATION_CHAR_THRESHOLD = 10_000
 # as a fallback if the DB lookup fails or is bypassed.
 # Keep this an `openai-responses:` model so WebSearchTool (baked in at Agent
 # construction) works on the Chat Completions-incompatible Responses API.
-MAIN_AGENT_MODEL = "openai-responses:gpt-5.4"
+MAIN_AGENT_MODEL = "openai-responses:gpt-5.6-luna"
 
 # Sub-agent model (cheaper, no builtin tool dependency)
 SUB_AGENT_MODEL = "anthropic:claude-haiku-4-5-20251001"

--- a/api/src/sernia_ai/model_config.py
+++ b/api/src/sernia_ai/model_config.py
@@ -32,10 +32,15 @@ from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 from pydantic_ai.settings import ModelSettings
 from sqlalchemy import select
 
-ModelKey = Literal["gpt-5.4", "sonnet-4-6", "opus-4-7"]
-ThinkingEffort = Literal["low", "medium", "high"]
+ModelKey = Literal["gpt-5.6-luna", "sonnet-4-6", "opus-4-7"]
+# Effort tiers map onto pydantic-ai's unified `thinking` ThinkingLevel
+# (minimal/low/medium/high/xhigh). "xhigh" is the maximum reasoning depth —
+# surfaced in the UI as "Max".
+ThinkingEffort = Literal["low", "medium", "high", "xhigh"]
 
-DEFAULT_MODEL_KEY: ModelKey = "gpt-5.4"
+DEFAULT_MODEL_KEY: ModelKey = "gpt-5.6-luna"
+# Safe fallback only — used when the DB lookup fails or is bypassed. The active
+# effort is the DB-backed `model_config` row (seeded/migrated to "xhigh").
 DEFAULT_THINKING_EFFORT: ThinkingEffort = "medium"
 _VALID_EFFORTS: frozenset[str] = frozenset(get_args(ThinkingEffort))
 
@@ -45,16 +50,16 @@ class ModelChoice:
     key: ModelKey
     label: str
     provider: Literal["openai", "anthropic"]
-    model_string: str  # e.g. "openai-responses:gpt-5.4"
+    model_string: str  # e.g. "openai-responses:gpt-5.6-luna"
     cost_note: str | None = None
 
 
 AVAILABLE_MODELS: tuple[ModelChoice, ...] = (
     ModelChoice(
-        key="gpt-5.4",
-        label="GPT-5.4",
+        key="gpt-5.6-luna",
+        label="GPT-5.6 Luna",
         provider="openai",
-        model_string="openai-responses:gpt-5.4",
+        model_string="openai-responses:gpt-5.6-luna",
     ),
     ModelChoice(
         key="sonnet-4-6",
@@ -93,12 +98,13 @@ def build_run_kwargs(key: str | None, effort: str | None = None) -> dict:
     The only provider-specific parts left are the prompt-cache knobs; web
     search/fetch live on the agent as provider-adaptive capabilities.
 
-    ``effort`` controls reasoning depth — low/medium/high — via the unified
-    ``thinking`` model setting. On Sonnet 4.6 and Opus 4.7 pydantic-ai maps it
-    to adaptive thinking + effort
+    ``effort`` controls reasoning depth — low/medium/high/xhigh ("Max") — via
+    the unified ``thinking`` model setting. On Sonnet 4.6 and Opus 4.7
+    pydantic-ai maps it to adaptive thinking + effort
     (https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking),
-    where Claude decides per-request whether and how much to think. On GPT-5.4
-    it maps to ``reasoning_effort``. Defaults to medium.
+    where Claude decides per-request whether and how much to think. On GPT-5.6
+    Luna it maps to ``reasoning_effort``. Falls back to medium for a
+    missing/unknown value.
     """
     choice = get_model_choice(key)
     resolved_effort = get_thinking_effort(effort)

--- a/api/src/tests/test_model_config.py
+++ b/api/src/tests/test_model_config.py
@@ -12,8 +12,8 @@ import pytest
 def test_build_run_kwargs_openai_shape():
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    kw = build_run_kwargs("gpt-5.4")
-    assert kw["model"] == "openai-responses:gpt-5.4"
+    kw = build_run_kwargs("gpt-5.6-luna")
+    assert kw["model"] == "openai-responses:gpt-5.6-luna"
     # No per-run native tools anymore — web search/fetch live on the agent
     # as provider-adaptive capabilities.
     assert "builtin_tools" not in kw
@@ -41,9 +41,9 @@ def test_build_run_kwargs_anthropic_shape():
 def test_build_run_kwargs_unknown_key_falls_back_to_default():
     from api.src.sernia_ai.model_config import DEFAULT_MODEL_KEY, build_run_kwargs
 
-    assert DEFAULT_MODEL_KEY == "gpt-5.4"
-    assert build_run_kwargs(None)["model"] == "openai-responses:gpt-5.4"
-    assert build_run_kwargs("nonsense")["model"] == "openai-responses:gpt-5.4"
+    assert DEFAULT_MODEL_KEY == "gpt-5.6-luna"
+    assert build_run_kwargs(None)["model"] == "openai-responses:gpt-5.6-luna"
+    assert build_run_kwargs("nonsense")["model"] == "openai-responses:gpt-5.6-luna"
 
 
 def test_default_thinking_effort_is_medium():
@@ -52,7 +52,7 @@ def test_default_thinking_effort_is_medium():
     assert DEFAULT_THINKING_EFFORT == "medium"
 
 
-@pytest.mark.parametrize("key", ["gpt-5.4", "sonnet-4-6", "opus-4-7"])
+@pytest.mark.parametrize("key", ["gpt-5.6-luna", "sonnet-4-6", "opus-4-7"])
 def test_unified_thinking_defaults_to_medium(key: str):
     """All models get the unified `thinking` setting (pydantic-ai maps it to
     adaptive thinking + effort on Anthropic, reasoning_effort on OpenAI)."""
@@ -62,11 +62,12 @@ def test_unified_thinking_defaults_to_medium(key: str):
     assert kw["model_settings"].get("thinking") == "medium", key
 
 
-@pytest.mark.parametrize("effort", ["low", "medium", "high"])
+@pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh"])
 def test_explicit_effort_threads_through_for_both_providers(effort: str):
+    """Includes ``xhigh`` — the "Max" effort tier surfaced in the settings UI."""
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    assert build_run_kwargs("gpt-5.4", effort)["model_settings"].get("thinking") == effort
+    assert build_run_kwargs("gpt-5.6-luna", effort)["model_settings"].get("thinking") == effort
     assert build_run_kwargs("sonnet-4-6", effort)["model_settings"].get("thinking") == effort
 
 
@@ -91,14 +92,14 @@ def test_unknown_effort_falls_back_to_medium():
     from api.src.sernia_ai.model_config import build_run_kwargs
 
     assert build_run_kwargs("sonnet-4-6", "ultra")["model_settings"].get("thinking") == "medium"
-    assert build_run_kwargs("gpt-5.4", None)["model_settings"].get("thinking") == "medium"
+    assert build_run_kwargs("gpt-5.6-luna", None)["model_settings"].get("thinking") == "medium"
 
 
 def test_available_models_cover_all_keys():
     from api.src.sernia_ai.model_config import AVAILABLE_MODELS
 
     keys = {m.key for m in AVAILABLE_MODELS}
-    assert keys == {"gpt-5.4", "sonnet-4-6", "opus-4-7"}
+    assert keys == {"gpt-5.6-luna", "sonnet-4-6", "opus-4-7"}
     providers = {m.provider for m in AVAILABLE_MODELS}
     assert providers == {"openai", "anthropic"}
     # Opus carries a cost note so the UI can warn users.

--- a/api/src/tests/test_sernia_agent_wiring.py
+++ b/api/src/tests/test_sernia_agent_wiring.py
@@ -81,7 +81,7 @@ class TestProviderAdaptiveNativeTools:
         from pydantic_ai.models.openai import OpenAIResponsesModel
         from pydantic_ai.providers.openai import OpenAIProvider
 
-        model = OpenAIResponsesModel("gpt-5.4", provider=OpenAIProvider(api_key="test-key"))
+        model = OpenAIResponsesModel("gpt-5.6-luna", provider=OpenAIProvider(api_key="test-key"))
         assert WebSearchTool in model.profile.supported_native_tools
         assert WebFetchTool not in model.profile.supported_native_tools
 

--- a/apps/web-react-router/app/routes/sernia-settings.tsx
+++ b/apps/web-react-router/app/routes/sernia-settings.tsx
@@ -69,7 +69,7 @@ interface ModelChoice {
   cost_note: string | null;
 }
 
-type ThinkingEffort = "low" | "medium" | "high";
+type ThinkingEffort = "low" | "medium" | "high" | "xhigh";
 
 interface ModelConfig {
   model_key: string;
@@ -80,6 +80,7 @@ const EFFORT_OPTIONS: { value: ThinkingEffort; label: string; hint: string }[] =
   { value: "low", label: "Low", hint: "Fast, minimal thinking. Skips simple queries." },
   { value: "medium", label: "Medium", hint: "Balanced. Sensible default for chat." },
   { value: "high", label: "High", hint: "Deeper reasoning. Slower, more tokens." },
+  { value: "xhigh", label: "Max", hint: "Maximum reasoning depth. Slowest, most tokens." },
 ];
 
 const DEFAULT_EFFORT: ThinkingEffort = "medium";
@@ -97,9 +98,9 @@ interface Settings {
   available_models: ModelChoice[];
 }
 
-const DEFAULT_MODEL_KEY = "gpt-5.4";
+const DEFAULT_MODEL_KEY = "gpt-5.6-luna";
 const FALLBACK_MODELS: ModelChoice[] = [
-  { key: "gpt-5.4", label: "GPT-5.4", provider: "openai", cost_note: null },
+  { key: "gpt-5.6-luna", label: "GPT-5.6 Luna", provider: "openai", cost_note: null },
   { key: "sonnet-4-6", label: "Claude Sonnet 4.6", provider: "anthropic", cost_note: null },
   { key: "opus-4-7", label: "Claude Opus 4.7", provider: "anthropic", cost_note: "~5x Sonnet pricing — use sparingly." },
 ];


### PR DESCRIPTION
## Description

Upgrades the main Sernia AI agent from **GPT-5.4** to **GPT-5.6 Luna** and runs it at **max reasoning effort**.

pydantic-ai's unified `thinking` setting tops out at `xhigh` (levels: minimal / low / medium / high / xhigh), so "max effort" maps to `xhigh`, which is surfaced in the settings UI as **"Max"**.

### What changed
- **`model_config.py`** — Replace `gpt-5.4` with `gpt-5.6-luna` in `ModelKey` / `AVAILABLE_MODELS` and make it `DEFAULT_MODEL_KEY`. Extend `ThinkingEffort` with `xhigh` ("Max"). `DEFAULT_THINKING_EFFORT` stays `medium` as the **safe fallback** for a missing/unknown value — the *active* max-effort setting lives in the DB-backed `model_config` row (below).
- **`config.py`** — `MAIN_AGENT_MODEL` → `openai-responses:gpt-5.6-luna` (Agent-construction fallback).
- **`seed_db.py`** — Fresh environments seed `model_config` as `gpt-5.6-luna / xhigh`.
- **Migration `0030_sernia_model_gpt56_luna`** — Idempotent upsert that moves existing `model_config` rows off the retired `gpt-5.4` key to `gpt-5.6-luna / xhigh`, so the upgrade takes effect on deploy (including Neon PR branches that inherit the production row) without a manual admin edit. Deliberate Anthropic selections (`sonnet-4-6` / `opus-4-7`) are left untouched; verified down/up round-trip.
- **`sernia-settings.tsx`** — Add the **Max** effort option; update the OpenAI model choice and defaults.
- **Tests / A/B harness / docs** — Updated `test_model_config.py` (incl. an `xhigh` case) and `test_sernia_agent_wiring.py`, the A/B `DEFAULT_VARIANTS`, and the Sernia `README` / `PLAN` docs.

### Verification
- `pytest api/src/tests/test_model_config.py test_sernia_agent_wiring.py test_llm_cost_breakdown.py` → 29 passed.
- Frontend `pnpm typecheck` → clean.
- Applied migration locally: `model_config` row went `gpt-5.4/medium` → `gpt-5.6-luna/xhigh`; `resolve_active_run_kwargs()` resolves `openai-responses:gpt-5.6-luna` at `xhigh`.

### Not in scope / follow-up
- The LLM-cost Logfire dashboard (`logfire/dashboards/llm-cost`) prices models by name and has **no `gpt-5.6-luna` pricing tier yet**, so new-model spend will show as `$0` until its per-token pricing is added. I left it out rather than guess pricing (which would fabricate cost numbers); the existing `gpt-5.4` tiers stay for historical attribution.
- `api/src/google/gmail/routes.py` still uses `gpt-5.4-mini` for the standalone Zillow-email endpoint — a separate model unrelated to the Sernia agent.

Railway preview: https://react-router-portfolio-pr-278.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)