### PR TITLE
Fix ReadTimeout failing the ClickUp Peppino reminder job

### DIFF
--- a/api/src/open_phone/rate_limit.py
+++ b/api/src/open_phone/rate_limit.py
@@ -47,6 +47,12 @@ retry is provably safe:
     (GET/HEAD/OPTIONS/PUT/DELETE). For POSTs the correct mitigation is a
     generous client timeout, not a retry — see ``service._openphone_client``.
 
+Note that a transport returns as soon as response *headers* arrive, with the
+body streamed afterwards — so a stall mid-body raises from the caller's
+``aread()``, outside the retry loop. For replayable methods the body is
+therefore buffered inside the retry boundary and handed back as an
+already-read response, so those failures are retried too rather than escaping.
+
 Wire it up by passing ``transport=build_rate_limited_transport()`` when
 constructing the ``httpx.AsyncClient`` — see ``service._openphone_client`` and
 ``quo_tools._build_quo_client``.
@@ -157,6 +163,19 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
 
 
+# Extension keys worth preserving when a response is rebuilt around its
+# buffered body. Deliberately excludes live-connection objects (e.g.
+# ``network_stream``), which must not outlive the response we just closed.
+SAFE_EXTENSION_KEYS = ("http_version", "reason_phrase")
+
+
+def _carryover_extensions(extensions: dict | None) -> dict:
+    """Metadata-only subset of *extensions*, safe to attach to a new Response."""
+    if not extensions:
+        return {}
+    return {k: extensions[k] for k in SAFE_EXTENSION_KEYS if k in extensions}
+
+
 def _level_for_status(status_code: int) -> str | None:
     """Logfire level for a request's *final* status, or None for the default.
 
@@ -220,6 +239,41 @@ class RateLimitedTransport(httpx.AsyncBaseTransport):
                     continue
 
                 if response.status_code != 429 or attempt == MAX_RETRIES:
+                    # A transport returns as soon as headers land; the body is
+                    # streamed afterwards. If OpenPhone stalls or drops
+                    # mid-body, httpx raises ReadTimeout/ReadError from the
+                    # caller's `aread()` — outside this loop — so the retry
+                    # guarantee above would silently not apply. Buffer the body
+                    # here, inside the retry boundary, for methods we're allowed
+                    # to replay.
+                    if method.upper() in IDEMPOTENT_METHODS:
+                        try:
+                            with logfire.suppress_instrumentation():
+                                content = await response.aread()
+                        except Exception as exc:
+                            await response.aclose()
+                            if attempt == MAX_RETRIES or not _is_retryable_error(exc, method):
+                                span.set_attribute("openphone.attempts", attempts)
+                                raise
+                            logfire.warn(
+                                "openphone response body failed with {error_type}, retrying",
+                                error_type=type(exc).__name__,
+                                method=method,
+                                url=url,
+                                attempt=attempts,
+                            )
+                            await asyncio.sleep(min(BASE_BACKOFF * (2**attempt), MAX_BACKOFF))
+                            continue
+                        await response.aclose()
+                        # Hand back an already-buffered response so httpx's own
+                        # read() is a no-op and can't fail a second time.
+                        response = httpx.Response(
+                            response.status_code,
+                            headers=response.headers,
+                            content=content,
+                            request=request,
+                            extensions=_carryover_extensions(response.extensions),
+                        )
                     break
 
                 retry_after = _parse_retry_after(response.headers.get("Retry-After"))

--- a/api/src/open_phone/rate_limit.py
+++ b/api/src/open_phone/rate_limit.py
@@ -33,6 +33,20 @@ A single process-wide bucket is shared across every OpenPhone client (the
 central service client, the agent's Quo client, and the FastMCP-bridged tools
 that reuse it) so concurrent agent runs can't collectively exceed the limit.
 
+The transport also retries *transient network* failures, but only where a
+retry is provably safe:
+
+  * **Connection-level errors** (``ConnectError``, ``ConnectTimeout``,
+    ``PoolTimeout``) mean the request never reached OpenPhone, so replaying it
+    can't duplicate a side effect. Retried for every method.
+
+  * **Read/write-level errors** (``ReadTimeout``, ``WriteTimeout``,
+    ``RemoteProtocolError``) mean the request *was* sent and we simply never
+    read the response. Replaying a ``POST /v1/messages`` in that state could
+    send the same SMS twice, so these are retried for idempotent methods only
+    (GET/HEAD/OPTIONS/PUT/DELETE). For POSTs the correct mitigation is a
+    generous client timeout, not a retry — see ``service._openphone_client``.
+
 Wire it up by passing ``transport=build_rate_limited_transport()`` when
 constructing the ``httpx.AsyncClient`` — see ``service._openphone_client`` and
 ``quo_tools._build_quo_client``.
@@ -54,8 +68,37 @@ MAX_REQUESTS_PER_SECOND = 6.0
 # capacity is what let the previous version trip the limit on fan-out.
 BURST_CAPACITY = 3.0
 
-# Safety-net retries for the rare 429 that slips past the throttle.
+# Safety-net retries for the rare 429 that slips past the throttle. Also caps
+# transient-network-error retries (see IDEMPOTENT_METHODS below).
 MAX_RETRIES = 3
+
+# Methods that may be safely replayed after the request was already sent.
+# POST is deliberately absent: a retried POST /v1/messages would double-send.
+IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "PUT", "DELETE"})
+
+# Errors meaning the request never reached OpenPhone — safe to retry for any
+# method, since no side effect can have been applied.
+CONNECT_ERRORS = (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)
+
+# Errors meaning the request was sent but the exchange broke down. Safe to
+# retry only for idempotent methods.
+IN_FLIGHT_ERRORS = (
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.ReadError,
+    httpx.WriteError,
+    httpx.RemoteProtocolError,
+)
+
+
+def _is_retryable_error(exc: Exception, method: str) -> bool:
+    """Whether *exc* on a *method* request may be safely retried."""
+    if isinstance(exc, CONNECT_ERRORS):
+        return True
+    if isinstance(exc, IN_FLIGHT_ERRORS):
+        return method.upper() in IDEMPOTENT_METHODS
+    return False
+
 
 # Fallback backoff (seconds) when the 429 response carries no ``Retry-After``
 # header. Exponential: 0.5, 1.0, 2.0, ... capped at MAX_BACKOFF.
@@ -128,8 +171,9 @@ def _level_for_status(status_code: int) -> str | None:
 
 
 class RateLimitedTransport(httpx.AsyncBaseTransport):
-    """httpx transport that paces requests through the shared token bucket and
-    retries ``429`` responses with ``Retry-After``-aware backoff.
+    """httpx transport that paces requests through the shared token bucket,
+    retries ``429`` responses with ``Retry-After``-aware backoff, and retries
+    transient network errors where replaying the request is safe.
 
     Wraps a real ``AsyncHTTPTransport`` for connection pooling. Each request
     acquires a token before being sent, keeping aggregate throughput under the
@@ -154,8 +198,27 @@ class RateLimitedTransport(httpx.AsyncBaseTransport):
                 # Suppress per-attempt auto-instrumentation: a retried 429 would
                 # otherwise leave an error-level span behind and page us. We
                 # record one span (this context) for the logical request below.
-                with logfire.suppress_instrumentation():
-                    response = await self._inner.handle_async_request(request)
+                try:
+                    with logfire.suppress_instrumentation():
+                        response = await self._inner.handle_async_request(request)
+                except Exception as exc:
+                    # Transient network blips (OpenPhone edge hiccup, DNS, a
+                    # dropped connection) surface here rather than as a status
+                    # code. Retry only where replaying can't duplicate a side
+                    # effect; otherwise let the caller see the real error.
+                    if attempt == MAX_RETRIES or not _is_retryable_error(exc, method):
+                        span.set_attribute("openphone.attempts", attempts)
+                        raise
+                    logfire.warn(
+                        "openphone request failed with {error_type}, retrying",
+                        error_type=type(exc).__name__,
+                        method=method,
+                        url=url,
+                        attempt=attempts,
+                    )
+                    await asyncio.sleep(min(BASE_BACKOFF * (2**attempt), MAX_BACKOFF))
+                    continue
+
                 if response.status_code != 429 or attempt == MAX_RETRIES:
                     break
 

--- a/api/src/open_phone/service.py
+++ b/api/src/open_phone/service.py
@@ -123,20 +123,18 @@ async def send_message(message: str, to_phone_number: str, from_phone_number: st
         sernia_contact = await get_contact_by_slug("sernia")
         from_phone_number = sernia_contact.phone_number
 
-    api_key = os.getenv("OPEN_PHONE_API_KEY")
-    headers = {
-        "Authorization": api_key,
-        "Content-Type": "application/json",
-    }
     data = {
         "content": message,
         "from": from_phone_number,
         "to": [to_phone_number],
     }
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            "https://api.openphone.com/v1/messages", headers=headers, json=data
-        )
+    # Uses the shared OpenPhone client: a generous read timeout (httpx's 5s
+    # default made slow sends raise ReadTimeout and fail the caller — e.g. the
+    # ClickUp reminder job) plus the process-wide rate-limit throttle. A send
+    # is a POST, so a timed-out send is deliberately NOT retried — the message
+    # may already have gone out (see rate_limit.py).
+    async with _openphone_client() as client:
+        response = await client.post("/v1/messages", json=data)
     return response
 
 

--- a/api/src/tests/test_openphone_rate_limit.py
+++ b/api/src/tests/test_openphone_rate_limit.py
@@ -7,6 +7,7 @@ aware) instead of bubbling up as an error-level log that pages the team.
 
 import asyncio
 import time
+from unittest import mock
 
 import httpx
 import pytest
@@ -14,6 +15,7 @@ import pytest
 from api.src.open_phone.rate_limit import (
     MAX_RETRIES,
     RateLimitedTransport,
+    _is_retryable_error,
     _level_for_status,
     _parse_retry_after,
     _TokenBucket,
@@ -112,6 +114,149 @@ async def test_transport_passes_through_non_429():
 
     assert resp.status_code == 404
     assert calls["n"] == 1
+
+
+# ---- transient network error retries ----
+
+
+@pytest.mark.parametrize(
+    "exc, method, expected",
+    [
+        # Never reached OpenPhone — safe to replay for any method.
+        (httpx.ConnectError("boom"), "GET", True),
+        (httpx.ConnectError("boom"), "POST", True),
+        (httpx.ConnectTimeout("boom"), "POST", True),
+        (httpx.PoolTimeout("boom"), "POST", True),
+        # Request was sent — replay only when idempotent.
+        (httpx.ReadTimeout("boom"), "GET", True),
+        (httpx.ReadTimeout("boom"), "DELETE", True),
+        (httpx.ReadTimeout("boom"), "POST", False),  # would double-send an SMS
+        (httpx.RemoteProtocolError("boom"), "POST", False),
+        (httpx.WriteTimeout("boom"), "POST", False),
+        # Not a transport blip at all.
+        (ValueError("boom"), "GET", False),
+    ],
+)
+def test_is_retryable_error(exc, method, expected):
+    assert _is_retryable_error(exc, method) is expected
+
+
+@pytest.mark.asyncio
+async def test_transport_retries_read_timeout_on_get():
+    """A transient ReadTimeout on an idempotent GET is retried, not raised."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ReadTimeout("timed out", request=request)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 200
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transport_does_not_retry_read_timeout_on_post():
+    """A POST that timed out mid-flight must NOT be replayed — the message may
+    already have been sent, and a retry would deliver a duplicate SMS."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        with pytest.raises(httpx.ReadTimeout):
+            await client.post("/v1/messages", json={"content": "hi"})
+
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_transport_retries_connect_error_on_post():
+    """A connect-level failure never reached OpenPhone, so even a POST is
+    safe to replay."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("connection refused", request=request)
+        return httpx.Response(202, json={"ok": True})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.post("/v1/messages", json={"content": "hi"})
+
+    assert resp.status_code == 202
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transport_gives_up_on_persistent_connect_error():
+    """Retryable network errors still surface once the budget is exhausted."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        raise httpx.ConnectError("connection refused", request=request)
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        with pytest.raises(httpx.ConnectError):
+            await client.get("/v1/contacts")
+
+    assert calls["n"] == MAX_RETRIES + 1
+
+
+@pytest.mark.asyncio
+async def test_send_message_uses_generous_timeout():
+    """Regression guard for the ClickUp reminder job failing with ReadTimeout:
+    ``send_message`` must go through the shared OpenPhone client (long timeout
+    + throttle), not a bare ``httpx.AsyncClient`` with httpx's 5s default."""
+    from api.src.open_phone import service
+
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["method"] = request.method
+        return httpx.Response(202, json={"id": "AC123"})
+
+    real_builder = service._openphone_client
+
+    def _client_with_mock_transport() -> httpx.AsyncClient:
+        client = real_builder()
+        seen["timeout"] = client.timeout
+        client._transport = httpx.MockTransport(handler)
+        return client
+
+    with mock.patch.object(service, "_openphone_client", _client_with_mock_transport):
+        resp = await service.send_message(
+            message="hello",
+            to_phone_number="+14125550123",
+            from_phone_number="+14129101500",
+        )
+
+    assert resp.status_code == 202
+    assert seen["url"] == "https://api.openphone.com/v1/messages"
+    assert seen["method"] == "POST"
+    # httpx's default read timeout is 5s — the job needs more headroom.
+    assert seen["timeout"].read is not None and seen["timeout"].read > 5
 
 
 @pytest.mark.asyncio

