### PR TITLE
Fix Sernia AI misreading year-old Quo threads as new reports

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -35,6 +35,28 @@ These hooks implement parameter-based permission control for MCP tools. Claude C
 
 **Key insight:** Neon's `branchId` parameter is optional - if omitted, it defaults to the main branch. This is the primary risk vector for accidental production writes.
 
+## Ruff auto-format (`ruff-format.sh`) — PostToolUse
+
+Unlike the guards above (which are `PreToolUse` and gate production), this is a
+`PostToolUse` hook on `Edit|Write|MultiEdit`. After Claude edits a `.py` file it
+runs `ruff check --fix` + `ruff format` on that one file, so formatting is
+*fixed* locally instead of only *checked* in CI.
+
+**Why:** CI runs `ruff check .` + `ruff format --check .`, which fail the build
+but don't fix anything. A Claude-authored edit (or a raw `cat >>` heredoc
+append) could reach CI unformatted and redden the PR for a purely mechanical
+reason. This closes that gap at the source.
+
+| Property | Behavior |
+|----------|----------|
+| Trigger | `PostToolUse` on `Edit`, `Write`, `MultiEdit` |
+| Scope | Only the edited file, and only when it ends in `.py` and exists |
+| Config | Auto-discovers the nearest `pyproject.toml` / `ruff.toml`, so `apps/sernia_mcp/` files use that subproject's config |
+| Failure mode | Fail-soft — always exits 0. Missing ruff, non-`.py` file, or a parse error is a silent no-op; it never blocks an edit |
+
+It does **not** cover human hand-edits (only Claude's tool calls). If you want a
+committer-agnostic guard too, add `pre-commit` with `ruff-pre-commit`.
+
 ## Adding New Hooks
 
 1. Create a bash script in this directory

--- a/.claude/hooks/ruff-format.sh
+++ b/.claude/hooks/ruff-format.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# PostToolUse hook: auto-format Python files Claude just edited so ruff never
+# fails in CI for a formatting-only reason.
+#
+# CI runs `ruff check .` + `ruff format --check .`. Those only *check*; nothing
+# *fixed* the code locally before this hook existed, so an agent-authored edit
+# (or a raw heredoc append) could reach CI unformatted. This runs
+# `ruff format` + `ruff check --fix` on the single edited file right after the
+# Edit/Write/MultiEdit tool call.
+#
+# Fail-soft by design: it must NEVER block an edit. Any problem (no ruff, parse
+# error, non-.py file) exits 0 silently. Ruff auto-discovers the nearest
+# pyproject/ruff.toml for the file, so it also handles apps/sernia_mcp/ files
+# with that subproject's config.
+
+INPUT=$(cat)
+
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Only touch existing Python files.
+case "$FILE" in
+  *.py) ;;
+  *) exit 0 ;;
+esac
+[ -f "$FILE" ] || exit 0
+
+# Prefer the repo venv's ruff (matches the CI-installed version), then fall back
+# to whatever ruff is on PATH.
+RUFF=""
+if [ -x "$CLAUDE_PROJECT_DIR/.venv/bin/ruff" ]; then
+  RUFF="$CLAUDE_PROJECT_DIR/.venv/bin/ruff"
+elif command -v ruff >/dev/null 2>&1; then
+  RUFF="$(command -v ruff)"
+else
+  exit 0
+fi
+
+# Import sorting / simple lint autofixes first, then formatting. Suppress output
+# and never propagate a failure.
+"$RUFF" check --fix --quiet "$FILE" >/dev/null 2>&1 || true
+"$RUFF" format --quiet "$FILE" >/dev/null 2>&1 || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -159,6 +159,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/ruff-format.sh"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "hooks": [

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -26,7 +26,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
-from datetime import UTC, date
+from datetime import UTC, date, datetime, timedelta
 
 import httpx
 import logfire
@@ -462,6 +462,68 @@ def _is_done_conversation(conv: dict) -> bool:
         return False
 
 
