### PR TITLE
Fix httpx.DecodingError from buffered OpenPhone responses (gzip re-decode)

### DIFF
--- a/api/src/open_phone/rate_limit.py
+++ b/api/src/open_phone/rate_limit.py
@@ -176,6 +176,26 @@ def _carryover_extensions(extensions: dict | None) -> dict:
     return {k: extensions[k] for k in SAFE_EXTENSION_KEYS if k in extensions}
 
 
+# Wire-framing headers that describe the *encoded* body on the network, not the
+# decoded bytes ``aread()`` hands back. ``aread()`` returns the body already
+# decompressed, so reattaching e.g. ``Content-Encoding: gzip`` to a rebuilt
+# response makes httpx try to gunzip already-plain bytes on the next read and
+# raise ``DecodingError: Error -3 while decompressing data: incorrect header
+# check``. ``Content-Length`` (the compressed size) and ``Transfer-Encoding``
+# are likewise stale once the body is buffered and decoded. Drop all three and
+# let httpx recompute ``Content-Length`` from the decoded content.
+STALE_BODY_FRAMING_HEADERS = frozenset({"content-encoding", "content-length", "transfer-encoding"})
+
+
+def _headers_for_decoded_body(headers: httpx.Headers) -> list[tuple[bytes, bytes]]:
+    """Original headers minus the wire-framing ones invalidated by decoding."""
+    return [
+        (name, value)
+        for name, value in headers.raw
+        if name.decode("latin-1").lower() not in STALE_BODY_FRAMING_HEADERS
+    ]
+
+
 def _level_for_status(status_code: int) -> str | None:
     """Logfire level for a request's *final* status, or None for the default.
 
@@ -266,10 +286,14 @@ class RateLimitedTransport(httpx.AsyncBaseTransport):
                             continue
                         await response.aclose()
                         # Hand back an already-buffered response so httpx's own
-                        # read() is a no-op and can't fail a second time.
+                        # read() is a no-op and can't fail a second time. The
+                        # buffered `content` is already decoded, so strip the
+                        # wire-framing headers (Content-Encoding etc.) that would
+                        # otherwise make httpx re-decode plain bytes and raise
+                        # DecodingError.
                         response = httpx.Response(
                             response.status_code,
-                            headers=response.headers,
+                            headers=_headers_for_decoded_body(response.headers),
                             content=content,
                             request=request,
                             extensions=_carryover_extensions(response.extensions),

--- a/api/src/tests/test_openphone_rate_limit.py
+++ b/api/src/tests/test_openphone_rate_limit.py
@@ -6,6 +6,7 @@ aware) instead of bubbling up as an error-level log that pages the team.
 """
 
 import asyncio
+import gzip
 import time
 from unittest import mock
 
@@ -308,6 +309,57 @@ async def test_buffered_response_preserves_status_headers_and_body():
     assert resp.status_code == 200
     assert resp.headers["X-Custom"] == "abc"
     assert resp.json() == {"data": [1, 2, 3]}
+
+
+class _RawStream(httpx.AsyncByteStream):
+    """Response stream that yields raw (undecoded) wire bytes, so httpx applies
+    the ``Content-Encoding`` decoder on read — mimicking a real gzipped
+    OpenPhone response rather than MockTransport's pre-decoded ``content=``."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def __aiter__(self):
+        yield self._data
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_buffered_response_decodes_gzip_body():
+    """Regression guard: OpenPhone/Cloudflare gzip their responses. ``aread()``
+    hands back the DECODED body, so rebuilding the buffered response around the
+    original headers (which still say ``Content-Encoding: gzip``) made httpx
+    re-run the gzip decoder on already-plain bytes and raise
+    ``DecodingError: Error -3 while decompressing data: incorrect header
+    check``. The rebuild must strip the stale wire-framing headers."""
+    payload = {"data": [{"id": "AC1", "body": "hello world"}]}
+    body = gzip.compress(b'{"data": [{"id": "AC1", "body": "hello world"}]}')
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "Content-Encoding": "gzip",
+                "Content-Length": str(len(body)),
+                "Content-Type": "application/json",
+            },
+            stream=_RawStream(body),
+        )
+
+    transport = RateLimitedTransport(inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://api.openphone.com"
+    ) as client:
+        resp = await client.get("/v1/contacts")
+
+    # Would raise httpx.DecodingError before the fix.
+    assert resp.status_code == 200
+    assert resp.json() == payload
+    # The stale wire-framing header is gone; the body is already decoded.
+    assert "content-encoding" not in resp.headers
+    assert resp.headers["Content-Type"] == "application/json"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Daily Logfire triage surfaced a new exception cluster on production: **`httpx.DecodingError: Error -3 while decompressing data: incorrect header check`** (14 hits, 13:00–13:01 UTC on 2026-07-31), firing on idempotent GETs to `api.openphone.com` (`/v1/conversations`, `/v1/contacts`) and cascading into Sernia agent tool failures (`quo_get_thread_messages`, `quo_search_contacts`, `send_sms`, `db_get_contact_sms_history`).

**Root cause — a regression from #285 (commit `5d625af`).** The body-buffering retry path rebuilds the response around `await response.aread()`, which returns the **decoded** body — but reused the original headers, which still advertise `Content-Encoding: gzip` and the compressed `Content-Length`. OpenPhone/Cloudflare gzip their responses, so httpx re-ran the gzip decoder against already-plain bytes on the next read and raised `DecodingError`, escaping `handle_async_request`.

Confirmed by reproducing the exact error locally against httpx 0.28.1, and by the Logfire trace (`019fb842a8adc734249a61ed92bc764a`).

## Fix

Strip the wire-framing headers (`Content-Encoding`, `Content-Length`, `Transfer-Encoding`) when rebuilding around the decoded body. These describe the encoded body on the network, not the buffered/decoded bytes; httpx recomputes `Content-Length` from the content. Non-framing headers (e.g. `Content-Type`) are preserved.

## Testing

- `pytest api/src/tests/test_openphone_rate_limit.py` → 40 passed.
- New regression test `test_buffered_response_decodes_gzip_body` drives a real gzipped response through the transport. It **fails on the current `main`** with the exact production error and passes with this fix. (The pre-existing rebuild test used an uncompressed body, so it never caught this.)

## Alert addressed

Logfire tracked issue: `httpx.DecodingError in fastapi` — *"Error -3 while decompressing data: incorrect header check"*.

Preview: https://react-router-portfolio-pr-286.up.railway.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ah4ZaV58et8ZnSfjWc5LwH