### PR TITLE
Add "max" reasoning-effort tier and set Sernia AI to max

### DIFF
--- a/api/seed_db.py
+++ b/api/seed_db.py
@@ -153,11 +153,11 @@ async def seed_app_settings(dry_run: bool = False) -> None:
         session.add(
             AppSetting(
                 key="model_config",
-                value={"model_key": "gpt-5.6-luna", "thinking_effort": "xhigh"},
+                value={"model_key": "gpt-5.6-luna", "thinking_effort": "max"},
             )
         )
         await session.commit()
-        log_info("✓ Created app_setting 'model_config' (gpt-5.6-luna / xhigh)")
+        log_info("✓ Created app_setting 'model_config' (gpt-5.6-luna / max)")
 
 
 def _build_sample_conversations() -> list[dict]:

--- a/api/src/database/migrations/versions/0031_sernia_effort_max.py
+++ b/api/src/database/migrations/versions/0031_sernia_effort_max.py
@@ -1,0 +1,51 @@
+"""Bump Sernia AI reasoning effort to "max" for the gpt-5.6-luna model_config.
+
+GPT-5.6 added a "max" reasoning-effort tier above "xhigh" (even more
+exploration/verification). Migration 0030 moved existing rows onto
+gpt-5.6-luna / xhigh; this bumps that active row to the new top tier.
+
+Only the gpt-5.6-luna row is touched — deliberate Anthropic selections
+(sonnet-4-6 / opus-4-7) keep their effort (and "max" is OpenAI-only anyway).
+
+Revision ID: 0031_sernia_effort_max
+Revises: 0030_sernia_model_gpt56_luna
+Create Date: 2026-07-12 00:45:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0031_sernia_effort_max'
+down_revision: Union[str, None] = '0030_sernia_model_gpt56_luna'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Set the gpt-5.6-luna model_config row to max effort. Idempotent: re-running
+    # is a no-op once the row already reads "max".
+    op.execute(
+        """
+        UPDATE app_settings
+        SET value = jsonb_set(value, '{thinking_effort}', '"max"')
+        WHERE key = 'model_config'
+          AND value->>'model_key' = 'gpt-5.6-luna'
+          AND value->>'thinking_effort' IS DISTINCT FROM 'max'
+        """
+    )
+
+
+def downgrade() -> None:
+    # Revert to the prior effort established by migration 0030.
+    op.execute(
+        """
+        UPDATE app_settings
+        SET value = jsonb_set(value, '{thinking_effort}', '"xhigh"')
+        WHERE key = 'model_config'
+          AND value->>'model_key' = 'gpt-5.6-luna'
+          AND value->>'thinking_effort' = 'max'
+        """
+    )

--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -9,7 +9,7 @@ Built with **PydanticAI** (Graph Beta API), **FastAPI**, and integrated with Ope
 - **Agent** (`agent.py`) — Main PydanticAI agent with tool use, sub-agents, and persistent memory
 - **Instructions** (`instructions.py`) — Static system prompt + dynamic context injection (datetime, memory, filetree, modality, triggers)
 - **Config** (`config.py`) — Phone IDs, rate limits, and other tunables
-- **Model config** (`model_config.py`) — Runtime-switchable main-agent model (GPT-5.6 Luna / Sonnet 4.6 / Opus 4.7) and reasoning effort (low / medium / high / Max), resolved per run via the `model_config` app_setting. Web search/fetch live on the agent as provider-adaptive `WebSearch`/`WebFetch` capabilities (native web fetch is Anthropic-only and is dropped automatically on OpenAI runs).
+- **Model config** (`model_config.py`) — Runtime-switchable main-agent model (GPT-5.6 Luna / Sonnet 4.6 / Opus 4.7) and reasoning effort (Low / Medium / High / X-High / Max — Max is GPT-5.6's top tier, above X-High), resolved per run via the `model_config` app_setting. Web search/fetch live on the agent as provider-adaptive `WebSearch`/`WebFetch` capabilities (native web fetch is Anthropic-only and is dropped automatically on OpenAI runs).
 - **Routes** (`routes.py`) — FastAPI endpoints for chat, conversations, approvals, and admin
 
 ## Documentation

--- a/api/src/sernia_ai/model_config.py
+++ b/api/src/sernia_ai/model_config.py
@@ -16,9 +16,12 @@ provider.
 Web search/fetch are no longer attached here: the agent's ``WebSearch`` /
 ``WebFetch`` capabilities (see ``agent.py``) adapt to the active provider
 automatically (native web fetch is Anthropic-only and is dropped on OpenAI
-runs). Thinking depth uses the unified ``thinking`` model setting, which
-pydantic-ai maps to adaptive thinking + effort on Anthropic and
-``reasoning_effort`` on OpenAI.
+runs). Reasoning depth (low/medium/high/xhigh/max) is provider-routed: on
+OpenAI it is passed through as the native ``openai_reasoning_effort`` (so
+GPT-5.6's ``max`` tier, newer than the pinned pydantic-ai's unified
+``thinking`` map, works); on Anthropic it feeds the unified ``thinking``
+setting, mapped to adaptive thinking + effort (``max`` clamps to ``xhigh``,
+being OpenAI-only).
 """
 
 from __future__ import annotations