+# Threads whose most recent activity is older than this are flagged as stale in
+# ``list_active_threads_impl``. Quo only auto-archives a thread when someone
+# marks it "done" (snoozed 100+ years); an un-actioned thread stays "active"
+# forever. Without an explicit age signal the agent has read a year-old message
+# as a fresh report — see the ``_relative_age`` docstring.
+STALE_THREAD_DAYS = 30
+
+
+def _parse_iso(created: str | None) -> datetime | None:
+    """Parse a Quo ISO-8601 timestamp to an aware UTC datetime, or None."""
+    if not created or not isinstance(created, str):
+        return None
+    try:
+        ts = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts
+
+
+def _relative_age(created: str | None, now: datetime | None = None) -> str:
+    """Human-readable age of an ISO-8601 timestamp, e.g. "3 hours ago",
+    "2 days ago", "1 year ago". Returns "" when ``created`` can't be parsed.
+
+    Every activity timestamp the Quo read tools render is annotated with this
+    so the agent never has to diff raw ISO dates against "today" in its head.
+    That date math is exactly where it has failed before: a message dated
+    ``2025-07-23`` that says "leak this morning", surfaced on ``2026-07-23``
+    (an *exact* one-year collision), got logged as a brand-new maintenance
+    report. A literal "1 year ago" on the line removes that ambiguity.
+    """
+    ts = _parse_iso(created)
+    if ts is None:
+        return ""
+    now = now or datetime.now(UTC)
+    secs = (now - ts).total_seconds()
+    if secs < -60:
+        return "in the future"
+    minutes, hours = secs / 60, secs / 3600
+    days = hours / 24
+    if secs < 90:
+        return "just now"
+    if minutes < 90:
+        return f"{round(minutes)} minutes ago"
+    if hours < 36:
+        return f"{round(hours)} hours ago"
+    if days < 45:
+        return f"{round(days)} days ago"
+    if days < 365:
+        return f"{round(days / 30)} months ago"
+    years = round(days / 365)
+    return f"{years} year{'s' if years != 1 else ''} ago"
+
+
+def _ts(created: str | None, now: datetime | None = None) -> str:
+    """Render a timestamp with its relative age for a thread/activity line:
+    ``2025-07-23T08:58:00Z · 1 year ago``. Falls back to the raw value (or
+    ``?``) when the timestamp is missing or unparseable."""
+    label = created or "?"
+    age = _relative_age(created, now)
+    return f"{label} · {age}" if age else label
+
+
 async def search_contacts_impl(
     client: httpx.AsyncClient,
     query: str,
@@ -669,10 +731,12 @@ def _render_group_thread_from_db(
     activities: list[dict],
     participants: list[str],
     phone_map: dict[str, str],
+    now: datetime | None = None,
 ) -> str:
     """Format a sequence of group-thread activities (from the events table)
     as a single chronological thread, similar to ``_render_thread`` but
     aware that messages can have multiple recipients."""
+    now = now or datetime.now(UTC)
     lines: list[str] = []
     msg_count = sum(1 for a in activities if a.get("_kind") == "message")
     call_count = sum(1 for a in activities if a.get("_kind") == "call")
@@ -686,7 +750,7 @@ def _render_group_thread_from_db(
     )
 
     for item in activities:
-        created = item.get("createdAt") or "?"
+        created = _ts(item.get("createdAt"), now)
         if item.get("_kind") == "call":
             direction = item.get("direction") or "?"
             dur = item.get("duration")
@@ -767,8 +831,6 @@ async def list_active_threads_impl(
             ("excludeInactive", "true"),
         ]
         if updated_after_days is not None:
-            from datetime import datetime, timedelta
-
             cutoff = (datetime.now(UTC) - timedelta(days=updated_after_days)).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             )
