### PR TITLE
fix(sernia): degrade gracefully when db_search_conversations query times out

### DIFF
--- a/api/src/sernia_ai/tools/db_search_tools.py
+++ b/api/src/sernia_ai/tools/db_search_tools.py
@@ -182,8 +182,26 @@ async def search_conversations(
             .order_by(AgentConversation.updated_at.desc())
             .limit(limit)
         )
-        result = await session.execute(stmt)
-        conversations = result.scalars().all()
+        try:
+            result = await session.execute(stmt)
+            conversations = result.scalars().all()
+        except TimeoutError:
+            # This search is an unindexed full-table ILIKE over the cast JSON
+            # `messages` column, so its cost grows with the conversation table
+            # and a broad query can exceed asyncpg's command_timeout (10s,
+            # database.py). Degrade gracefully with actionable feedback instead
+            # of raising — an unhandled TimeoutError here aborts the whole agent
+            # run and trips the error-level alert.
+            logfire.warning(
+                "search_conversations timed out; query too broad to scan",
+                query=query,
+                limit=limit,
+            )
+            return (
+                f"Search for '{query}' timed out — the conversation history is too "
+                "large to scan for that term. Try a more specific or longer keyword, "
+                "or narrow the search another way (e.g. a distinctive name or phrase)."
+            )
 
     if not conversations:
         return f"No conversations found matching '{query}'."


### PR DESCRIPTION
## What fired

Logfire alert **"Error-level records (non-local)"** fired on 2026-07-22 ~13:07 UTC (delivered to `#logfire`, 200 OK).

Trace [`019f8515e1262d44c4e26e2b98bdcff0`](https://logfire-us.pydantic.dev/espo412/portfolio?q=trace_id%3D%27019f8515e1262d44c4e26e2b98bdcff0%27) — a scheduled Sernia agent run. Two error-level records, same parent span:
- `SELECT neondb` on `agent_conversations` ran **10.15s** then errored (level 17)
- `sernia tool error: db_search_conversations` → **`TimeoutError`** (empty message)

## Root cause

`search_conversations` (`db_search_tools.py`) does:

```python
select(AgentConversation)
    .where(cast(AgentConversation.messages, String).ilike(f"%{query}%"))
    .order_by(AgentConversation.updated_at.desc())
    .limit(limit)
```

That's an **unindexed full-table `ILIKE '%query%'`** over the cast JSON `messages` column — the planner scans and filters every row, then sorts, then limits (the `limit` can't short-circuit an unindexed substring match). No index on `agent_conversations` helps it. Cost grows with the table, and a broad query exceeded asyncpg's `command_timeout: 10` (`database.py:101`), which raised a bare `TimeoutError`. That exception was unhandled, so it aborted the agent tool call and tripped the error-level alert.

Rare today (1 timeout out of 129 `agent_conversations` queries in the last 7 days; avg 0.42s), but it will recur and worsen as the conversation table grows.

## Fix

Catch `TimeoutError` in `search_conversations` and return actionable feedback (narrow the query) instead of raising. A best-effort search tool timing out should not crash the whole agent run — this keeps the tool usable and stops this cause from tripping the alert, without changing behavior for successful queries.

```python
try:
    result = await session.execute(stmt)
    conversations = result.scalars().all()
except TimeoutError:
    logfire.warning("search_conversations timed out; query too broad to scan", ...)
    return "Search for '{query}' timed out — ... try a more specific keyword ..."
```

## Scope & follow-up

- Scoped to the one tool that fired. The sibling SMS-search tools (`search_sms_history`, `get_contact_sms_history`) use the same `ILIKE '%…%'` pattern on `open_phone_events` and would benefit from the same treatment — left out to keep this PR to one cause.
- The deeper root-cause fix — a `pg_trgm` GIN index on the search expression, or bounding the scan by recency — is a heavier production migration and is **not** included here; it's a documented follow-up.

## Testing

- `ast.parse` + `ruff check` clean.
- Logic-only guard around an existing query; no schema or interface change.

Preview: https://react-router-portfolio-pr-281.up.railway.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)