### PR TITLE
Fix AI SMS thread fetch 400ing on bracketed participants param

### DIFF
--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -91,7 +91,9 @@ Whenever a call appears in either tool's output, the Call ID (`AC...`) is includ
 
 ### Group Threads
 
-OpenPhone supports multi-participant conversations (e.g. two roommates sharing one Quo thread), but the public API does **not** let you list a group thread's messages by participant: `/v1/messages?participants[]=A&participants[]=B` silently filters to the 1:1 conversation with the *first* participant, regardless of how many are passed. The group conversation is real (it appears in `/v1/conversations`), and individual messages can be fetched by ID via `/v1/messages/{id}`, but you can't enumerate them.
+OpenPhone supports multi-participant conversations (e.g. two roommates sharing one Quo thread), but the public API does **not** let you list a group thread's messages by participant: `/v1/messages?participants[]=A&participants[]=B` silently filters to the 1:1 conversation with the *first* participant, regardless of how many are passed.
+
+> **Gotcha — send `participants`, not `participants[]`, from Python.** The bracketed form above is *curl* syntax, where the brackets go over the wire literally. httpx percent-encodes them to `participants%5B%5D`, which OpenPhone does not recognise and answers with a **400**. Every call site here uses the plain `participants` key; `test_triggers.py::TestFetchSmsThreadRequest` guards the one that regressed. The group conversation is real (it appears in `/v1/conversations`), and individual messages can be fetched by ID via `/v1/messages/{id}`, but you can't enumerate them.
 
 Workarounds in this codebase:
 

--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -145,8 +145,15 @@ async def _fetch_sms_thread(
             resp = await client.get(
                 "/v1/messages",
                 params={
+                    # Plain ``participants``, NOT ``participants[]``: httpx
+                    # percent-encodes the brackets to ``participants%5B%5D``,
+                    # which OpenPhone does not recognise and rejects with a
+                    # 400. (Literal brackets work in curl, which is why the
+                    # bracketed form looks right in the API docs.) Every other
+                    # call site in the codebase uses the plain key — see
+                    # ``quo_tools._fetch_latest_message``.
                     "phoneNumberId": QUO_SERNIA_AI_PHONE_ID,
-                    "participants[]": from_phone,
+                    "participants": from_phone,
                     "maxResults": SMS_CONVERSATION_MAX_MESSAGES,
                 },
             )

--- a/api/src/tests/test_triggers.py
+++ b/api/src/tests/test_triggers.py
@@ -641,6 +641,57 @@ class TestAiSmsEventTriggerSmoke:
         assert hasattr(routes_module, "handle_ai_sms_event")
 
 
+class TestFetchSmsThreadRequest:
+    """Guard the query parameters _fetch_sms_thread sends to OpenPhone."""
+
+    @pytest.mark.asyncio
+    async def test_uses_unbracketed_participants_param(self):
+        """The participant filter must be ``participants``, not ``participants[]``.
+
+        httpx percent-encodes the brackets to ``participants%5B%5D``, which
+        OpenPhone does not recognise — it answers 400, the thread fetch fails,
+        and the agent replies without any SMS history. Every 200 in production
+        uses the plain key; every bracketed request 400s.
+        """
+        import api.src.sernia_ai.triggers.ai_sms_event_trigger as trigger_mod
+        from api.src.sernia_ai.config import (
+            QUO_SERNIA_AI_PHONE_ID,
+            SMS_CONVERSATION_MAX_MESSAGES,
+        )
+
+        seen: list[httpx.URL] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.url)
+            return httpx.Response(200, json={"data": []})
+
+        # Bind the real class before patching — the module reaches the client
+        # through the shared ``httpx`` module, so the patch is global and a
+        # late lookup inside the factory would recurse into itself.
+        real_client_cls = httpx.AsyncClient
+
+        def client_factory(**kwargs):
+            kwargs.pop("transport", None)
+            return real_client_cls(transport=httpx.MockTransport(handler), **kwargs)
+
+        with (
+            patch.dict("os.environ", {"OPEN_PHONE_API_KEY": "test-key"}),
+            patch.object(trigger_mod.httpx, "AsyncClient", client_factory),
+        ):
+            result = await trigger_mod._fetch_sms_thread("+14123703550")
+
+        assert result == []
+        assert len(seen) == 1, f"expected one /v1/messages request, got {seen}"
+        url = seen[0]
+        assert url.params.get("participants") == "+14123703550"
+        assert url.params.get("phoneNumberId") == QUO_SERNIA_AI_PHONE_ID
+        assert url.params.get("maxResults") == str(SMS_CONVERSATION_MAX_MESSAGES)
+        # The encoded bracket form is what OpenPhone rejects — assert on the
+        # raw query string so an accidental re-introduction is caught.
+        assert "participants%5B%5D" not in str(url), f"bracketed participants param sent: {url}"
+        assert "participants[]" not in str(url), f"bracketed participants param sent: {url}"
+
+
 class TestSmsToModelMessages:
     """Test OpenPhone message conversion to PydanticAI format."""
 


### PR DESCRIPTION
## Description

Addresses the **"Error-level records (non-local)"** Logfire alert, which fired twice in the last 24h on `ai_sms_event: failed to fetch SMS thread` (`httpx.HTTPStatusError: 400`, production, 00:22Z and 03:26Z).

### Cause

`_fetch_sms_thread` passed the OpenPhone participant filter as `participants[]`:

```python
params={
    "phoneNumberId": QUO_SERNIA_AI_PHONE_ID,
    "participants[]": from_phone,      # ← httpx encodes to participants%5B%5D
    "maxResults": SMS_CONVERSATION_MAX_MESSAGES,
}
```

httpx percent-encodes the brackets, producing `participants%5B%5D`, which OpenPhone does not recognise and rejects with a 400. The bracketed form is *curl* syntax — curl puts the brackets on the wire literally, which is why it looks correct in the API docs and in `tools/quo_bug_report.md`.

Production telemetry over the last two weeks confirms the split cleanly:

| Param form | Requests | Result |
|---|---|---|
| `participants=` (plain) | 22 | all 200 |
| `participants%5B%5D=` (bracketed) | 2 | all 400 |

Every other call site already uses the plain key — `quo_tools._fetch_latest_message`, `_fetch_latest_call`, `_fetch_one_to_one_thread`. `ai_sms_event_trigger` was the lone outlier.

### Impact

The failure is caught and logged, so the agent still replies — but with **no SMS thread history**, so it loses the messages sent from other conversations that `_fetch_sms_thread` exists to recover (see `triggers/README.md` → History Loading). The error-level log is also what trips the alert.

Low frequency because the path only runs on inbound SMS to the AI's direct line from an internal contact — but it has been failing 100% of the time it runs.

### Changes

- `triggers/ai_sms_event_trigger.py` — use the plain `participants` key, with a comment explaining why the bracketed form is wrong from Python.
- `tests/test_triggers.py` — new `TestFetchSmsThreadRequest`, asserting on the raw query string so the encoded bracket form can't be reintroduced. Verified it fails against the old code, reproducing the exact production URL.
- `tools/README.md` — gotcha note in the Group Threads section, where the bracket syntax is discussed.

### Testing

- Full default suite: **512 passed**, 5 skipped.
- `api/src/tests/test_contact_service.py::test_basic_create_contact` fails in a full run, but it fails identically on the unmodified base commit — pre-existing test-ordering flake, unrelated to this change and left alone.

### Preview

https://react-router-portfolio-pr-288.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQfzafY9XssnSBFKwCRtvG)_