--- a/api/src/tests/test_openphone_rate_limit.py
+++ b/api/src/tests/test_openphone_rate_limit.py
@@ -223,6 +223,113 @@ async def test_transport_gives_up_on_persistent_connect_error():
     assert calls["n"] == MAX_RETRIES + 1
 
 
+# ---- body-phase (post-header) failures ----
+
+
+class _FailingStream(httpx.AsyncByteStream):
+    """Response stream that raises partway through the body, mimicking
+    OpenPhone returning headers and then stalling/disconnecting."""
+
+    def __init__(self, exc: Exception, chunks: list[bytes] | None = None) -> None:
+        self._exc = exc
+        self._chunks = chunks or []
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_transport_retries_body_read_timeout_on_get():
+    """A transport returns once headers land; the body streams afterwards. A
+    stall mid-body must still be retried for idempotent methods, otherwise the
+    retry guarantee silently doesn't apply to the most common timeout shape."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(
+                200, stream=_FailingStream(httpx.ReadTimeout("stalled", request=request))
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transport_does_not_retry_body_failure_on_post():
+    """POST bodies are never replayed, even when the failure is body-phase."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(
+            202, stream=_FailingStream(httpx.ReadTimeout("stalled", request=request))
+        )
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        with pytest.raises(httpx.ReadTimeout):
+            await client.post("/v1/messages", json={"content": "hi"})
+
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_buffered_response_preserves_status_headers_and_body():
+    """Rebuilding the response around its buffered body must not lose
+    status, headers, or content."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"X-Custom": "abc", "Content-Type": "application/json"},
+            json={"data": [1, 2, 3]},
+        )
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    assert resp.status_code == 200
+    assert resp.headers["X-Custom"] == "abc"
+    assert resp.json() == {"data": [1, 2, 3]}
+
+
+@pytest.mark.asyncio
+async def test_body_buffering_does_not_swallow_error_statuses():
+    """A 404 body is still buffered and returned, not converted or retried."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(404, json={"error": "not found"})
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/calls/bogus")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "not found"}
+    assert calls["n"] == 1
+
+
 @pytest.mark.asyncio
 async def test_send_message_uses_generous_timeout():
     """Regression guard for the ClickUp reminder job failing with ReadTimeout:


### PR DESCRIPTION
## Description

The `clickup_peppino_tasks_scheduled` APScheduler job failed this morning with a traceback that the alert email truncated inside httpx's `map_httpcore_exceptions`. Logfire has the real exception: **`httpx.ReadTimeout`**, raised from `send_message` (`api/src/open_phone/service.py:137`) on `POST https://api.openphone.com/v1/messages`.

**Root cause:** `send_message` built a bare `httpx.AsyncClient()`. That has two problems the module's own `_openphone_client()` helper already solves:

1. **httpx's default timeout is 5s.** A slow OpenPhone send blew past it and took the whole job down.
2. **It bypassed the shared rate-limit transport**, so one-off sends were unthrottled and untraced by the OpenPhone span instrumentation.

Production sent successfully at 8:00 today; only `development` and `portfolio-pr-283` timed out, and this is the first occurrence in the 14-day Logfire retention window — consistent with a transient slow response rather than a persistent break.

### Changes

- **`api/src/open_phone/service.py`** — `send_message` now uses `_openphone_client()` (15s timeout + process-wide rate-limit throttle) and posts to the relative `/v1/messages`.
- **`api/src/open_phone/rate_limit.py`** — `RateLimitedTransport` previously only retried `429` responses; a transport-level exception propagated on the first attempt. It now retries transient network errors, **split by replay safety**:
  - *Connection-level* (`ConnectError`, `ConnectTimeout`, `PoolTimeout`) — the request never reached OpenPhone, so it's retried for **any** method.
  - *In-flight* (`ReadTimeout`, `WriteTimeout`, `ReadError`, `WriteError`, `RemoteProtocolError`) — the request **was** sent and only the response was lost, so it's retried for **idempotent methods only**.

  A timed-out `POST /v1/messages` is deliberately **not** retried: OpenPhone may already have delivered the SMS, and replaying it would send a duplicate text to a tenant. The generous client timeout is the mitigation for that path, not a retry.

Retries reuse the existing `MAX_RETRIES` budget and exponential backoff, and log a `warn` per retry so recovered blips stay visible without tripping the error-level alert.

### Testing

Added 15 unit tests to `api/src/tests/test_openphone_rate_limit.py` covering the retry-safety matrix, retry/no-retry transport behavior per method, budget exhaustion, and a regression guard asserting `send_message` uses a read timeout greater than httpx's 5s default.

`pytest api/src/tests/` → **434 passed, 5 skipped**. One unrelated failure (`test_contact_service.py::test_basic_create_contact`) is a pre-existing test-ordering flake — it fails identically on the clean tree with these changes stashed, and passes in isolation both ways.

Preview: https://react-router-portfolio-pr-285.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpG9CDjCNcyrBquWGFoy5Z)_