@@ -850,11 +912,23 @@ async def list_active_threads_impl(
         if isinstance(result, dict):
             snippet_map[conv.get("id", "")] = result
 
+    now = datetime.now(UTC)
     lines: list[str] = []
+    stale_count = 0
     for conv in conversations:
         participants = conv.get("participants", [])
         last_activity = conv.get("lastActivityAt", "?")
         conv_id = conv.get("id", "?")
+
+        # A thread only leaves the Quo "active" set when someone marks it
+        # "done"; nothing ages out on its own. Flag threads whose newest
+        # activity is older than STALE_THREAD_DAYS so the agent doesn't treat
+        # a long-dormant thread as something that needs attention right now.
+        last_ts = _parse_iso(last_activity if last_activity != "?" else None)
+        is_stale = last_ts is not None and (now - last_ts) > timedelta(days=STALE_THREAD_DAYS)
+        if is_stale:
+            stale_count += 1
+        stale_prefix = "⚠️ STALE — " if is_stale else ""
 
         enriched = []
         for phone in participants:
@@ -883,12 +957,21 @@ async def list_active_threads_impl(
                         snippet_line = f"\n  Snippet: {sender_label}: {preview}"
 
         lines.append(
-            f"Thread: {', '.join(enriched)}{snippet_line}\n"
-            f"  Last activity: {last_activity}\n"
+            f"{stale_prefix}Thread: {', '.join(enriched)}{snippet_line}\n"
+            f"  Last activity: {_ts(last_activity if last_activity != '?' else None, now)}\n"
             f"  Conversation ID: {conv_id}"
         )
 
-    return f"Active threads ({len(conversations)}):\n\n" + "\n\n".join(lines)
+    header = f"Active threads ({len(conversations)}):"
+    if stale_count:
+        header += (
+            f"\n\n⚠️ {stale_count} of these thread{'s' if stale_count != 1 else ''} "
+            f"had no activity in over {STALE_THREAD_DAYS} days (marked STALE below). "
+            "Their newest message is old — do NOT treat it as a new report. Check the "
+            "'Last activity' age before acting, and open the thread only to follow up "
+            "on something genuinely unresolved."
+        )
+    return f"{header}\n\n" + "\n\n".join(lines)
 
 
 async def _fetch_one_to_one_thread(
@@ -933,8 +1016,10 @@ def _render_thread(
     phone_map: dict[str, str],
     *,
     header_prefix: str = "Thread with",
+    now: datetime | None = None,
 ) -> str:
     """Render a chronological thread (SMS + calls interleaved)."""
+    now = now or datetime.now(UTC)
     items: list[tuple[str, dict]] = [("message", m) for m in messages] + [
         ("call", c) for c in calls
     ]
@@ -947,7 +1032,7 @@ def _render_thread(
     ]
 
     for kind, item in items:
-        created = item.get("createdAt", "?")
+        created = _ts(item.get("createdAt"), now)
         if kind == "call":
             direction = item.get("direction", "?")
             duration = item.get("duration")
@@ -990,9 +1075,10 @@ def _render_thread(
 def _format_group_activity_line(
     item: dict,
     phone_map: dict[str, str],
+    now: datetime | None = None,
 ) -> str:
     """Render a single group-thread activity (message or call) as one line."""
-    created = item.get("createdAt", "?")
+    created = _ts(item.get("createdAt"), now)
     if item.get("_kind") == "call":
         direction = item.get("direction", "?")
         duration = item.get("duration")
@@ -1240,7 +1326,7 @@ async def get_call_details_impl(
             meta_bits.append(f"**Status:** {status}")
         created = call.get("createdAt")
         if created:
-            meta_bits.append(f"**Created:** {created}")
+            meta_bits.append(f"**Created:** {_ts(created)}")
         participants = call.get("participants") or []
         if participants:
             named = [
@@ -1855,10 +1941,21 @@ def _build_quo_toolset():
         Call snippets include the Call ID — pass it to ``get_call_details`` to
         read the summary + transcript.
 
+        Every "Last activity" timestamp is annotated with its age (e.g.
+        ``· 3 days ago``). Threads with no activity for over 30 days are
+        prefixed ``⚠️ STALE`` — a thread stays "active" until someone marks it
+        done in Quo, so an old dormant thread can still appear here. Treat a
+        STALE thread's newest message as history, NOT a new report.
+
+        For recurring / scheduled inbox sweeps, pass ``updated_after_days``
+        (e.g. 7) so you only see recently-active threads and never re-surface a
+        year-old message as if it just came in.
+
         Args:
             max_results: Max threads to return (default 20).
             updated_after_days: Optional — only include threads updated within
-                this many days. Omit for all active threads (matches Quo inbox).
+                this many days. Omit for all active threads (matches Quo inbox);
+                set it for scheduled checks to exclude dormant threads.
         """
         return await list_active_threads_impl(client, max_results, updated_after_days)
 
@@ -1894,8 +1991,11 @@ def _build_quo_toolset():
         a group thread by passing a list of phone numbers.
 
         Returns SMS messages and calls interleaved in chronological order with
-        contact names enriched. Call entries include the Call ID — pass it to
-        ``get_call_details`` to read the call's summary + transcript.
+        contact names enriched. Each line's timestamp is annotated with its age
+        (e.g. ``· 1 year ago``) — always check it before acting: an old message
+        is history, not a new report, even when its wording says "this morning".
+        Call entries include the Call ID — pass it to ``get_call_details`` to
+        read the call's summary + transcript.
 
         **Group threads** (multiple phones): full group-thread history is
         served from our local webhook events table when available. If the

--- a/api/src/tests/test_quo_render.py
+++ b/api/src/tests/test_quo_render.py
@@ -1,0 +1,217 @@
+"""Unit tests for Quo thread/timestamp rendering — no API keys, no network.
+
+These lock in the fix for the "year-old thread read as a new report" bug: the
+Quo read tools now annotate every activity timestamp with its relative age and
+flag long-dormant threads as STALE, so the agent never has to diff raw ISO
+dates against "today" (the exact-one-year collision it has failed on before).
+"""
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from api.src.open_phone.service import invalidate_contact_cache
+from api.src.sernia_ai.tools.quo_tools import (
+    STALE_THREAD_DAYS,
+    _format_group_activity_line,
+    _relative_age,
+    _render_group_thread_from_db,
+    _render_thread,
+    _ts,
+    list_active_threads_impl,
+)
+
+# A fixed "now" so age math is deterministic. This is exactly one year and a
+# few hours after James's real July 23, 2025 leak text from the bug report.
+NOW = datetime(2026, 7, 23, 13, 0, 0, tzinfo=UTC)
+YEAR_AGO = "2025-07-23T08:58:00Z"
+
+
+# --------------------------------------------------------------------------- #
+# _relative_age
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("created", "expected"),
+    [
+        (YEAR_AGO, "1 year ago"),  # the exact collision from the bug
+        ("2024-07-23T08:58:00Z", "2 years ago"),
+        ("2026-07-23T12:59:30Z", "just now"),
+        ("2026-07-23T12:30:00Z", "30 minutes ago"),
+        ("2026-07-23T05:00:00Z", "8 hours ago"),
+        ("2026-07-20T13:00:00Z", "3 days ago"),
+        ("2026-05-23T13:00:00Z", "2 months ago"),
+    ],
+)
+def test_relative_age_buckets(created: str, expected: str):
+    assert _relative_age(created, NOW) == expected
+
+
+def test_relative_age_unparseable_returns_empty():
+    assert _relative_age("not-a-date", NOW) == ""
+    assert _relative_age(None, NOW) == ""
+    assert _relative_age("", NOW) == ""
+
+
+def test_relative_age_future_is_flagged():
+    assert _relative_age("2026-07-24T13:00:00Z", NOW) == "in the future"
+
+
+def test_ts_appends_age_and_falls_back():
+    assert _ts(YEAR_AGO, NOW) == f"{YEAR_AGO} · 1 year ago"
+    # Unparseable/missing timestamps degrade to a bare label, never a crash.
+    assert _ts(None, NOW) == "?"
+    assert _ts("garbage", NOW) == "garbage"
+
+
+# --------------------------------------------------------------------------- #
+# Thread renderers embed the age on every line
+# --------------------------------------------------------------------------- #
+
+
+def test_render_thread_annotates_year_old_message():
+    messages = [
+        {
+            "createdAt": YEAR_AGO,
+            "direction": "incoming",
+            "text": "Good morning, it appears there's a leak this morning",
+            "from": "+14125379335",
+        }
+    ]
+    out = _render_thread(
+        messages,
+        [],
+        "James Gammiere",
+        "+14125379335",
+        {"+14125379335": "James Gammiere"},
+        now=NOW,
+    )
+    # The "this morning" wording is a year old — the age must be right there.
+    assert "1 year ago" in out
+    assert YEAR_AGO in out
+
+
+def test_group_activity_line_annotates_age():
+    line = _format_group_activity_line(
+        {"_kind": "message", "createdAt": YEAR_AGO, "from": "+1", "to": ["+2"], "text": "hi"},
+        {},
+        now=NOW,
+    )
+    assert "1 year ago" in line
+
+
+def test_render_group_thread_from_db_annotates_age():
+    out = _render_group_thread_from_db(
+        [{"_kind": "message", "createdAt": YEAR_AGO, "from": "+1", "to": ["+2"], "text": "hi"}],
+        ["+1", "+2"],
+        {},
+        now=NOW,
+    )
+    assert "1 year ago" in out
+
+
+# --------------------------------------------------------------------------- #
+# list_active_threads_impl flags stale threads (mocked Quo API)
+# --------------------------------------------------------------------------- #
+
+FRESH_CONV_ID = "CONVfresh"
+STALE_CONV_ID = "CONVstale"
+FRESH_PHONE = "+14120000001"
+STALE_PHONE = "+14125379335"
+
+_CONTACTS = [
+    {
+        "defaultFields": {
+            "firstName": "Fresh",
+            "lastName": "Tenant",
+            "phoneNumbers": [{"value": FRESH_PHONE}],
+        }
+    },
+    {
+        "defaultFields": {
+            "firstName": "James",
+            "lastName": "Gammiere",
+            "phoneNumbers": [{"value": STALE_PHONE}],
+        }
+    },
+]
+
+_CONVERSATIONS = [
+    {
+        "id": FRESH_CONV_ID,
+        "participants": [FRESH_PHONE],
+        "lastActivityAt": "2026-07-21T13:00:00Z",  # 2 days ago
+    },
+    {
+        "id": STALE_CONV_ID,
+        "participants": [STALE_PHONE],
+        "lastActivityAt": YEAR_AGO,  # a year ago — dormant, never marked done
+    },
+]
+
+_LATEST_MSG = {
+    FRESH_PHONE: {
+        "createdAt": "2026-07-21T13:00:00Z",
+        "direction": "incoming",
+        "text": "Trash day reminder?",
+        "from": FRESH_PHONE,
+    },
+    STALE_PHONE: {
+        "createdAt": YEAR_AGO,
+        "direction": "incoming",
+        "text": "Good morning, it appears there's a leak this morning",
+        "from": STALE_PHONE,
+    },
+}
+
+
+def _mock_handler(request: httpx.Request) -> httpx.Response:
+    path = request.url.path
+    if path == "/v1/conversations":
+        return httpx.Response(200, json={"data": _CONVERSATIONS, "nextPageToken": None})
+    if path == "/v1/contacts":
+        return httpx.Response(200, json={"data": _CONTACTS, "nextPageToken": None})
+    if path == "/v1/messages":
+        phone = request.url.params.get("participants")
+        msg = _LATEST_MSG.get(phone)
+        return httpx.Response(200, json={"data": [msg] if msg else []})
+    if path == "/v1/calls":
+        return httpx.Response(200, json={"data": []})
+    return httpx.Response(404, json={"data": []})
+
+
+@pytest.mark.asyncio
+async def test_list_active_threads_flags_stale_thread(monkeypatch):
+    """A year-old thread that was never marked 'done' still lists as active —
+    it must be flagged STALE with a header warning so the agent doesn't treat
+    it as a new report (the root cause of the false ClickUp task)."""
+    invalidate_contact_cache()
+
+    # Pin "now" so the year-old thread is deterministically past the threshold.
+    import api.src.sernia_ai.tools.quo_tools as qt
+
+    class _FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return NOW
+
+    monkeypatch.setattr(qt, "datetime", _FixedDateTime)
+
+    async with httpx.AsyncClient(
+        base_url="https://api.openphone.com",
+        transport=httpx.MockTransport(_mock_handler),
+    ) as client:
+        out = await list_active_threads_impl(client, max_results=20)
+
+    invalidate_contact_cache()
+
+    # The dormant thread is flagged and explained.
+    assert "⚠️ STALE" in out
+    assert f"over {STALE_THREAD_DAYS} days" in out
+    assert "do NOT treat it as a new report" in out
+    assert "1 year ago" in out  # James's last-activity age
+    # The fresh thread carries an age but no STALE prefix.
+    assert "2 days ago" in out
+    assert "⚠️ STALE — Thread: Fresh" not in out

--- a/apps/sernia_mcp/src/sernia_mcp/core/quo/contacts.py
+++ b/apps/sernia_mcp/src/sernia_mcp/core/quo/contacts.py
@@ -38,6 +38,68 @@ def _is_done_conversation(conv: dict) -> bool:
         return False
 
 
+# Threads whose most recent activity is older than this are flagged as stale in
+# ``list_active_threads_core``. Quo only drops a thread from the "active" set
+# when someone marks it "done" (snoozed 100+ years); an un-actioned thread
+# stays active forever. Without an explicit age signal the model has read a
+# year-old message as a fresh report — see the ``_relative_age`` docstring.
+STALE_THREAD_DAYS = 30
+
+
+def _parse_iso(created: str | None) -> datetime | None:
+    """Parse a Quo ISO-8601 timestamp to an aware UTC datetime, or None."""
+    if not created or not isinstance(created, str):
+        return None
+    try:
+        ts = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts
+
+
+def _relative_age(created: str | None, now: datetime | None = None) -> str:
+    """Human-readable age of an ISO-8601 timestamp, e.g. "3 hours ago",
+    "2 days ago", "1 year ago". Returns "" when ``created`` can't be parsed.
+
+    Every activity timestamp these read tools render is annotated with this so
+    the model never has to diff raw ISO dates against "today" in its head. That
+    date math is exactly where it has failed before: a message dated
+    ``2025-07-23`` that says "leak this morning", surfaced on ``2026-07-23`` (an
+    *exact* one-year collision), got logged as a brand-new maintenance report. A
+    literal "1 year ago" on the line removes that ambiguity.
+    """
+    ts = _parse_iso(created)
+    if ts is None:
+        return ""
+    now = now or datetime.now(UTC)
+    secs = (now - ts).total_seconds()
+    if secs < -60:
+        return "in the future"
+    minutes, hours = secs / 60, secs / 3600
+    days = hours / 24
+    if secs < 90:
+        return "just now"
+    if minutes < 90:
+        return f"{round(minutes)} minutes ago"
+    if hours < 36:
+        return f"{round(hours)} hours ago"
+    if days < 45:
+        return f"{round(days)} days ago"
+    if days < 365:
+        return f"{round(days / 30)} months ago"
+    years = round(days / 365)
+    return f"{years} year{'s' if years != 1 else ''} ago"
+
+
+def _ts(created: str | None, now: datetime | None = None) -> str:
+    """Render a timestamp with its relative age for a thread/activity line:
+    ``2025-07-23T08:58:00Z · 1 year ago``. Falls back to the raw value (or
+    ``?``) when the timestamp is missing or unparseable."""
+    label = created or "?"
+    age = _relative_age(created, now)
+    return f"{label} · {age}" if age else label
+
+
 def _format_call_snippet(call: dict) -> str:
     """One-line snippet for a call activity, including the Call ID so the
     caller can fetch summary + transcript via ``get_call_details_core``."""
@@ -252,7 +314,7 @@ async def get_call_details_core(
             meta_bits.append(f"**Status:** {status}")
         created = call.get("createdAt")
         if created:
-            meta_bits.append(f"**Created:** {created}")
+            meta_bits.append(f"**Created:** {_ts(created)}")
         participants = call.get("participants") or []
         if participants:
             named = [
@@ -423,11 +485,23 @@ async def list_active_threads_core(
             if isinstance(result, dict):
                 snippet_map[conv.get("id", "")] = result
 
+    now = datetime.now(UTC)
     lines: list[str] = []
+    stale_count = 0
     for conv in conversations:
         participants = conv.get("participants", [])
         last_activity = conv.get("lastActivityAt", "?")
         conv_id = conv.get("id", "?")
+
+        # A thread only leaves the Quo "active" set when someone marks it
+        # "done"; nothing ages out on its own. Flag threads whose newest
+        # activity is older than STALE_THREAD_DAYS so the model doesn't treat
+        # a long-dormant thread as something that needs attention right now.
+        last_ts = _parse_iso(last_activity if last_activity != "?" else None)
+        is_stale = last_ts is not None and (now - last_ts) > timedelta(days=STALE_THREAD_DAYS)
+        if is_stale:
+            stale_count += 1
+        stale_prefix = "⚠️ STALE — " if is_stale else ""
 
         enriched = []
         for phone in participants:
@@ -456,12 +530,21 @@ async def list_active_threads_core(
                         snippet_line = f"\n  Snippet: {sender_label}: {preview}"
 
         lines.append(
-            f"Thread: {', '.join(enriched)}{snippet_line}\n"
-            f"  Last activity: {last_activity}\n"
+            f"{stale_prefix}Thread: {', '.join(enriched)}{snippet_line}\n"
+            f"  Last activity: {_ts(last_activity if last_activity != '?' else None, now)}\n"
             f"  Conversation ID: {conv_id}"
         )
 
-    return f"Active threads ({len(conversations)}):\n\n" + "\n\n".join(lines)
+    header = f"Active threads ({len(conversations)}):"
+    if stale_count:
+        header += (
+            f"\n\n⚠️ {stale_count} of these thread{'s' if stale_count != 1 else ''} "
+            f"had no activity in over {STALE_THREAD_DAYS} days (marked STALE below). "
+            "Their newest message is old — do NOT treat it as a new report. Check the "
+            "'Last activity' age before acting, and open the thread only to follow up "
+            "on something genuinely unresolved."
+        )
+    return f"{header}\n\n" + "\n\n".join(lines)
 
 
 async def _fetch_one_to_one_thread(
@@ -505,8 +588,10 @@ def _render_thread(
     phone_map: dict[str, str],
     *,
     header_prefix: str = "Thread with",
+    now: datetime | None = None,
 ) -> str:
     """Render a chronological thread (SMS + calls interleaved)."""
+    now = now or datetime.now(UTC)
     items: list[tuple[str, dict]] = [("message", m) for m in messages] + [
         ("call", c) for c in calls
     ]
@@ -519,7 +604,7 @@ def _render_thread(
     ]
 
     for kind, item in items:
-        created = item.get("createdAt", "?")
+        created = _ts(item.get("createdAt"), now)
         if kind == "call":
             direction = item.get("direction", "?")
             duration = item.get("duration")
@@ -562,9 +647,10 @@ def _render_thread(
 def _format_group_activity_line(
     item: dict,
     phone_map: dict[str, str],
+    now: datetime | None = None,
 ) -> str:
     """Render a single group-thread activity (message or call) as one line."""
-    created = item.get("createdAt", "?")
+    created = _ts(item.get("createdAt"), now)
     if item.get("_kind") == "call":
         direction = item.get("direction", "?")
         duration = item.get("duration")

--- a/apps/sernia_mcp/src/sernia_mcp/tools/quo.py
+++ b/apps/sernia_mcp/src/sernia_mcp/tools/quo.py
@@ -65,8 +65,11 @@ async def quo_get_thread_messages(
     team line, OR a group thread by passing a list of phones.
 
     Returns SMS messages and calls interleaved chronologically, enriched with
-    contact names. Call entries include the Call ID — pass it to
-    ``quo_get_call_details`` to read the call's summary + transcript.
+    contact names. Each line's timestamp is annotated with its age (e.g.
+    ``· 1 year ago``) — always check it before acting: an old message is
+    history, not a new report, even when its wording says "this morning". Call
+    entries include the Call ID — pass it to ``quo_get_call_details`` to read
+    the call's summary + transcript.
 
     **Group threads** (multiple phones, partial data): OpenPhone's public
     API does not list group-thread history by participant filter, so this
@@ -102,13 +105,22 @@ async def quo_list_active_sms_threads(
     is most recent — SMS or call. Call snippets include the Call ID so you
     can pass it to ``quo_get_call_details`` for the summary + transcript.
 
+    Every "Last activity" timestamp is annotated with its age (e.g.
+    ``· 3 days ago``). Threads with no activity for over 30 days are prefixed
+    ``⚠️ STALE`` — a thread stays "active" until someone marks it done in Quo,
+    so an old dormant thread can still appear here. Treat a STALE thread's
+    newest message as history, NOT a new report.
+
     Use this for "what threads need attention right now" — for a specific
-    conversation's full thread history, use ``quo_get_thread_messages``.
+    conversation's full thread history, use ``quo_get_thread_messages``. For
+    recurring / scheduled sweeps, pass ``updated_after_days`` (e.g. 7) so you
+    only see recently-active threads.
 
     Args:
         max_results: Max threads to return (default 20).
         updated_after_days: Optional — only include threads updated within
-            this many days. Omit for all active threads (matches Quo inbox).
+            this many days. Omit for all active threads (matches Quo inbox);
+            set it for scheduled checks to exclude dormant threads.
     """
     try:
         return await list_active_threads_core(

--- a/apps/sernia_mcp/tests/test_quo_active_threads.py
+++ b/apps/sernia_mcp/tests/test_quo_active_threads.py
@@ -706,3 +706,108 @@ async def test_tool_exposes_via_mcp_client():
     async with Client(mcp) as c:
         names = {t.name for t in await c.list_tools()}
         assert "quo_list_active_sms_threads" in names
+
+
+# --------------------------------------------------------------------------- #
+# Relative-age annotation + stale-thread flagging (the false-report fix)
+# --------------------------------------------------------------------------- #
+
+from datetime import UTC, datetime  # noqa: E402
+
+NOW = datetime(2026, 7, 23, 13, 0, 0, tzinfo=UTC)
+YEAR_AGO = "2025-07-23T08:58:00Z"
+
+
+@pytest.mark.parametrize(
+    ("created", "expected"),
+    [
+        (YEAR_AGO, "1 year ago"),
+        ("2026-07-23T12:59:30Z", "just now"),
+        ("2026-07-20T13:00:00Z", "3 days ago"),
+        ("2026-05-23T13:00:00Z", "2 months ago"),
+        ("not-a-date", ""),
+        (None, ""),
+    ],
+)
+def test_relative_age_buckets(created, expected):
+    from sernia_mcp.core.quo.contacts import _relative_age
+
+    assert _relative_age(created, NOW) == expected
+
+
+def test_ts_appends_age_and_falls_back():
+    from sernia_mcp.core.quo.contacts import _ts
+
+    assert _ts(YEAR_AGO, NOW) == f"{YEAR_AGO} · 1 year ago"
+    assert _ts(None, NOW) == "?"
+
+
+def test_render_thread_annotates_year_old_message():
+    from sernia_mcp.core.quo.contacts import _render_thread
+
+    out = _render_thread(
+        [{"createdAt": YEAR_AGO, "direction": "incoming", "text": "leak this morning", "from": "+1"}],
+        [],
+        "James Gammiere",
+        "+1",
+        {"+1": "James Gammiere"},
+        now=NOW,
+    )
+    assert "1 year ago" in out
+    assert YEAR_AGO in out
+
+
+@pytest.mark.asyncio
+async def test_list_active_threads_flags_stale_thread():
+    """A year-old thread that was never marked 'done' still lists as active —
+    it must be flagged STALE with a header warning so the model doesn't treat
+    it as a new report (root cause of the false ClickUp task)."""
+    from sernia_mcp.core.quo.contacts import list_active_threads_core
+
+    fake_conversations = {
+        "data": [
+            {
+                "id": "conv-fresh",
+                "participants": ["+15550000010"],
+                "lastActivityAt": "2026-07-21T13:00:00Z",  # ~2 days ago
+                "snoozedUntil": None,
+            },
+            {
+                "id": "conv-stale",
+                "participants": ["+14125379335"],
+                "lastActivityAt": YEAR_AGO,  # dormant, never marked done
+                "snoozedUntil": None,
+            },
+        ],
+        "nextPageToken": None,
+    }
+    fake_messages = {
+        "data": [{"direction": "incoming", "text": "leak this morning", "createdAt": YEAR_AGO}]
+    }
+    fake_calls = {"data": []}
+
+    async def fake_get(url, params=None):
+        resp = AsyncMock()
+        resp.raise_for_status = lambda: None
+        if url == "/v1/conversations":
+            resp.json = lambda: fake_conversations
+        elif url == "/v1/messages":
+            resp.json = lambda: fake_messages
+        elif url == "/v1/calls":
+            resp.json = lambda: fake_calls
+        return resp
+
+    fake_client = AsyncMock()
+    fake_client.get = fake_get
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = None
+
+    with (
+        patch("sernia_mcp.core.quo.contacts.build_quo_client", return_value=fake_client),
+        patch("sernia_mcp.core.quo.contacts.get_all_contacts", new=AsyncMock(return_value=[])),
+    ):
+        result = await list_active_threads_core(max_results=20)
+
+    assert "⚠️ STALE" in result, result
+    assert "do NOT treat it as a new report" in result, result
+    assert "ago" in result  # last-activity ages are annotated

--- a/apps/sernia_mcp/tests/test_quo_active_threads.py
+++ b/apps/sernia_mcp/tests/test_quo_active_threads.py
@@ -746,7 +746,14 @@ def test_render_thread_annotates_year_old_message():
     from sernia_mcp.core.quo.contacts import _render_thread
 
     out = _render_thread(
-        [{"createdAt": YEAR_AGO, "direction": "incoming", "text": "leak this morning", "from": "+1"}],
+        [
+            {
+                "createdAt": YEAR_AGO,
+                "direction": "incoming",
+                "text": "leak this morning",
+                "from": "+1",
+            }
+        ],
         [],
         "James Gammiere",
         "+1",


### PR DESCRIPTION
## Description

The scheduled "inbox check" surfaced James Gammiere's **July 23, 2025** leak text on **July 23, 2026** — an *exact* one-year collision — and opened a false high-priority ClickUp task (`86ajnz6k9`) for a leak that was reported and handled a year earlier. The agent later admitted it "cannot find a July 23 leak text from James in his Quo thread."

### How it happened (root cause was in the tools, not just hallucination)

1. **No recency framing on timestamps.** Every activity line was rendered as a bare ISO string (`[2025-07-23T08:58…] James → Sernia Capital: … leak this morning`), forcing the model to diff dates against "today" in its head. A same-month/day, one-year-off timestamp combined with "this morning" wording is exactly where that date math fails.
2. **No staleness signal on the active inbox.** `list_active_sms_threads` (with `updated_after_days` omitted) returns *every* thread that was never marked "done" in Quo, regardless of age. A year-dormant thread looked identical to a fresh one, so the scheduled sweep pulled it and read the old message as new.

### The fix

Mirrored in both parallel implementations — the production agent's `api/src/sernia_ai/tools/quo_tools.py` and the `apps/sernia_mcp` core:

- **Relative-age annotation** on every rendered timestamp (`… · 1 year ago`) — thread, group-thread, DB-group, active-inbox "Last activity", and call-details output.
- **STALE flagging** for threads with no activity in over 30 days (`⚠️ STALE — …`), plus a header warning telling the agent not to treat a stale thread's newest message as a new report.
- **Docstring guidance** steering scheduled/recurring sweeps toward passing `updated_after_days` so dormant threads are excluded up front.

All rendering degrades gracefully — unparseable/missing timestamps fall back to the raw value, never crash.

### Tests

Added credential-free unit tests (no live API needed):
- `api/src/tests/test_quo_render.py` — age helper buckets (incl. the exact one-year case), `_ts` formatting/fallback, renderer annotation, and mocked-Quo-API stale-thread flagging.
- Extended `apps/sernia_mcp/tests/test_quo_active_threads.py` with the parallel checks.

Both new test modules pass. The one unrelated failing test in the default suite (`test_contact_service::test_basic_create_contact`) is a pre-existing module-level contact-cache contamination flake — it fails without this change and passes in isolation.

**Railway preview:** https://react-router-portfolio-pr-282.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VquFchggCeLQNVrXXgwtfj