### PR TITLE
fix(sernia): clamp Quo get_thread_messages max_results to OpenPhone's 100/page cap

### DIFF
--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -65,6 +65,13 @@ OPENPHONE_SPEC_URL = (
     "/public/openphone-public-api-v1-prod.json"
 )
 
+# OpenPhone's list endpoints (``/v1/messages``, ``/v1/calls``) cap ``maxResults``
+# at 100 per page; anything higher is rejected with an HTTP 400. Tool callers
+# (the agent) pick ``max_results`` freely, so clamp before building the request
+# to avoid an error-level 400 span (which trips the "Error-level records" alert)
+# followed by a self-correcting retry.
+OPENPHONE_MAX_RESULTS_PER_PAGE = 100
+
 # MCP-generated tools that mutate data and require human approval.
 # createContact_v1 / updateContactById_v1 replaced by custom tools with
 # proper Pydantic types, first-class tags, and read-merge-write safety.
@@ -985,13 +992,17 @@ async def _fetch_one_to_one_thread(
     """
     import asyncio
 
+    # OpenPhone rejects maxResults > 100 with a 400; clamp so any caller-chosen
+    # value stays within the API's per-page limit.
+    page_size = max(1, min(max_results, OPENPHONE_MAX_RESULTS_PER_PAGE))
+
     async def _fetch(path: str) -> dict:
         resp = await client.get(
             path,
             params={
                 "phoneNumberId": QUO_SHARED_EXTERNAL_PHONE_ID,
                 "participants": phone_number,
-                "maxResults": str(max_results),
+                "maxResults": str(page_size),
             },
         )
         resp.raise_for_status()
@@ -2010,7 +2021,8 @@ def _build_quo_toolset():
             phone_number: A single phone in E.164 (1:1 thread) OR a list of
                 phones (group thread).
             max_results: Max items per type to return per participant
-                (default 20 messages + 20 calls).
+                (default 20 messages + 20 calls). Capped at 100 — OpenPhone's
+                per-page limit; higher values are clamped to 100.
         """
         return await get_thread_messages_impl(client, phone_number, max_results)
 

--- a/api/src/tests/test_openphone_rate_limit.py
+++ b/api/src/tests/test_openphone_rate_limit.py
@@ -140,3 +140,58 @@ async def test_token_bucket_allows_initial_burst():
     elapsed = time.monotonic() - start
     # Five tokens were pre-loaded; none should have blocked.
     assert elapsed < 0.05
+
+
+# ---- maxResults clamp (denoise OpenPhone 400s) ----
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_to_one_thread_clamps_max_results():
+    """A caller-chosen max_results above OpenPhone's per-page cap must be
+    clamped to 100 before the request. OpenPhone rejects maxResults > 100 with
+    a 400, which is logged error-level and trips the alert; the agent picks
+    max_results freely, so the clamp keeps every request valid.
+    """
+    from api.src.sernia_ai.tools.quo_tools import (
+        OPENPHONE_MAX_RESULTS_PER_PAGE,
+        _fetch_one_to_one_thread,
+    )
+
+    seen_max_results: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_max_results.append(request.url.params.get("maxResults"))
+        return httpx.Response(200, json={"data": []})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://api.openphone.com",
+    ) as client:
+        # 200 exceeds the cap — both /v1/messages and /v1/calls must clamp.
+        await _fetch_one_to_one_thread(client, "+14129101500", max_results=200)
+
+    assert seen_max_results, "expected requests to /v1/messages and /v1/calls"
+    assert all(v == str(OPENPHONE_MAX_RESULTS_PER_PAGE) for v in seen_max_results), (
+        f"maxResults not clamped to {OPENPHONE_MAX_RESULTS_PER_PAGE}: {seen_max_results}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_one_to_one_thread_preserves_small_max_results():
+    """A value at or below the cap passes through unchanged."""
+    from api.src.sernia_ai.tools.quo_tools import _fetch_one_to_one_thread
+
+    seen_max_results: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_max_results.append(request.url.params.get("maxResults"))
+        return httpx.Response(200, json={"data": []})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://api.openphone.com",
+    ) as client:
+        await _fetch_one_to_one_thread(client, "+14129101500", max_results=20)
+
+    assert seen_max_results
+    assert all(v == "20" for v in seen_max_results), seen_max_results


### PR DESCRIPTION
## Description

**Alert addressed:** `Error-level records (non-local)` — the catch-all "something broke" alert.

### What fired
Daily triage surfaced two error-level (`level 17`) spans in **production** on 2026-07-26 21:00 UTC, inside a Sernia agent run (trace `019fa03a534b87a960169af479a2e756`):

```
GET https://api.openphone.com/v1/messages?...&participants=%2B14129101500&maxResults=200  → 400
GET https://api.openphone.com/v1/calls?...&participants=%2B14129101500&maxResults=200      → 400
```

### Root cause
`get_thread_messages` lets the agent (LLM) pick `max_results`, which flows straight into OpenPhone's `maxResults` query param in `_fetch_one_to_one_thread` (`api/src/sernia_ai/tools/quo_tools.py`). OpenPhone's `/v1/messages` and `/v1/calls` list endpoints cap `maxResults` at **100 per page** and reject anything higher with an HTTP 400. httpx raises on that status, which is logged at error level — tripping the catch-all alert.

The agent had requested `maxResults=200`, got the two 400s, then self-corrected ~2s later with a retry at `maxResults=100` (both succeeded). So the request was functionally fine; the only fallout was error-level noise and a wasted round-trip. Every other OpenPhone call in the codebase already hardcodes `maxResults` ≤ 100 — this was the one agent-controllable path with no clamp.

### Fix
Clamp `max_results` to `OPENPHONE_MAX_RESULTS_PER_PAGE` (100) before building the request, so any caller-chosen value stays within the API's per-page limit. No 400 is emitted regardless of what the agent passes.

- New module constant `OPENPHONE_MAX_RESULTS_PER_PAGE = 100`.
- `page_size = max(1, min(max_results, OPENPHONE_MAX_RESULTS_PER_PAGE))` applied in `_fetch_one_to_one_thread`.
- Tool docstring updated to document the cap (per the module's CLAUDE.md convention to keep tool descriptions in sync).

### Tests
Added two non-live unit tests in `test_openphone_rate_limit.py` (run in the default no-keys suite via `httpx.MockTransport`):
- `max_results=200` → both `/v1/messages` and `/v1/calls` requests send `maxResults=100`.
- `max_results=20` → passes through unchanged.

Full `test_openphone_rate_limit.py` passes (20 tests).

### Notes
- Prefers fixing the cause (invalid request) over silencing the alert — the alert definition is unchanged.
- Scoped to this one cause; no other behavior touched.

Preview: https://react-router-portfolio-pr-284.up.railway.app/ (no web-app changes in this PR)

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed. — N/A (backend tool logic only, no Railway config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EGnpyTxywtjWxzd5Ctekp

---
_Generated by [Claude Code](https://claude.ai/code/session_012EGnpyTxywtjWxzd5Ctekp)_