### PR TITLE
Keep distinct encrypted reasoning items apart in OpenRouter streaming

### DIFF
--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -52,6 +52,18 @@ Things worth knowing about the OpenRouter path (all handled in
   tool's `allowed_domains`, so `SerniaOpenRouterModel` re-attaches
   `WEB_SEARCH_ALLOWED_DOMAINS` as the plugin's `include_domains` — without it
   the agent could search the whole web.
+- **Streamed encrypted reasoning items are kept distinct.** pydantic-ai's
+  OpenRouter streaming keys `reasoning_details` deltas by type + position, not
+  by reasoning item id — so a streamed response containing two encrypted
+  reasoning items (which OpenAI emits when reasoning interleaves with several
+  tool calls in one turn) merges them into a single ThinkingPart carrying the
+  first item's id and the last item's encrypted payload. Replaying that part
+  fails the whole run with a 400 `invalid_encrypted_content` ("Encrypted
+  content item_id did not match the target item id"). Bug confirmed present
+  upstream through pydantic-ai 2.24.0; `SerniaOpenRouterStreamedResponse`
+  fixes the keying, and a canary test
+  (`test_upstream_still_merges_encrypted_reasoning_items`) fails when upstream
+  fixes it so the subclass can be deleted.
 - **Cost tracking** comes from OpenRouter, not genai-prices. genai-prices has
   no entry for the `openai/gpt-5.6-luna` OpenRouter route, so pydantic-ai's own
   pricing raises `LookupError` and never stamps `operation.cost`. We enable

--- a/api/src/sernia_ai/model_config.py
+++ b/api/src/sernia_ai/model_config.py
@@ -31,7 +31,7 @@ clamps to ``xhigh``, being an OpenAI tier).
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import cache
@@ -39,10 +39,15 @@ from typing import Any, Literal, cast, get_args
 
 import logfire
 from opentelemetry import trace
-from pydantic_ai.messages import ModelResponse
+from pydantic_ai.messages import ModelResponse, ModelResponseStreamEvent
 from pydantic_ai.models import ModelRequestParameters, StreamedResponse
 from pydantic_ai.models.anthropic import AnthropicModelSettings
-from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
+from pydantic_ai.models.openrouter import (
+    OpenRouterModel,
+    OpenRouterModelSettings,
+    OpenRouterStreamedResponse,
+    _from_reasoning_detail,  # pyright: ignore[reportPrivateUsage]
+)
 from pydantic_ai.native_tools import WebSearchTool
 from pydantic_ai.settings import ModelSettings
 from sqlalchemy import select
@@ -139,8 +144,58 @@ def get_openrouter_effort(value: str | None) -> str:
 _COST_SPAN_ATTR = "operation.cost"
 
 
+class SerniaOpenRouterStreamedResponse(OpenRouterStreamedResponse):
+    """Streamed response that keeps distinct encrypted reasoning items apart.
+
+    pydantic-ai keys streamed ``reasoning_details`` deltas by type and
+    position-within-chunk — ``f'reasoning_detail_{detail.type}_{i}'`` — so the
+    reasoning item's own id never enters the key. When one streamed response
+    carries TWO encrypted reasoning items (the upstream OpenAI Responses API
+    emits one per reasoning segment when reasoning interleaves with several
+    tool calls), both land on the same vendor key and the parts manager merges
+    them into a single ThinkingPart: the FIRST item's id with the LAST item's
+    encrypted payload (``ThinkingPartDelta`` carries no id and *replaces* the
+    signature). Replaying that Frankenstein part on the next request makes
+    OpenAI reject it with ``invalid_encrypted_content`` ("Encrypted content
+    item_id did not match the target item id"), failing the whole agent run.
+    The bug is streaming-only (the non-streaming path maps each detail to its
+    own ThinkingPart) and is still present on pydantic-ai main as of 2.24.0 —
+    upgrading does not fix it. ``test_model_config.py`` carries a canary test
+    that fails when upstream fixes it, so this subclass can be deleted.
+
+    Fix: key ``reasoning.encrypted`` details by their item id when present.
+    Encrypted payloads always arrive whole (opaque blobs are never
+    delta-streamed — upstream's own delta logic replaces rather than appends
+    signatures), so id-keying cannot split a legitimately-continuing item.
+    Text/summary details keep upstream's keying untouched, including its
+    Gemini multi-type handling.
+    """
+
+    def _map_thinking_delta(self, choice: Any) -> Iterable[ModelResponseStreamEvent]:
+        reasoning_details = getattr(choice.delta, "reasoning_details", None)
+        if not reasoning_details:
+            # No OpenRouter reasoning details on this chunk — upstream falls
+            # back to plain `delta.reasoning` handling; keep that path.
+            yield from super()._map_thinking_delta(choice)
+            return
+        for i, detail in enumerate(reasoning_details):
+            thinking_part = _from_reasoning_detail(detail)
+            if detail.type == "reasoning.encrypted" and detail.id:
+                vendor_id = f"reasoning_detail_{detail.type}_{detail.id}"
+            else:
+                vendor_id = f"reasoning_detail_{detail.type}_{i}"
+            yield from self._parts_manager.handle_thinking_delta(
+                vendor_part_id=vendor_id,
+                id=thinking_part.id,
+                content=thinking_part.content,
+                signature=thinking_part.signature,
+                provider_name=self._provider_name,
+                provider_details=thinking_part.provider_details,
+            )
+
+
 class SerniaOpenRouterModel(OpenRouterModel):
-    """OpenRouter model that keeps two things pydantic-ai drops on this provider.
+    """OpenRouter model that keeps three things pydantic-ai drops or breaks on this provider.
 
     **1. The web-search domain allowlist.** PydanticAI maps a ``WebSearchTool``
     onto OpenRouter's ``web`` plugin (``extra_body["plugins"] = [{"id": "web"}]``)
@@ -161,7 +216,16 @@ class SerniaOpenRouterModel(OpenRouterModel):
     ``build_openrouter_settings``'s ``usage.include`` — so we stamp that. It is
     strictly better data than a price table: it reflects the endpoint actually
     routed to and includes web-plugin charges.
+
+    **3. Distinct encrypted reasoning items in streamed responses.** See
+    :class:`SerniaOpenRouterStreamedResponse` — without it, a streamed
+    response with two encrypted reasoning items is merged into one corrupt
+    ThinkingPart whose replay 400s with ``invalid_encrypted_content``.
     """
+
+    @property
+    def _streamed_response_cls(self) -> type[OpenRouterStreamedResponse]:
+        return SerniaOpenRouterStreamedResponse
 
     def prepare_request(
         self,

--- a/api/src/tests/test_model_config.py
+++ b/api/src/tests/test_model_config.py
@@ -306,3 +306,114 @@ def test_stamp_openrouter_cost_is_a_noop_without_cost():
 
     (span,) = exporter.get_finished_spans()
     assert "operation.cost" not in (span.attributes or {})
+
+
+# ---------------------------------------------------------------------------
+# Streamed encrypted-reasoning integrity (SerniaOpenRouterStreamedResponse)
+# ---------------------------------------------------------------------------
+#
+# Root cause of the production `invalid_encrypted_content` 400 (2026-08-05,
+# trace 019fcff60d3999d40125ebed3a7929be): pydantic-ai's OpenRouter streaming
+# keys reasoning_details deltas by type + position-within-chunk, so two
+# encrypted reasoning items with different `rs_...` ids in one streamed
+# response merge into a single ThinkingPart — first item's id, last item's
+# encrypted payload. OpenAI then rejects the replay because the encrypted blob
+# decrypts to a different item id than the part claims.
+
+
+def _encrypted_chunk_choice(item_id: str, data: str, index: int):
+    """A real _OpenRouterChunkChoice carrying one encrypted reasoning detail."""
+    from pydantic_ai.models.openrouter import (
+        _OpenRouterChunkChoice,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    return _OpenRouterChunkChoice.model_validate(
+        {
+            "index": 0,
+            "delta": {
+                "reasoning_details": [
+                    {
+                        "type": "reasoning.encrypted",
+                        "id": item_id,
+                        "format": "openai-responses-v1",
+                        "index": index,
+                        "data": data,
+                    }
+                ]
+            },
+            "finish_reason": None,
+        }
+    )
+
+
+def _drain_thinking_deltas(response_cls, choices):
+    """Feed chunk choices through a streamed-response class's thinking mapper.
+
+    Builds the instance without running the dataclass __init__ (it wants a live
+    HTTP stream); _map_thinking_delta only touches _parts_manager (derived from
+    model_request_parameters) and _provider_name.
+    """
+    from pydantic_ai.messages import ThinkingPart
+    from pydantic_ai.models import ModelRequestParameters
+
+    resp = object.__new__(response_cls)
+    resp.model_request_parameters = ModelRequestParameters()
+    resp._provider_name = "openrouter"
+    for choice in choices:
+        for _ in resp._map_thinking_delta(choice):
+            pass
+    return [p for p in resp._parts_manager.get_parts() if isinstance(p, ThinkingPart)]
+
+
+def test_streamed_encrypted_reasoning_items_stay_distinct():
+    """Two encrypted reasoning items must survive streaming as two parts.
+
+    Each keeps its own id↔payload pairing, so the replayed reasoning_details
+    are exactly what OpenAI produced and verification passes.
+    """
+    from api.src.sernia_ai.model_config import SerniaOpenRouterStreamedResponse
+
+    parts = _drain_thinking_deltas(
+        SerniaOpenRouterStreamedResponse,
+        [
+            _encrypted_chunk_choice("rs_AAA", "ENCRYPTED_BLOB_OF_AAA", index=0),
+            _encrypted_chunk_choice("rs_BBB", "ENCRYPTED_BLOB_OF_BBB", index=1),
+        ],
+    )
+
+    assert [(p.id, p.signature) for p in parts] == [
+        ("rs_AAA", "ENCRYPTED_BLOB_OF_AAA"),
+        ("rs_BBB", "ENCRYPTED_BLOB_OF_BBB"),
+    ]
+
+
+def test_streamed_response_class_is_wired():
+    """SerniaOpenRouterModel must actually stream through the fixed class."""
+    from api.src.sernia_ai.model_config import (
+        SerniaOpenRouterStreamedResponse,
+        resolve_model,
+    )
+
+    model = resolve_model("openrouter:openai/gpt-5.6-luna")
+    assert model._streamed_response_cls is SerniaOpenRouterStreamedResponse
+
+
+def test_upstream_still_merges_encrypted_reasoning_items():
+    """CANARY: upstream OpenRouterStreamedResponse still has the merge bug.
+
+    When this test FAILS, pydantic-ai has fixed the vendor-key collision
+    upstream — delete SerniaOpenRouterStreamedResponse (and these tests) and
+    rely on the library. Until then, this documents exactly what the subclass
+    protects against: one part, first id, last payload.
+    """
+    from pydantic_ai.models.openrouter import OpenRouterStreamedResponse
+
+    parts = _drain_thinking_deltas(
+        OpenRouterStreamedResponse,
+        [
+            _encrypted_chunk_choice("rs_AAA", "ENCRYPTED_BLOB_OF_AAA", index=0),
+            _encrypted_chunk_choice("rs_BBB", "ENCRYPTED_BLOB_OF_BBB", index=1),
+        ],
+    )
+
+    assert [(p.id, p.signature) for p in parts] == [("rs_AAA", "ENCRYPTED_BLOB_OF_BBB")]


### PR DESCRIPTION
## Description

Root-causes and fixes the production **`invalid_encrypted_content`** 400 on `openai/gpt-5.6-luna` from the 2026-08-05 Logfire triage (trace `019fcff60d3999d40125ebed3a7929be`) — the item escalated to Slack this morning. Follow-up investigation confirmed the suspicion that this is a **pydantic-ai bug, not an OpenRouter one**.

### Root cause (reproduced deterministically)

`OpenRouterStreamedResponse._map_thinking_delta` keys streamed `reasoning_details` deltas by

```python
vendor_id = f'reasoning_detail_{detail.type}_{i}'   # i = position within the chunk
```

The reasoning item's own `rs_...` id never enters the key. When one streamed response carries **two encrypted reasoning items** — which the upstream OpenAI Responses API emits when reasoning interleaves with several tool calls in a single turn — both land on the same vendor key and the parts manager merges them into one ThinkingPart:

- `ThinkingPartDelta` has **no id field** → the *first* item's id survives;
- `apply()` **replaces** the signature → the *last* item's encrypted payload wins.

Replay then sends item `rs_A` carrying `rs_B`'s encrypted blob, and OpenAI rejects it: *"Encrypted content item_id did not match the target item id."* Minimal repro (two chunks through the real `_OpenRouterChunkChoice` path):

```
ThinkingParts assembled: 1
  part id='rs_AAA' sig='ENCRYPTED_BLOB_OF_BBB'   ← Frankenstein part
```

This matches every observed fact: streaming-only (the non-streaming path maps each detail to its own part — the SMS-trigger run the same night was fine), intermittent (~1 in 22 model calls — the rate at which a response contains ≥2 encrypted reasoning segments), and it appeared with PR #287 only because that PR introduced the OpenRouter streaming path.

**Upgrading doesn't fix it:** the identical keying and merge logic is on pydantic-ai `main` as of **2.24.0** (verified in both `models/openrouter.py` and `_parts_manager.py`).

### Changes

- `model_config.py` — `SerniaOpenRouterStreamedResponse`: keys `reasoning.encrypted` details by their item id when present. Encrypted payloads always arrive whole (opaque blobs are never delta-streamed; upstream itself replaces rather than appends signatures), so id-keying can't split a legitimately-continuing item. Text/summary details keep upstream's keying, including its Gemini multi-type handling. Wired via the `_streamed_response_cls` hook — the same pattern as the class's existing web-search-allowlist and cost-stamping patches (the docstring's "two things" is now three).
- `test_model_config.py` — three tests: the fix (two items survive with correct id↔payload pairing), the wiring, and an **upstream canary** (`test_upstream_still_merges_encrypted_reasoning_items`) that fails the moment pydantic-ai fixes the collision, signalling the subclass can be deleted.
- `README.md` — Model Gateways bullet documenting the gotcha.

### Testing

Full default suite: **515 passed**, 5 skipped. (`test_basic_create_contact` fails in this sandbox on unmodified `main` too — known local flake, green in CI.)

### Upstream report (ready to file — this session's GitHub access is scoped to this repo)

> **Title:** OpenRouter streaming merges distinct encrypted reasoning items into one ThinkingPart → `invalid_encrypted_content` on replay
>
> **Body:** `OpenRouterStreamedResponse._map_thinking_delta` uses `vendor_id = f'reasoning_detail_{detail.type}_{i}'` where `i` is the index within each chunk's `reasoning_details` list. When a streamed response contains two `reasoning.encrypted` items with different ids (OpenAI Responses emits one per reasoning segment when reasoning interleaves with multiple tool calls), both map to the same vendor key. `ModelResponsePartsManager.handle_thinking_delta` then merges them: `ThinkingPartDelta` carries no id (first item's id survives) and replaces the signature (last item's payload wins). Replaying the merged part yields a 400: `invalid_encrypted_content — Encrypted content item_id did not match the target item id`. Repro: feed two single-detail chunks (`rs_AAA`/blob A, `rs_BBB`/blob B) through `_map_thinking_delta`; result is one ThinkingPart `id='rs_AAA', signature='blob B'`. Suggested fix: include `detail.id` in the vendor key for encrypted details (they always arrive whole), e.g. `f'reasoning_detail_{detail.type}_{detail.id or i}'`. Present on `main` as of 2.24.0; hit in production via `openrouter:openai/gpt-5.6-luna`.

### Preview

https://react-router-portfolio-pr-289.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQfzafY9XssnSBFKwCRtvG)_