@@ -33,14 +36,18 @@ from pydantic_ai.settings import ModelSettings
 from sqlalchemy import select
 
 ModelKey = Literal["gpt-5.6-luna", "sonnet-4-6", "opus-4-7"]
-# Effort tiers map onto pydantic-ai's unified `thinking` ThinkingLevel
-# (minimal/low/medium/high/xhigh). "xhigh" is the maximum reasoning depth —
-# surfaced in the UI as "Max".
-ThinkingEffort = Literal["low", "medium", "high", "xhigh"]
+# Reasoning-effort tiers, ascending. low/medium/high/xhigh come from OpenAI's
+# reasoning_effort scale; "max" is GPT-5.6's top tier (added *above* xhigh — it
+# gives the model even more time to explore alternatives, run checks, and
+# revise). On OpenAI models the tier is passed straight through as
+# `openai_reasoning_effort`; the pinned pydantic-ai's unified `thinking` map
+# only knows up to xhigh, so "max" must use the native knob. "max" is
+# OpenAI-only — on Anthropic models it clamps to "xhigh" (see build_run_kwargs).
+ThinkingEffort = Literal["low", "medium", "high", "xhigh", "max"]
 
 DEFAULT_MODEL_KEY: ModelKey = "gpt-5.6-luna"
 # Safe fallback only — used when the DB lookup fails or is bypassed. The active
-# effort is the DB-backed `model_config` row (seeded/migrated to "xhigh").
+# effort is the DB-backed `model_config` row (seeded/migrated to "max").
 DEFAULT_THINKING_EFFORT: ThinkingEffort = "medium"
 _VALID_EFFORTS: frozenset[str] = frozenset(get_args(ThinkingEffort))
 
@@ -98,12 +105,16 @@ def build_run_kwargs(key: str | None, effort: str | None = None) -> dict:
     The only provider-specific parts left are the prompt-cache knobs; web
     search/fetch live on the agent as provider-adaptive capabilities.
 
-    ``effort`` controls reasoning depth — low/medium/high/xhigh ("Max") — via
-    the unified ``thinking`` model setting. On Sonnet 4.6 and Opus 4.7
-    pydantic-ai maps it to adaptive thinking + effort
+    ``effort`` controls reasoning depth — low/medium/high/xhigh/max, ascending.
+    On GPT-5.6 Luna it is passed through as ``openai_reasoning_effort`` (the
+    Responses API's native knob), so the full tier list — including ``max``,
+    GPT-5.6's highest — works regardless of the pinned pydantic-ai's unified
+    ``thinking`` map (which only knows up to xhigh). On Sonnet 4.6 and Opus 4.7
+    the effort feeds the unified ``thinking`` setting, which pydantic-ai maps to
+    adaptive thinking + effort
     (https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking),
-    where Claude decides per-request whether and how much to think. On GPT-5.6
-    Luna it maps to ``reasoning_effort``. Falls back to medium for a
+    where Claude decides per-request whether and how much to think; ``max`` is
+    OpenAI-only, so it clamps to ``xhigh`` there. Falls back to medium for a
     missing/unknown value.
     """
     choice = get_model_choice(key)
@@ -111,17 +122,24 @@ def build_run_kwargs(key: str | None, effort: str | None = None) -> dict:
     settings: ModelSettings
 
     if choice.provider == "anthropic":
+        # "max" is an OpenAI-only tier; Anthropic's highest adaptive effort is
+        # "xhigh", so clamp it there for Claude models.
+        anthropic_effort = "xhigh" if resolved_effort == "max" else resolved_effort
         settings = AnthropicModelSettings(
             anthropic_cache_instructions=True,
             anthropic_cache_tool_definitions=True,
             anthropic_cache_messages=True,
-            thinking=resolved_effort,
+            thinking=anthropic_effort,
         )
     else:  # openai
+        # Route effort through the native ``openai_reasoning_effort`` knob rather
+        # than the unified ``thinking`` field: GPT-5.6's "max" tier is newer than
+        # the pinned pydantic-ai's ThinkingLevel map (which tops out at xhigh),
+        # and the native knob is forwarded verbatim to the Responses API.
         # `openai_prompt_cache_retention="24h"` extends the default ~5–10 min
         # in-memory cache to 24h so infrequent scheduled runs still hit cache.
         settings = OpenAIResponsesModelSettings(
-            thinking=resolved_effort,
+            openai_reasoning_effort=resolved_effort,
             openai_prompt_cache_retention="24h",
         )
 

--- a/api/src/tests/test_model_config.py
+++ b/api/src/tests/test_model_config.py
@@ -1,9 +1,13 @@
 """Smoke tests for sernia_ai.model_config — keeps the runtime model picker honest.
 
-Since the pydantic-ai 1.106 upgrade, web search/fetch are provider-adaptive
-capabilities on the agent itself (see test_sernia_agent_wiring.py), and
-thinking depth uses the unified ``thinking`` model setting instead of the
-provider-specific ``anthropic_thinking``/``openai_reasoning_effort`` knobs.
+Effort tiers are provider-routed (see ``model_config.build_run_kwargs``):
+- OpenAI (GPT-5.6 Luna): the effort is passed through as the native
+  ``openai_reasoning_effort`` knob, so the full ladder — including ``max``,
+  GPT-5.6's top tier above ``xhigh`` — works regardless of the pinned
+  pydantic-ai's unified ``thinking`` map (which only knows up to xhigh).
+- Anthropic (Sonnet 4.6 / Opus 4.7): the effort feeds the unified ``thinking``
+  setting (mapped to adaptive thinking). ``max`` is OpenAI-only, so it clamps
+  to ``xhigh`` there.
 """
 
 import pytest
@@ -17,8 +21,12 @@ def test_build_run_kwargs_openai_shape():
     # No per-run native tools anymore — web search/fetch live on the agent
     # as provider-adaptive capabilities.
     assert "builtin_tools" not in kw
+    settings = kw["model_settings"]
     # OpenAI Responses settings include the cache retention knob.
-    assert kw["model_settings"].get("openai_prompt_cache_retention") == "24h"
+    assert settings.get("openai_prompt_cache_retention") == "24h"
+    # Effort routes through the native reasoning-effort knob, not unified thinking.
+    assert settings.get("openai_reasoning_effort") == "medium"
+    assert "thinking" not in settings
 
 
 def test_build_run_kwargs_anthropic_shape():
@@ -52,23 +60,41 @@ def test_default_thinking_effort_is_medium():
     assert DEFAULT_THINKING_EFFORT == "medium"
 
 
-@pytest.mark.parametrize("key", ["gpt-5.6-luna", "sonnet-4-6", "opus-4-7"])
-def test_unified_thinking_defaults_to_medium(key: str):
-    """All models get the unified `thinking` setting (pydantic-ai maps it to
-    adaptive thinking + effort on Anthropic, reasoning_effort on OpenAI)."""
+def test_effort_defaults_to_medium_for_both_providers():
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    kw = build_run_kwargs(key)
-    assert kw["model_settings"].get("thinking") == "medium", key
+    openai_settings = build_run_kwargs("gpt-5.6-luna")["model_settings"]
+    assert openai_settings.get("openai_reasoning_effort") == "medium"
+    anthropic_settings = build_run_kwargs("sonnet-4-6")["model_settings"]
+    assert anthropic_settings.get("thinking") == "medium"
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+def test_openai_effort_uses_reasoning_effort_knob(effort: str):
+    """All tiers — including ``max`` (GPT-5.6's top tier, newer than the pinned
+    pydantic-ai's unified ``thinking`` map) — pass through the native knob."""
+    from api.src.sernia_ai.model_config import build_run_kwargs
+
+    settings = build_run_kwargs("gpt-5.6-luna", effort)["model_settings"]
+    assert settings.get("openai_reasoning_effort") == effort
+    assert "thinking" not in settings
 
 
 @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh"])
-def test_explicit_effort_threads_through_for_both_providers(effort: str):
-    """Includes ``xhigh`` — the "Max" effort tier surfaced in the settings UI."""
+def test_anthropic_effort_uses_unified_thinking(effort: str):
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    assert build_run_kwargs("gpt-5.6-luna", effort)["model_settings"].get("thinking") == effort
     assert build_run_kwargs("sonnet-4-6", effort)["model_settings"].get("thinking") == effort
+
+
+def test_max_effort_is_native_on_openai_and_clamps_on_anthropic():
+    """``max`` is OpenAI-only; on Claude models it clamps to xhigh."""
+    from api.src.sernia_ai.model_config import build_run_kwargs
+
+    openai_settings = build_run_kwargs("gpt-5.6-luna", "max")["model_settings"]
+    assert openai_settings.get("openai_reasoning_effort") == "max"
+    anthropic_settings = build_run_kwargs("sonnet-4-6", "max")["model_settings"]
+    assert anthropic_settings.get("thinking") == "xhigh"
 
 
 def test_unified_thinking_maps_to_adaptive_on_anthropic():
@@ -91,8 +117,10 @@ def test_unified_thinking_maps_to_adaptive_on_anthropic():
 def test_unknown_effort_falls_back_to_medium():
     from api.src.sernia_ai.model_config import build_run_kwargs
 
-    assert build_run_kwargs("sonnet-4-6", "ultra")["model_settings"].get("thinking") == "medium"
-    assert build_run_kwargs("gpt-5.6-luna", None)["model_settings"].get("thinking") == "medium"
+    anthropic_settings = build_run_kwargs("sonnet-4-6", "ultra")["model_settings"]
+    assert anthropic_settings.get("thinking") == "medium"
+    openai_settings = build_run_kwargs("gpt-5.6-luna", None)["model_settings"]
+    assert openai_settings.get("openai_reasoning_effort") == "medium"
 
 
 def test_available_models_cover_all_keys():

--- a/apps/web-react-router/app/routes/sernia-settings.tsx
+++ b/apps/web-react-router/app/routes/sernia-settings.tsx
@@ -69,18 +69,21 @@ interface ModelChoice {
   cost_note: string | null;
 }
 
-type ThinkingEffort = "low" | "medium" | "high" | "xhigh";
+type ThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 interface ModelConfig {
   model_key: string;
   thinking_effort: ThinkingEffort;
 }
 
+// Ascending effort. "Max" is GPT-5.6's top reasoning tier (above X-High). It is
+// OpenAI-only — on Anthropic models it clamps to X-High (see model_config.py).
 const EFFORT_OPTIONS: { value: ThinkingEffort; label: string; hint: string }[] = [
   { value: "low", label: "Low", hint: "Fast, minimal thinking. Skips simple queries." },
   { value: "medium", label: "Medium", hint: "Balanced. Sensible default for chat." },
   { value: "high", label: "High", hint: "Deeper reasoning. Slower, more tokens." },
-  { value: "xhigh", label: "Max", hint: "Maximum reasoning depth. Slowest, most tokens." },
+  { value: "xhigh", label: "X-High", hint: "Very deep reasoning. Slower, many more tokens." },
+  { value: "max", label: "Max", hint: "Maximum reasoning (GPT-5.6). Most exploration, slowest, most tokens." },
 ];
 
 const DEFAULT_EFFORT: ThinkingEffort = "medium";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "alembic>=1.13.1",
     # AI / LLM
-    "openai>=1.77.0",
+    # >=2.45.0: ReasoningEffort includes GPT-5.6's "max" tier (above "xhigh").
+    "openai>=2.45.0",
     "pydantic>=2.11.2",
     # >=1.106: core capabilities API (WebSearch/WebFetch/Thinking) + harness-ready (>=1.95.1)
     "pydantic-ai[dbos]>=1.106.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -2677,7 +2677,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.30.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2689,9 +2689,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]
@@ -3181,7 +3181,7 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "logfire", extras = ["asyncpg", "httpx", "fastapi", "sqlalchemy", "requests"], specifier = ">=0.11.0" },
     { name = "markdownify", specifier = ">=1.2.2" },
-    { name = "openai", specifier = ">=1.77.0" },
+    { name = "openai", specifier = ">=2.45.0" },
     { name = "prefect", specifier = ">=3.4.24" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2.11.2" },


### PR DESCRIPTION
## Description

Follow-up to #278. That PR ran Sernia at `xhigh` and labeled it "Max" in the UI — but **`max` is a real, distinct GPT-5.6 reasoning-effort tier _above_ `xhigh`** (it gives the model even more time to explore alternatives, run checks, and revise). This PR adds the real tier, fixes the mislabel, makes `max` the active setting, and bumps the `openai` SDK so `max` is a first-class typed value.

### Why the previous framing was wrong
The installed `openai` 2.30.0 / `pydantic-ai` 1.106 both capped `ReasoningEffort` at `xhigh`, which led to the earlier "xhigh = max" assumption. The latest spec-generated `openai` SDK (2.45.0) shows the real contract:

```python
ReasoningEffort = Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]]
```

So `max` is genuine and sits above `xhigh`.

### What changed
- **`model_config.py`** — Add `max` to `ThinkingEffort`. Route OpenAI effort through the **native `openai_reasoning_effort` knob** (forwarded verbatim to the Responses API) instead of the unified `thinking` field, because the pinned pydantic-ai's `ThinkingLevel` map tops out at `xhigh` and can't express `max`. `max` is OpenAI-only, so on Anthropic models it **clamps to `xhigh`**.
- **`openai` 2.30.0 → 2.45.0** (`pyproject.toml` + `uv.lock`) — so `max` is a first-class value in the SDK's `ReasoningEffort`, modeling the Responses request honestly at the SDK boundary rather than relying on the value passing through the old TypedDict params. Only `openai` moved in the lockfile. pydantic-ai stays at **1.106** (it already requires `openai>=2.29.0` with no upper cap and already uses `griffelib>=2.0`, so no framework bump or `griffe` churn).
- **`sernia-settings.tsx`** — Relabel `xhigh` as **"X-High"** (it was mislabeled "Max") and add a distinct **"Max"** option.
- **`seed_db.py`** — Fresh environments seed `model_config` as `gpt-5.6-luna / max`.
- **Migration `0031_sernia_effort_max`** — Idempotent bump of the existing `gpt-5.6-luna` `model_config` row from `xhigh` → `max` (only touches the gpt-5.6-luna row; deliberate Anthropic selections untouched). Verified down/up round-trip.
- **Tests / docs** — `test_model_config.py` now covers the native reasoning-effort knob, the `max` tier, and the Anthropic clamp; Sernia `README` updated.

### Verification
- `openai` 2.45.0 confirms `max` in `ReasoningEffort`; on the new SDK + pinned pydantic-ai, `_translate_thinking` still yields `{'effort': 'max'}`, and Anthropic `thinking="xhigh"` → `{'type': 'adaptive'}` (clamp safe).
- App imports clean on openai 2.45; `ruff check .` clean; `pytest` → 399 passed (1 unrelated contact-service flake from Postgres flapping mid-run, passes in isolation); frontend `pnpm typecheck` clean.
- Applied migration locally: row `gpt-5.6-luna/xhigh` → `gpt-5.6-luna/max`; `resolve_active_run_kwargs()` resolves `openai-responses:gpt-5.6-luna` with `openai_reasoning_effort=max`.
- Couldn't live-call the OpenAI API from the sandbox (no key), but it's a config setting — reversible via `/sernia-settings`.

Railway preview: https://react-router-portfolio-pr-279.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)