### PR TITLE
Fix Sernia AI response recovery and notifications

### DIFF
--- a/api/src/ai_demos/models.py
+++ b/api/src/ai_demos/models.py
@@ -353,7 +353,7 @@ async def persist_agent_run_result(
     agent_name: str,
     clerk_user_id: str | None = None,
     metadata: dict[str, Any] | None = None,
-) -> None:
+) -> bool:
     """
     Convenience function to persist an agent run result to the database.
     Handles session creation and error logging.
@@ -375,15 +375,19 @@ async def persist_agent_run_result(
         agent_name: Name of the agent
         clerk_user_id: Clerk user ID (e.g., "user_2abc123...") - used for ownership
         metadata: Optional metadata to store
+
+    Returns:
+        True only when the conversation was successfully committed. Existing
+        callers may continue to ignore the return value.
     """
     logfire.info(
         f"persist_agent_run_result called: conversation_id={conversation_id}, agent_name={agent_name}"
     )
     if not conversation_id:
         logfire.warning("No conversation_id provided for persistence")
-        return
+        return False
 
-    async def _do_persist():
+    async def _do_persist() -> bool:
         """Inner function that does the actual persistence."""
         try:
             async with provide_session() as s:
@@ -423,16 +427,26 @@ async def persist_agent_run_result(
             logfire.info(
                 f"Conversation {conversation_id} saved to database for agent {agent_name} and clerk_user_id {clerk_user_id}"
             )
+            return True
         except Exception as e:
             logfire.error(f"Failed to save conversation {conversation_id}: {e}")
+            return False
 
     # Spawn as a background task and shield from cancellation
     task = asyncio.create_task(_do_persist())
     try:
-        await asyncio.shield(task)
+        return await asyncio.shield(task)
     except asyncio.CancelledError:
-        # Parent was cancelled (e.g., client disconnected), but task continues
+        # Parent was cancelled (e.g., client disconnected), but shield kept the
+        # DB task alive. Wait for that same task so callers can distinguish a
+        # confirmed commit from a failure before dispatching notifications.
         logfire.info(f"Persistence shielded from cancellation for {conversation_id}")
+        try:
+            return await task
+        except asyncio.CancelledError:
+            # The persistence task itself was cancelled independently.
+            logfire.warn(f"Persistence task cancelled for {conversation_id}")
+            return False
 
 
 def _sanitize_json(obj: Any) -> Any:

--- a/api/src/sernia_ai/push/README.md
+++ b/api/src/sernia_ai/push/README.md
@@ -1,9 +1,11 @@
 # Notifications (Push + SMS)
 
-Team notifications for Sernia AI's HITL approvals and trigger alerts. Two channels fire in parallel for belt-and-suspenders delivery:
+Notifications for Sernia AI chat responses, HITL approvals, and trigger alerts. Two delivery channels are available:
 
-1. **Web Push** — PWA push notifications to phones and desktops (no native app required)
-2. **SMS to shared team number** — persistent record in the team's OpenPhone thread with a deeplink to web chat
+1. **Web Push** — PWA push notifications to phones and desktops (no native app required). Normal web-chat completions are sent only to the Clerk user who submitted the request. HITL approvals and trigger alerts remain team-wide.
+2. **SMS to shared team number** — persistent record in the team's OpenPhone thread with a deeplink to web chat for trigger alerts
+
+Normal response notifications use a generic body (`Your response is ready.`) rather than response text so sensitive content is not exposed in lock-screen previews. If the requesting user has no active subscription, delivery is skipped; targeted notifications never fall back to broadcasting to all Sernia users.
 
 ## Protocol
 
@@ -40,7 +42,7 @@ sequenceDiagram
     Browser->>Backend: POST /push/subscribe
     Backend->>Backend: Save to web_push_subscriptions
 
-    Note over Backend,OP: Notification Delivery (parallel)
+    Note over Backend,OP: Trigger Notification Delivery (parallel)
     Backend->>Backend: Trigger creates conversation
 
     par Web Push
@@ -54,6 +56,8 @@ sequenceDiagram
 
     Browser->>Browser: Click notification → /sernia-chat?id={conv_id}
 ```
+
+For a normal web-chat completion (including the follow-up after an approval decision), the route persists the completed run and sends Web Push only to the requesting user's subscriptions. The payload has `data.type = "response"`; the service worker uses that type to suppress the OS notification when the matching conversation is already focused.
 
 ## SMS Team Notifications
 
@@ -124,9 +128,9 @@ Output is in `.env`-ready format — copy directly into local `.env` and Railway
 | File | Purpose |
 |------|---------|
 | `models.py` | `WebPushSubscription` SQLAlchemy model — stores browser push endpoints |
-| `service.py` | Subscription CRUD + push sending via `pywebpush` + SMS team notifications |
+| `service.py` | Subscription CRUD + targeted response push, team-wide alert push, and SMS notifications |
 | `routes.py` | 3 endpoints: `GET /push/vapid-public-key`, `POST /push/subscribe`, `POST /push/unsubscribe` |
-| `apps/web-react-router/public/sw.js` | Service worker — handles `push` + `notificationclick` events only (no caching) |
+| `apps/web-react-router/public/sw.js` | Service worker — handles focus-aware push display and notification deeplinks (no caching) |
 | `apps/web-react-router/public/manifest.json` | PWA manifest — enables "Add to Home Screen" on mobile |
 | `apps/web-react-router/app/hooks/use-push-notifications.ts` | React hook for SW registration, permission, subscribe/unsubscribe |
 

--- a/api/src/sernia_ai/push/service.py
+++ b/api/src/sernia_ai/push/service.py
@@ -1,4 +1,4 @@
-"""Web Push + SMS notification service for Sernia AI HITL approvals."""
+"""Web Push + SMS notification service for Sernia AI."""
 
 import asyncio
 import json
@@ -217,11 +217,10 @@ async def notify_user_push(
 
         if not subs:
             logfire.info(
-                "web push: no subscriptions for targeted user — falling back to all users",
+                "web push: no subscriptions for targeted user — skipping",
                 clerk_user_id=clerk_user_id,
                 title=title,
             )
-            await notify_all_sernia_users(title=title, body=body, data=data)
             return
 
         logfire.info(
@@ -261,6 +260,45 @@ async def notify_user_push(
             )
             await session.commit()
             logfire.info("cleaned up expired web push subs", count=len(expired_endpoints))
+
+
+async def notify_chat_response(
+    conversation_id: str,
+    clerk_user_id: str,
+) -> None:
+    """Notify only the user who requested a completed web-chat response.
+
+    The notification intentionally contains no response text because OS-level
+    notification previews can be visible on a locked or shared device.
+    ``notify_user_push`` does not broadcast when the user has no subscription.
+    """
+    if not conversation_id or not clerk_user_id:
+        logfire.warn(
+            "notify_chat_response called without conversation or user — skipping",
+            conversation_id=conversation_id,
+            clerk_user_id=clerk_user_id,
+        )
+        return
+
+    data = {
+        "url": f"/sernia-chat?id={conversation_id}",
+        "conversation_id": conversation_id,
+        "type": "response",
+    }
+
+    try:
+        await notify_user_push(
+            clerk_user_id=clerk_user_id,
+            title="Sernia AI",
+            body="Your response is ready.",
+            data=data,
+        )
+    except Exception:
+        logfire.exception(
+            "notify_chat_response failed",
+            conversation_id=conversation_id,
+            clerk_user_id=clerk_user_id,
+        )
 
 
 async def notify_pending_approval(

--- a/api/src/sernia_ai/routes.py
+++ b/api/src/sernia_ai/routes.py
@@ -55,7 +55,7 @@ from api.src.sernia_ai.model_config import (
 )
 from api.src.sernia_ai.models import _IS_PRODUCTION, AppSetting
 from api.src.sernia_ai.push.routes import router as push_router
-from api.src.sernia_ai.push.service import notify_pending_approval
+from api.src.sernia_ai.push.service import notify_chat_response, notify_pending_approval
 from api.src.sernia_ai.tools._logging import create_logged_task
 from api.src.sernia_ai.triggers.ai_sms_event_trigger import (
     _fetch_sms_thread,
@@ -267,7 +267,7 @@ async def chat_sernia(
     )
 
     async def _on_complete(result):
-        await persist_agent_run_result(
+        persisted = await persist_agent_run_result(
             result,
             conversation_id=conversation_id,
             agent_name=AGENT_NAME,
@@ -275,7 +275,18 @@ async def chat_sernia(
         )
         create_logged_task(commit_and_push(WORKSPACE_PATH), name="git_sync")
 
-        # Send push notification if there are pending approvals
+        if not persisted:
+            logfire.warn(
+                "chat push skipped because persistence was not confirmed",
+                conversation_id=conversation_id,
+                clerk_user_id=clerk_user_id,
+            )
+            return
+
+        # Pending approvals remain team-wide operational alerts. Normal chat
+        # completions notify only the Clerk user who submitted the request; the
+        # service worker suppresses response notifications while that chat is
+        # focused.
         pending = extract_pending_approvals(result)
         if pending:
             first = pending[0]
@@ -286,6 +297,14 @@ async def chat_sernia(
                     tool_args=first.get("args"),
                 ),
                 name="notify_pending_approval",
+            )
+        elif isinstance(result.output, str) and result.output.strip():
+            create_logged_task(
+                notify_chat_response(
+                    conversation_id=conversation_id,
+                    clerk_user_id=clerk_user_id,
+                ),
+                name="notify_chat_response",
             )
 
     on_complete = _on_complete
@@ -444,7 +463,7 @@ async def approve_conversation(
 
         # Persist the approval result (tool outputs + agent follow-up) to DB
         # so that subsequent messages have the full conversation history.
-        await persist_agent_run_result(
+        persisted = await persist_agent_run_result(
             result,
             conversation_id=conversation_id,
             agent_name=AGENT_NAME,
@@ -472,6 +491,31 @@ async def approve_conversation(
 
         pending = extract_pending_approvals(result)
         tool_results = extract_tool_results(result)
+
+        if not persisted:
+            logfire.warn(
+                "approval push skipped because persistence was not confirmed",
+                conversation_id=conversation_id,
+                clerk_user_id=clerk_user_id,
+            )
+        elif pending:
+            first = pending[0]
+            create_logged_task(
+                notify_pending_approval(
+                    conversation_id=conversation_id,
+                    tool_name=first["tool_name"],
+                    tool_args=first.get("args"),
+                ),
+                name="notify_pending_approval",
+            )
+        elif isinstance(result.output, str) and result.output.strip():
+            create_logged_task(
+                notify_chat_response(
+                    conversation_id=conversation_id,
+                    clerk_user_id=clerk_user_id,
+                ),
+                name="notify_chat_response",
+            )
 
         return {
             "conversation_id": conversation_id,

--- a/api/src/tests/test_web_push.py
+++ b/api/src/tests/test_web_push.py
@@ -5,6 +5,9 @@ Smoke: Verifies model, service, and routes import cleanly and are wired correctl
 Live:  Sends a real push notification to all subscribed devices (requires VAPID keys + DB).
 """
 
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 
@@ -19,6 +22,7 @@ class TestSmoke:
     def test_service_functions_import(self):
         from api.src.sernia_ai.push.service import (
             notify_all_sernia_users,
+            notify_chat_response,
             notify_pending_approval,
             remove_subscription,
             save_subscription,
@@ -27,6 +31,7 @@ class TestSmoke:
         assert callable(save_subscription)
         assert callable(remove_subscription)
         assert callable(notify_all_sernia_users)
+        assert callable(notify_chat_response)
         assert callable(notify_pending_approval)
 
     def test_routes_have_expected_paths(self):
@@ -56,6 +61,290 @@ class TestSmoke:
         assert "/push/test" in paths
 
 
+@pytest.mark.asyncio
+async def test_chat_response_notification_is_private_and_user_targeted(monkeypatch):
+    from api.src.sernia_ai.push import service
+
+    notify_user = AsyncMock()
+    monkeypatch.setattr(service, "notify_user_push", notify_user)
+
+    await service.notify_chat_response(
+        conversation_id="conversation-123",
+        clerk_user_id="user-456",
+    )
+
+    notify_user.assert_awaited_once_with(
+        clerk_user_id="user-456",
+        title="Sernia AI",
+        body="Your response is ready.",
+        data={
+            "url": "/sernia-chat?id=conversation-123",
+            "conversation_id": "conversation-123",
+            "type": "response",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_targeted_push_does_not_broadcast_without_user_subscription(monkeypatch):
+    from api.src.sernia_ai.push import service
+
+    query_result = MagicMock()
+    query_result.scalars.return_value.all.return_value = []
+    session = AsyncMock()
+    session.execute.return_value = query_result
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    notify_all = AsyncMock()
+    monkeypatch.setattr(service, "_get_vapid", lambda: object())
+    monkeypatch.setattr(service, "AsyncSessionFactory", FakeSessionContext)
+    monkeypatch.setattr(service, "notify_all_sernia_users", notify_all)
+
+    await service.notify_user_push(
+        clerk_user_id="user-without-subscription",
+        title="Sernia AI",
+        body="Your response is ready.",
+        data={"type": "response"},
+    )
+
+    session.execute.assert_awaited_once()
+    notify_all.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_agent_run_result_reports_commit_status(monkeypatch):
+    from api.src.ai_demos import models
+
+    session = MagicMock()
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    result = MagicMock()
+    result.all_messages.return_value = []
+    result.usage.return_value = MagicMock(
+        total_tokens=0,
+        input_tokens=0,
+        output_tokens=0,
+    )
+    save_conversation = AsyncMock()
+    monkeypatch.setattr(models, "provide_session", FakeSessionContext)
+    monkeypatch.setattr(models, "save_agent_conversation", save_conversation)
+
+    persisted = await models.persist_agent_run_result(
+        result=result,
+        conversation_id="conversation-123",
+        agent_name="test-agent",
+        clerk_user_id="user-456",
+    )
+
+    assert persisted is True
+    save_conversation.assert_awaited_once()
+
+    save_conversation.reset_mock(side_effect=True)
+    save_conversation.side_effect = RuntimeError("database unavailable")
+
+    persisted = await models.persist_agent_run_result(
+        result=result,
+        conversation_id="conversation-123",
+        agent_name="test-agent",
+        clerk_user_id="user-456",
+    )
+
+    assert persisted is False
+
+
+@pytest.mark.asyncio
+async def test_cancelled_chat_waits_for_commit_then_schedules_response_push(monkeypatch):
+    from api.src.ai_demos import models
+    from api.src.sernia_ai import routes
+
+    save_started = asyncio.Event()
+    allow_save_to_finish = asyncio.Event()
+    session = MagicMock()
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    result = MagicMock()
+    result.output = "Completed response"
+    result.all_messages.return_value = []
+    result.usage.return_value = MagicMock(
+        total_tokens=0,
+        input_tokens=0,
+        output_tokens=0,
+    )
+
+    async def delayed_successful_save(**kwargs):
+        save_started.set()
+        await allow_save_to_finish.wait()
+
+    monkeypatch.setattr(models, "provide_session", FakeSessionContext)
+    monkeypatch.setattr(models, "save_agent_conversation", delayed_successful_save)
+
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "id": "conversation-123",
+            "messages": [{"role": "user", "parts": [{"type": "text", "text": "Hi"}]}],
+        }
+    )
+    user = MagicMock()
+    user.id = "user-456"
+    user.first_name = "Test"
+    user.last_name = "User"
+    user.email_addresses = []
+    scheduled_tasks: list[str | None] = []
+
+    def capture_task(coro, *, name=None):
+        scheduled_tasks.append(name)
+        coro.close()
+        return MagicMock()
+
+    async def dispatch_after_persistence(_request, **kwargs):
+        await kwargs["on_complete"](result)
+        return routes.Response(content="")
+
+    monkeypatch.setattr(routes, "get_conversation_messages", AsyncMock(return_value=[]))
+    monkeypatch.setattr(routes, "resolve_active_run_kwargs", AsyncMock(return_value={}))
+    monkeypatch.setattr(routes, "extract_pending_approvals", MagicMock(return_value=[]))
+    monkeypatch.setattr(routes, "create_logged_task", capture_task)
+    monkeypatch.setattr(routes.VercelAIAdapter, "dispatch_request", dispatch_after_persistence)
+
+    chat_request = asyncio.create_task(
+        routes.chat_sernia(
+            request=request,
+            user=user,
+            session=MagicMock(),
+        )
+    )
+    await save_started.wait()
+
+    chat_request.cancel()
+    allow_save_to_finish.set()
+
+    response = await chat_request
+
+    assert response.status_code == 200
+    assert scheduled_tasks == ["git_sync", "notify_chat_response"]
+
+
+@pytest.mark.asyncio
+async def test_chat_route_skips_push_when_persistence_fails(monkeypatch):
+    from api.src.sernia_ai import routes
+
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "id": "conversation-123",
+            "messages": [{"role": "user", "parts": [{"type": "text", "text": "Hi"}]}],
+        }
+    )
+    user = MagicMock()
+    user.id = "user-456"
+    user.first_name = "Test"
+    user.last_name = "User"
+    user.email_addresses = []
+
+    result = MagicMock()
+    result.output = "Completed response"
+    scheduled_tasks: list[str | None] = []
+
+    def capture_task(coro, *, name=None):
+        scheduled_tasks.append(name)
+        coro.close()
+        return MagicMock()
+
+    async def dispatch_with_failed_persistence(_request, **kwargs):
+        await kwargs["on_complete"](result)
+        return routes.Response(content="")
+
+    monkeypatch.setattr(routes, "get_conversation_messages", AsyncMock(return_value=[]))
+    monkeypatch.setattr(routes, "persist_agent_run_result", AsyncMock(return_value=False))
+    monkeypatch.setattr(routes, "resolve_active_run_kwargs", AsyncMock(return_value={}))
+    monkeypatch.setattr(routes, "create_logged_task", capture_task)
+    monkeypatch.setattr(
+        routes.VercelAIAdapter, "dispatch_request", dispatch_with_failed_persistence
+    )
+
+    response = await routes.chat_sernia(request=request, user=user, session=MagicMock())
+
+    assert response.status_code == 200
+    assert scheduled_tasks == ["git_sync"]
+
+
+@pytest.mark.asyncio
+async def test_approval_route_skips_push_when_persistence_fails(monkeypatch):
+    from api.src.sernia_ai import routes
+
+    body = routes.ApprovalRequest(
+        decisions=[
+            routes.ApprovalDecisionRequest(
+                tool_call_id="tool-123",
+                approved=True,
+            )
+        ]
+    )
+    user = MagicMock()
+    user.id = "user-456"
+    user.first_name = "Test"
+    user.last_name = "User"
+    user.email_addresses = []
+
+    result = MagicMock()
+    result.output = "Approval follow-up"
+    scheduled_tasks: list[str | None] = []
+
+    class FakeCaptureContext:
+        def __enter__(self):
+            return []
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def capture_task(coro, *, name=None):
+        scheduled_tasks.append(name)
+        coro.close()
+        return MagicMock()
+
+    monkeypatch.setattr(routes, "capture_run_messages", FakeCaptureContext)
+    monkeypatch.setattr(routes, "resume_with_approvals", AsyncMock(return_value=result))
+    monkeypatch.setattr(routes, "persist_agent_run_result", AsyncMock(return_value=False))
+    monkeypatch.setattr(routes, "resolve_active_run_kwargs", AsyncMock(return_value={}))
+    monkeypatch.setattr(routes, "get_agent_conversation", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        routes,
+        "extract_pending_approvals",
+        MagicMock(return_value=[{"tool_name": "send_email", "args": {}}]),
+    )
+    monkeypatch.setattr(routes, "extract_tool_results", MagicMock(return_value={}))
+    monkeypatch.setattr(routes, "create_logged_task", capture_task)
+
+    response = await routes.approve_conversation(
+        conversation_id="conversation-123",
+        body=body,
+        user=user,
+        session=MagicMock(),
+    )
+
+    assert response["status"] == "pending_approval"
+    assert scheduled_tasks == ["git_sync"]
+
+
 @pytest.mark.live
 @pytest.mark.asyncio
 async def test_send_push_notification():
@@ -68,9 +357,9 @@ async def test_send_push_notification():
 
     from api.src.database.database import AsyncSessionFactory
     from api.src.sernia_ai.push.models import WebPushSubscription
-    from api.src.sernia_ai.push.service import _vapid, notify_all_sernia_users
+    from api.src.sernia_ai.push.service import _get_vapid, notify_all_sernia_users
 
-    assert _vapid, "VAPID_PRIVATE_KEY not set or failed to load — add to .env"
+    assert _get_vapid(), "VAPID_PRIVATE_KEY not set or failed to load — add to .env"
 
     async with AsyncSessionFactory() as session:
         count = await session.scalar(select(func.count()).select_from(WebPushSubscription))

--- a/apps/web-react-router/app/app.css
+++ b/apps/web-react-router/app/app.css
@@ -418,19 +418,20 @@ body {
   height: calc(var(--chat-vh, 100dvh) - var(--env-banner-h, 0px));
 }
 
-@keyframes typing-dot {
-  0%, 60%, 100% {
-    transform: translateY(0);
-    opacity: 0.4;
-  }
-  30% {
-    transform: translateY(-4px);
-    opacity: 1;
+@keyframes sernia-thinking-orbit {
+  to {
+    transform: rotate(360deg);
   }
 }
 
-.animate-typing-dot {
-  animation: typing-dot 1.2s ease-in-out infinite;
+.animate-sernia-thinking-orbit {
+  animation: sernia-thinking-orbit 1.4s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-sernia-thinking-orbit {
+    animation: none;
+  }
 }
 
 .skeleton {

--- a/apps/web-react-router/app/components/chat/tool-cards.tsx
+++ b/apps/web-react-router/app/components/chat/tool-cards.tsx
@@ -138,6 +138,7 @@ export function ToolApprovalCard({
   allPending,
   conversationId,
   onApprovalComplete,
+  onProcessingChange,
   isProcessing,
   getToken,
   apiBase,
@@ -146,6 +147,7 @@ export function ToolApprovalCard({
   allPending?: PendingApproval[];
   conversationId: string;
   onApprovalComplete: (result: any) => void;
+  onProcessingChange?: (processing: boolean) => void;
   isProcessing: boolean;
   getToken: () => Promise<string | null>;
   apiBase: string;
@@ -186,6 +188,7 @@ export function ToolApprovalCard({
     if (!allDecided) return;
 
     setProcessing(true);
+    onProcessingChange?.(true);
     try {
       const decisionList: ApprovalDecisionPayload[] = pendingList.map((p) => {
         const d = decisions[p.toolCallId];
@@ -215,6 +218,7 @@ export function ToolApprovalCard({
       alert(err instanceof Error ? err.message : "Failed to process approval");
     } finally {
       setProcessing(false);
+      onProcessingChange?.(false);
     }
   };
 

--- a/apps/web-react-router/app/hooks/use-push-notifications.ts
+++ b/apps/web-react-router/app/hooks/use-push-notifications.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "@clerk/react-router";
 
 const API_BASE = "/api/sernia-ai";
+const PUSH_USER_STORAGE_KEY = "sernia-push-user-id";
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
@@ -37,15 +38,32 @@ interface PushNotificationState {
 }
 
 export function usePushNotifications(): PushNotificationState {
-  const { getToken } = useAuth();
+  const { getToken, isSignedIn, userId } = useAuth();
   const [isSupported, setIsSupported] = useState(false);
-  const [permission, setPermission] = useState<NotificationPermission | "unsupported">("unsupported");
+  const [permission, setPermission] = useState<
+    NotificationPermission | "unsupported"
+  >("unsupported");
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [needsInstall, setNeedsInstall] = useState(false);
-  const [iosBrowser, setIosBrowser] = useState<"safari" | "chrome" | null>(null);
+  const [iosBrowser, setIosBrowser] = useState<"safari" | "chrome" | null>(
+    null,
+  );
   const [canInstall, setCanInstall] = useState(false);
   const deferredInstallPrompt = useRef<BeforeInstallPromptEvent | null>(null);
+  // Clerk can transition directly between identities. Serialize subscription
+  // ownership updates so an older user's request cannot finish last and take
+  // the endpoint back from the current user.
+  const identitySyncQueue = useRef<Promise<void>>(Promise.resolve());
+  const enqueuePushOperation = useCallback((operation: () => Promise<void>) => {
+    const task = identitySyncQueue.current
+      .catch(() => undefined)
+      .then(operation);
+    // Keep the queue usable after an individual network failure while still
+    // returning that failure to the caller that owns the UI state.
+    identitySyncQueue.current = task.catch(() => undefined);
+    return task;
+  }, []);
 
   // Capture the beforeinstallprompt event (Android Chrome / desktop Chrome)
   useEffect(() => {
@@ -61,7 +79,8 @@ export function usePushNotifications(): PushNotificationState {
     return () => window.removeEventListener("beforeinstallprompt", handler);
   }, []);
 
-  // Check support and current state on mount
+  // Check platform support on mount. Subscription ownership is reconciled in
+  // the identity-aware effect below rather than inferred from browser state.
   useEffect(() => {
     if (typeof window === "undefined") return;
 
@@ -74,7 +93,8 @@ export function usePushNotifications(): PushNotificationState {
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
     const isStandalone =
       window.matchMedia("(display-mode: standalone)").matches ||
-      ("standalone" in navigator && (navigator as { standalone?: boolean }).standalone === true);
+      ("standalone" in navigator &&
+        (navigator as { standalone?: boolean }).standalone === true);
 
     if (isIOS && !isStandalone) {
       setNeedsInstall(true);
@@ -84,55 +104,54 @@ export function usePushNotifications(): PushNotificationState {
     }
 
     setPermission(Notification.permission);
-
-    // Check if already subscribed
-    navigator.serviceWorker.ready.then((registration) => {
-      registration.pushManager.getSubscription().then((sub) => {
-        setIsSubscribed(sub !== null);
-      });
-    });
   }, []);
 
-  const subscribe = useCallback(async () => {
-    if (!isSupported || isLoading) return;
+  // A PushSubscription belongs to the signed-in Clerk identity, not merely to
+  // the browser profile. Re-assert that mapping on mount/account changes and
+  // invalidate it locally on logout. Unknown or mismatched legacy ownership is
+  // rotated instead of risking delivery of another user's private alerts.
+  useEffect(() => {
+    if (!isSupported || needsInstall) return;
+
+    let cancelled = false;
     setIsLoading(true);
+    const updateSubscribed = (value: boolean) => {
+      if (!cancelled) setIsSubscribed(value);
+    };
 
-    try {
-      // Register service worker
-      const registration = await navigator.serviceWorker.register("/sw.js");
-      await navigator.serviceWorker.ready;
+    const reconcileIdentity = async () => {
+      const registration = await navigator.serviceWorker.getRegistration();
+      let subscription =
+        (await registration?.pushManager.getSubscription()) ?? null;
+      const boundUserId = localStorage.getItem(PUSH_USER_STORAGE_KEY);
 
-      // Request notification permission
-      const perm = await Notification.requestPermission();
-      setPermission(perm);
-      if (perm !== "granted") {
-        setIsLoading(false);
+      if (!isSignedIn || !userId) {
+        if (subscription) await subscription.unsubscribe();
+        localStorage.removeItem(PUSH_USER_STORAGE_KEY);
+        updateSubscribed(false);
         return;
       }
 
-      // Fetch VAPID public key
+      if (!registration || Notification.permission !== "granted") {
+        updateSubscribed(false);
+        return;
+      }
+
+      if (subscription && boundUserId !== userId) {
+        await subscription.unsubscribe();
+        subscription = null;
+        localStorage.removeItem(PUSH_USER_STORAGE_KEY);
+      }
+
+      if (!subscription) {
+        updateSubscribed(false);
+        return;
+      }
+
       const token = await getToken();
-      const vapidRes = await fetch(`${API_BASE}/push/vapid-public-key`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const { publicKey } = await vapidRes.json();
-
-      if (!publicKey) {
-        console.error("VAPID public key not configured on server");
-        setIsLoading(false);
-        return;
-      }
-
-      // Subscribe to push
-      const subscription = await registration.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(publicKey).buffer as ArrayBuffer,
-      });
-
+      if (!token) throw new Error("Not signed in");
       const subJson = subscription.toJSON();
-
-      // Send subscription to backend
-      await fetch(`${API_BASE}/push/subscribe`, {
+      const saveRes = await fetch(`${API_BASE}/push/subscribe`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -144,48 +163,173 @@ export function usePushNotifications(): PushNotificationState {
           auth: subJson.keys?.auth,
         }),
       });
+      if (!saveRes.ok) {
+        throw new Error(
+          `Failed to reconcile notification subscription (${saveRes.status})`,
+        );
+      }
 
-      setIsSubscribed(true);
+      localStorage.setItem(PUSH_USER_STORAGE_KEY, userId);
+      updateSubscribed(true);
+    };
+
+    const task = enqueuePushOperation(reconcileIdentity);
+    void task
+      .catch((err) => {
+        console.error("Push identity sync error:", err);
+        updateSubscribed(false);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    enqueuePushOperation,
+    getToken,
+    isSignedIn,
+    isSupported,
+    needsInstall,
+    userId,
+  ]);
+
+  const subscribe = useCallback(async () => {
+    if (!isSupported || isLoading || !isSignedIn || !userId) return;
+    setIsLoading(true);
+
+    try {
+      await enqueuePushOperation(async () => {
+        // Register service worker
+        const registration = await navigator.serviceWorker.register("/sw.js");
+        await navigator.serviceWorker.ready;
+
+        // Request notification permission
+        const perm = await Notification.requestPermission();
+        setPermission(perm);
+        if (perm !== "granted") return;
+
+        // Fetch VAPID public key
+        const token = await getToken();
+        if (!token) throw new Error("Not signed in");
+        const vapidRes = await fetch(`${API_BASE}/push/vapid-public-key`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!vapidRes.ok) {
+          throw new Error(
+            `Failed to load notification key (${vapidRes.status})`,
+          );
+        }
+        const { publicKey } = await vapidRes.json();
+
+        if (!publicKey) {
+          throw new Error("VAPID public key not configured on server");
+        }
+
+        // Subscribe to push
+        let subscription = await registration.pushManager.getSubscription();
+        if (
+          subscription &&
+          localStorage.getItem(PUSH_USER_STORAGE_KEY) !== userId
+        ) {
+          await subscription.unsubscribe();
+          subscription = null;
+          localStorage.removeItem(PUSH_USER_STORAGE_KEY);
+        }
+        subscription =
+          subscription ||
+          (await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(publicKey)
+              .buffer as ArrayBuffer,
+          }));
+
+        const subJson = subscription.toJSON();
+
+        // Send subscription to backend
+        const saveRes = await fetch(`${API_BASE}/push/subscribe`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            endpoint: subJson.endpoint,
+            p256dh: subJson.keys?.p256dh,
+            auth: subJson.keys?.auth,
+          }),
+        });
+        if (!saveRes.ok) {
+          await subscription.unsubscribe();
+          localStorage.removeItem(PUSH_USER_STORAGE_KEY);
+          throw new Error(
+            `Failed to save notification subscription (${saveRes.status})`,
+          );
+        }
+
+        localStorage.setItem(PUSH_USER_STORAGE_KEY, userId);
+        setIsSubscribed(true);
+      });
     } catch (err) {
       console.error("Push subscribe error:", err);
     } finally {
       setIsLoading(false);
     }
-  }, [isSupported, isLoading, getToken]);
+  }, [
+    enqueuePushOperation,
+    getToken,
+    isLoading,
+    isSignedIn,
+    isSupported,
+    userId,
+  ]);
 
   const unsubscribe = useCallback(async () => {
     if (!isSupported || isLoading) return;
     setIsLoading(true);
 
     try {
-      const registration = await navigator.serviceWorker.ready;
-      const subscription = await registration.pushManager.getSubscription();
+      await enqueuePushOperation(async () => {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
 
-      if (subscription) {
-        const endpoint = subscription.endpoint;
+        if (subscription) {
+          const endpoint = subscription.endpoint;
 
-        // Unsubscribe from browser push
-        await subscription.unsubscribe();
+          // Unsubscribe from browser push before contacting the backend so a
+          // failed cleanup request still cannot deliver to this browser.
+          await subscription.unsubscribe();
+          localStorage.removeItem(PUSH_USER_STORAGE_KEY);
+          setIsSubscribed(false);
 
-        // Notify backend
-        const token = await getToken();
-        await fetch(`${API_BASE}/push/unsubscribe`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ endpoint }),
-        });
-      }
+          // Notify backend
+          const token = await getToken();
+          if (!token) return;
+          const removeRes = await fetch(`${API_BASE}/push/unsubscribe`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ endpoint }),
+          });
+          if (!removeRes.ok) {
+            throw new Error(
+              `Failed to remove notification subscription (${removeRes.status})`,
+            );
+          }
+        }
 
-      setIsSubscribed(false);
+        localStorage.removeItem(PUSH_USER_STORAGE_KEY);
+        setIsSubscribed(false);
+      });
     } catch (err) {
       console.error("Push unsubscribe error:", err);
     } finally {
       setIsLoading(false);
     }
-  }, [isSupported, isLoading, getToken]);
+  }, [enqueuePushOperation, getToken, isLoading, isSupported]);
 
   const promptInstall = useCallback(async () => {
     if (!deferredInstallPrompt.current) return;

--- a/apps/web-react-router/app/lib/sernia-chat-recovery.test.ts
+++ b/apps/web-react-router/app/lib/sernia-chat-recovery.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  serverHasResponseForRequest,
+  userMessageFingerprint,
+} from "./sernia-chat-recovery.ts";
+
+const userMessage = (text: string) => ({
+  role: "user",
+  parts: [{ type: "text", text }],
+});
+
+const assistantMessage = (text: string) => ({
+  role: "assistant",
+  parts: [{ type: "text", text }],
+});
+
+test("fingerprints do not retain raw prompt content", async () => {
+  const fingerprint = await userMessageFingerprint(
+    userMessage("private tenant details"),
+  );
+
+  assert.equal(fingerprint.length, 64);
+  assert.equal(fingerprint.includes("private tenant details"), false);
+});
+
+test("rejects a stale snapshot that predates the submitted turn", async () => {
+  const marker = {
+    fingerprint: await userMessageFingerprint(userMessage("latest request")),
+    occurrence: 1,
+  };
+  const staleSnapshot = [
+    userMessage("older request"),
+    assistantMessage("older response"),
+  ];
+
+  assert.equal(await serverHasResponseForRequest(staleSnapshot, marker), false);
+});
+
+test("accepts the submitted turn only after an assistant response is persisted", async () => {
+  const submitted = userMessage("latest request");
+  const marker = {
+    fingerprint: await userMessageFingerprint(submitted),
+    occurrence: 1,
+  };
+
+  assert.equal(await serverHasResponseForRequest([submitted], marker), false);
+  assert.equal(
+    await serverHasResponseForRequest(
+      [submitted, assistantMessage("completed response")],
+      marker,
+    ),
+    true,
+  );
+});
+
+test("distinguishes repeated identical prompts by occurrence", async () => {
+  const repeated = userMessage("run it again");
+  const marker = {
+    fingerprint: await userMessageFingerprint(repeated),
+    occurrence: 2,
+  };
+
+  assert.equal(
+    await serverHasResponseForRequest(
+      [repeated, assistantMessage("first response"), repeated],
+      marker,
+    ),
+    false,
+  );
+  assert.equal(
+    await serverHasResponseForRequest(
+      [
+        repeated,
+        assistantMessage("first response"),
+        repeated,
+        assistantMessage("second response"),
+      ],
+      marker,
+    ),
+    true,
+  );
+});
+
+test("matches persisted attachments when the adapter drops the filename", async () => {
+  const submitted = {
+    role: "user",
+    parts: [
+      {
+        type: "file",
+        mediaType: "application/pdf",
+        filename: "private-lease.pdf",
+        url: "data:application/pdf;base64,submitted",
+      },
+    ],
+  };
+  const persisted = {
+    role: "user",
+    parts: [
+      {
+        type: "file",
+        mediaType: "application/pdf",
+        filename: null,
+        url: "data:application/pdf;base64,persisted",
+      },
+    ],
+  };
+  const marker = {
+    fingerprint: await userMessageFingerprint(submitted),
+    occurrence: 1,
+  };
+
+  assert.equal(
+    await serverHasResponseForRequest(
+      [persisted, assistantMessage("attachment reviewed")],
+      marker,
+    ),
+    true,
+  );
+});

--- a/apps/web-react-router/app/lib/sernia-chat-recovery.ts
+++ b/apps/web-react-router/app/lib/sernia-chat-recovery.ts
@@ -1,0 +1,61 @@
+export interface PendingRequestMarker {
+  fingerprint: string;
+  occurrence: number;
+  createdAt?: number;
+}
+
+// IDs are regenerated when messages are dumped from the DB. Match submitted
+// user turns by a digest of stable visible content instead. The digest keeps
+// raw prompts and filenames out of sessionStorage while remaining comparable
+// to the authoritative DB copy after a remount.
+export async function userMessageFingerprint(message: any): Promise<string> {
+  if (message?.role !== "user") return "";
+  const parts = Array.isArray(message.parts) ? message.parts : [];
+  const stableContent = parts
+    .map((part: any) => {
+      if (part.type === "text") return `text:${part.text ?? ""}`;
+      if (part.type === "file") {
+        // PydanticAI's Vercel adapter does not round-trip filenames when it
+        // dumps URL/BinaryContent parts back to UI messages. Media type is the
+        // stable field; occurrence ordering disambiguates repeated uploads.
+        return `file:${part.mediaType ?? ""}`;
+      }
+      return part.type ?? "unknown";
+    })
+    .join("\u0000");
+
+  const bytes = new TextEncoder().encode(stableContent);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+export async function serverHasResponseForRequest(
+  serverMessages: any[],
+  marker: PendingRequestMarker,
+): Promise<boolean> {
+  let occurrence = 0;
+  let submittedUserIndex = -1;
+
+  for (let index = 0; index < serverMessages.length; index += 1) {
+    if (
+      (await userMessageFingerprint(serverMessages[index])) !==
+      marker.fingerprint
+    ) {
+      continue;
+    }
+    occurrence += 1;
+    if (occurrence === marker.occurrence) {
+      submittedUserIndex = index;
+      break;
+    }
+  }
+
+  return (
+    submittedUserIndex >= 0 &&
+    serverMessages
+      .slice(submittedUserIndex + 1)
+      .some((message: any) => message.role === "assistant")
+  );
+}

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -14,14 +14,14 @@ import {
   useIsStandalonePwa,
 } from "~/hooks/use-pull-to-refresh";
 import { cn } from "~/lib/utils";
+import {
+  serverHasResponseForRequest,
+  userMessageFingerprint,
+  type PendingRequestMarker,
+} from "~/lib/sernia-chat-recovery";
 import { Markdown } from "~/components/markdown";
 import { AuthGuard } from "~/components/auth-guard";
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from "~/components/ui/tabs";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "~/components/ui/tabs";
 import {
   AlertCircle,
   Building,
@@ -53,13 +53,62 @@ import {
   FilePreviewStrip,
 } from "~/components/chat/file-attachment-area";
 import { FileMessageDisplay } from "~/components/chat/file-message-display";
-import { SidebarProvider, SidebarInset, useSidebar } from "~/components/ui/sidebar";
+import {
+  SidebarProvider,
+  SidebarInset,
+  useSidebar,
+} from "~/components/ui/sidebar";
 import {
   ConversationSidebar,
   prefetchConversations,
 } from "~/components/sernia/conversation-sidebar";
 
 const API_BASE = "/api/sernia-ai";
+const PENDING_REQUEST_STORAGE_PREFIX = "sernia-pending-request-";
+
+function pendingRequestStorageKey(conversationId: string): string {
+  return `${PENDING_REQUEST_STORAGE_PREFIX}${conversationId}`;
+}
+
+function clearPendingRequestMarkerStorage(conversationId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(pendingRequestStorageKey(conversationId));
+  } catch {
+    // In-memory recovery still works if storage is unavailable.
+  }
+}
+
+function readPendingRequestMarker(
+  conversationId: string,
+): PendingRequestMarker | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(
+      pendingRequestStorageKey(conversationId),
+    );
+    if (!raw) return null;
+    const marker = JSON.parse(raw);
+    if (
+      typeof marker?.fingerprint === "string" &&
+      Number.isInteger(marker?.occurrence) &&
+      marker.occurrence > 0
+    ) {
+      return {
+        fingerprint: marker.fingerprint,
+        occurrence: marker.occurrence,
+        createdAt:
+          typeof marker.createdAt === "number" &&
+          Number.isFinite(marker.createdAt)
+            ? marker.createdAt
+            : Date.now(),
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -88,35 +137,53 @@ const suggestedPrompts = [
 ];
 
 // ---------------------------------------------------------------------------
-// Typing indicator — shown while waiting on the backend's first response byte
+// Thinking state
 // ---------------------------------------------------------------------------
 
-function TypingIndicator() {
+function AssistantAvatar({ active = false }: { active?: boolean }) {
+  return (
+    <div className="relative w-8 h-8 shrink-0" aria-hidden="true">
+      {active && (
+        <span className="absolute -inset-1 animate-sernia-thinking-orbit">
+          <span className="absolute left-1/2 top-0 w-1.5 h-1.5 -translate-x-1/2 rounded-full bg-primary shadow-[0_0_0_3px_hsl(var(--background))]" />
+        </span>
+      )}
+    <div
+        className={cn(
+          "relative w-8 h-8 rounded-full bg-primary flex items-center justify-center",
+          active &&
+            "ring-1 ring-primary/25 ring-offset-2 ring-offset-background",
+        )}
+    >
+          <Building className="w-4 h-4 text-primary-foreground" />
+        </div>
+      </div>
+  );
+}
+
+function ThinkingBubble({
+  label = "Sernia AI is thinking",
+}: {
+  label?: string;
+}) {
+  return (
+    <div className="bg-muted/50 rounded-2xl px-4 py-2.5 shadow-sm text-sm text-muted-foreground">
+      {label}
+      <span aria-hidden="true">…</span>
+      </div>
+  );
+}
+
+function ThinkingIndicator({ label }: { label?: string }) {
   return (
     <div
       className="flex gap-3 justify-start"
       role="status"
-      aria-label="Sernia AI is typing"
+      aria-live="polite"
+      aria-atomic="true"
     >
-      <div className="shrink-0">
-        <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center">
-          <Building className="w-4 h-4 text-primary-foreground" />
-        </div>
-      </div>
-      <div className="bg-muted/50 rounded-2xl px-4 py-3 shadow-sm flex items-center gap-1.5">
-        <span
-          className="w-1.5 h-1.5 rounded-full bg-muted-foreground animate-typing-dot"
-          style={{ animationDelay: "0ms" }}
-        />
-        <span
-          className="w-1.5 h-1.5 rounded-full bg-muted-foreground animate-typing-dot"
-          style={{ animationDelay: "150ms" }}
-        />
-        <span
-          className="w-1.5 h-1.5 rounded-full bg-muted-foreground animate-typing-dot"
-          style={{ animationDelay: "300ms" }}
-        />
-      </div>
+      <AssistantAvatar active />
+      <ThinkingBubble label={label} />
     </div>
   );
 }
@@ -149,7 +216,7 @@ function messagesSignature(msgs: any[]): string {
             ? p.text
             : p.toolCallId
               ? `${p.toolCallId}:${p.state ?? ""}`
-              : p.type
+              : p.type,
         )
         .join("\u0000");
       return `${m.role}:${content}`;
@@ -168,6 +235,7 @@ function ChatView({
   initialAllPending,
   getToken,
   readOnly = false,
+  onMountedChange,
 }: {
   conversationId: string;
   initialMessages: any[];
@@ -175,15 +243,27 @@ function ChatView({
   initialAllPending?: PendingApproval[];
   getToken: () => Promise<string | null>;
   readOnly?: boolean;
+  onMountedChange?: (mounted: boolean) => void;
 }) {
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(initialPending);
-  const [allPendingApprovals, setAllPendingApprovals] =
-    useState<PendingApproval[]>(initialAllPending || (initialPending ? [initialPending] : []));
+  const [allPendingApprovals, setAllPendingApprovals] = useState<
+    PendingApproval[]
+  >(initialAllPending || (initialPending ? [initialPending] : []));
   const [isProcessingApproval, setIsProcessingApproval] = useState(false);
+  const [recoveryState, setRecoveryState] = useState<
+    "idle" | "checking" | "failed"
+  >("idle");
+  const [recoveryCycle, setRecoveryCycle] = useState(0);
+  const [isPreparingRequest, setIsPreparingRequest] = useState(false);
+  const [pendingRequestMarker, setPendingRequestMarker] =
+    useState<PendingRequestMarker | null>(() =>
+      readPendingRequestMarker(conversationId),
+    );
   const draftKey = `sernia-draft-${conversationId}`;
   const [input, setInput] = useState(
-    () => (typeof window !== "undefined" && sessionStorage.getItem(draftKey)) || ""
+    () =>
+      (typeof window !== "undefined" && sessionStorage.getItem(draftKey)) || "",
   );
   // Persist draft to sessionStorage so it survives component remounts
   useEffect(() => {
@@ -198,6 +278,12 @@ function ChatView({
   const [messagesContainerRef, messagesEndRef] =
     useScrollToBottom<HTMLDivElement>();
   const attachment = useFileAttachments();
+  const lastChatHttpStatusRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    onMountedChange?.(true);
+    return () => onMountedChange?.(false);
+  }, [onMountedChange]);
 
   // Track the actual height of the input bar so the messages list reserves
   // matching bottom padding. The input bar is position:fixed on mobile, so
@@ -207,10 +293,7 @@ function ChatView({
     if (!el || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver((entries) => {
       const h = entries[0]?.contentRect.height ?? 0;
-      document.documentElement.style.setProperty(
-        "--chat-input-h",
-        `${h}px`
-      );
+      document.documentElement.style.setProperty("--chat-input-h", `${h}px`);
     });
     observer.observe(el);
     return () => {
@@ -232,6 +315,15 @@ function ChatView({
   const transport = useRef(
     new DefaultChatTransport({
       api: `${API_BASE}/chat`,
+      fetch: async (input, init) => {
+        // A non-2xx response is a terminal server rejection, while a fetch
+        // failure or a broken 2xx stream may still finish and persist in the
+        // backend. Recovery polling is limited to the latter cases.
+        lastChatHttpStatusRef.current = null;
+        const response = await fetch(input, init);
+        lastChatHttpStatusRef.current = response.status;
+        return response;
+      },
       headers: async () => {
         const token = await getToken();
         return { Authorization: `Bearer ${token}` };
@@ -260,11 +352,18 @@ function ChatView({
           },
         };
       },
-    })
+    }),
   ).current;
 
-  const { messages, sendMessage, status, stop, setMessages, error, clearError } =
-    useChat({
+  const {
+    messages,
+    sendMessage,
+    status,
+    stop,
+    setMessages,
+    error,
+    clearError,
+  } = useChat({
       id: conversationId,
       messages: initialMessages,
       transport,
@@ -277,30 +376,151 @@ function ChatView({
   isProcessingApprovalRef.current = isProcessingApproval;
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
+  const authoritativeMessagesRef = useRef(initialMessages);
+  const pendingRequestRef = useRef<PendingRequestMarker | null>(
+    pendingRequestMarker,
+  );
+  const syncGenerationRef = useRef(0);
+  const syncAbortControllerRef = useRef<AbortController | null>(null);
+  const isPreparingRequestRef = useRef(false);
+
+  const invalidateServerSync = useCallback(() => {
+    syncGenerationRef.current += 1;
+    syncAbortControllerRef.current?.abort();
+    syncAbortControllerRef.current = null;
+  }, []);
+
+  const handleApprovalProcessingChange = useCallback(
+    (processing: boolean) => {
+      isProcessingApprovalRef.current = processing;
+      if (processing) invalidateServerSync();
+      setIsProcessingApproval(processing);
+    },
+    [invalidateServerSync],
+  );
+
+  const storePendingRequest = useCallback(
+    (marker: PendingRequestMarker | null) => {
+      pendingRequestRef.current = marker;
+      setPendingRequestMarker(marker);
+      if (marker) {
+        try {
+          sessionStorage.setItem(
+            pendingRequestStorageKey(conversationId),
+            JSON.stringify(marker),
+          );
+        } catch {
+          // Keep the in-memory marker if browser storage is unavailable.
+        }
+      } else {
+        clearPendingRequestMarkerStorage(conversationId);
+      }
+    },
+    [conversationId],
+  );
+
+  const rememberPendingRequest = useCallback(
+    async (parts: any[]) => {
+      invalidateServerSync();
+      isPreparingRequestRef.current = true;
+      setIsPreparingRequest(true);
+      try {
+        const fingerprint = await userMessageFingerprint({
+          role: "user",
+          parts,
+        });
+        let occurrence = 1;
+        for (const message of authoritativeMessagesRef.current) {
+          if ((await userMessageFingerprint(message)) === fingerprint) {
+            occurrence += 1;
+          }
+        }
+        storePendingRequest({
+          fingerprint,
+          occurrence,
+          createdAt: Date.now(),
+        });
+      } finally {
+        isPreparingRequestRef.current = false;
+        setIsPreparingRequest(false);
+      }
+    },
+    [invalidateServerSync, storePendingRequest],
+  );
+
+  const handleStop = useCallback(() => {
+    stop();
+  }, [stop]);
 
   // Re-sync the chat from the DB (the authoritative source). useChat only
   // reads its `messages` option at mount, so without this any response that
   // finishes after the stream dies client-side (mobile tab suspension,
   // network blip, provider error) stays invisible until a full page reload.
-  const syncFromServer = useCallback(async () => {
-    const busy = () =>
-      statusRef.current === "submitted" ||
-      statusRef.current === "streaming" ||
-      isProcessingApprovalRef.current;
-    if (busy()) return;
+  const syncFromServer = useCallback(
+    async (allowWhileActive = false) => {
+      const chatActive = () =>
+        statusRef.current === "submitted" || statusRef.current === "streaming";
+      const busy = () => chatActive() || isProcessingApprovalRef.current;
+      if (isProcessingApprovalRef.current || (!allowWhileActive && busy())) {
+        return false;
+      }
+      const generation = syncGenerationRef.current + 1;
+      syncGenerationRef.current = generation;
+      syncAbortControllerRef.current?.abort();
+      const controller = new AbortController();
+      syncAbortControllerRef.current = controller;
+      const pendingRequestAtStart = pendingRequestRef.current;
     try {
       const token = await getToken();
       const res = await fetch(
         `${API_BASE}/conversation/${conversationId}/messages`,
-        { headers: { Authorization: `Bearer ${token}` } }
+          {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: controller.signal,
+          },
       );
-      if (!res.ok) return;
+        if (!res.ok) return false;
       const data = await res.json();
       // Re-check after the awaits — the user may have hit send meanwhile.
-      if (busy()) return;
+        if (
+          controller.signal.aborted ||
+          generation !== syncGenerationRef.current ||
+          isProcessingApprovalRef.current ||
+          (!allowWhileActive && busy())
+        ) {
+          return false;
+        }
       const serverMessages: any[] = data.messages || [];
       // Empty server copy = nothing persisted yet; keep local state.
-      if (serverMessages.length === 0) return;
+        if (serverMessages.length === 0) return false;
+
+        // Never let an early recovery fetch replace the optimistic user turn
+        // with an older DB snapshot. Persistence happens only after the agent
+        // finishes, so wait until the exact submitted turn and a later assistant
+        // response are both present.
+        const pendingRequest =
+          pendingRequestRef.current ?? pendingRequestAtStart;
+        if (
+          pendingRequest &&
+          !(await serverHasResponseForRequest(serverMessages, pendingRequest))
+        ) {
+          return false;
+        }
+        // Digest comparison is asynchronous; a new request may have started
+        // while it was running even though the fetch itself had completed.
+        if (
+          controller.signal.aborted ||
+          generation !== syncGenerationRef.current ||
+          (pendingRequestAtStart !== null &&
+            pendingRequestRef.current !== pendingRequestAtStart)
+        ) {
+          return false;
+        }
+
+        if (allowWhileActive && chatActive()) {
+          stop();
+        }
+
       if (
         messagesSignature(serverMessages) !==
         messagesSignature(messagesRef.current)
@@ -310,17 +530,60 @@ function ChatView({
         setPendingApproval(allPending[0] ?? null);
         setAllPendingApprovals(allPending);
       }
+        authoritativeMessagesRef.current = serverMessages;
+        storePendingRequest(null);
+        if (statusRef.current === "error") {
+          clearError();
+        }
+        setRecoveryState("idle");
+        return true;
     } catch {
       // Network failure — keep whatever we have.
+        return false;
+      } finally {
+        if (syncAbortControllerRef.current === controller) {
+          syncAbortControllerRef.current = null;
+        }
     }
-  }, [conversationId, getToken, setMessages]);
+    },
+    [
+      clearError,
+      conversationId,
+      getToken,
+      setMessages,
+      stop,
+      storePendingRequest,
+    ],
+  );
 
-  // Sync when the tab regains visibility or the network comes back.
+  // A push completion signal can arrive in the narrow window before an
+  // approval request leaves its processing state. Reconcile once processing
+  // ends so that signal cannot be lost if the HTTP response itself broke.
+  const wasProcessingApprovalRef = useRef(false);
+  useEffect(() => {
+    const wasProcessing = wasProcessingApprovalRef.current;
+    wasProcessingApprovalRef.current = isProcessingApproval;
+    if (wasProcessing && !isProcessingApproval) {
+      void syncFromServer(true);
+    }
+  }, [isProcessingApproval, syncFromServer]);
+
+  useEffect(
+    () => () => {
+      syncGenerationRef.current += 1;
+      syncAbortControllerRef.current?.abort();
+    },
+    [],
+  );
+
+  // Sync when the tab regains visibility or the network comes back. Allow an
+  // authoritative completed response to replace a locally stuck stream — a
+  // suspended mobile tab can retain "submitted"/"streaming" indefinitely.
   useEffect(() => {
     const handleVisibility = () => {
-      if (document.visibilityState === "visible") syncFromServer();
+      if (document.visibilityState === "visible") syncFromServer(true);
     };
-    const handleOnline = () => syncFromServer();
+    const handleOnline = () => syncFromServer(true);
     document.addEventListener("visibilitychange", handleVisibility);
     window.addEventListener("online", handleOnline);
     return () => {
@@ -329,13 +592,114 @@ function ChatView({
     };
   }, [syncFromServer]);
 
-  // If the stream errors, the run may still have completed server-side (the
-  // backend persists via on_complete) — pull the authoritative copy.
+  // When this view is mounted, apply focused completion signals in place so
+  // attachments, drafts, scroll state, and the selected admin tab are kept.
   useEffect(() => {
-    if (status === "error") {
-      syncFromServer();
+    const handleServiceWorkerMessage = (event: MessageEvent) => {
+      const isCompletionSignal =
+        event.data?.type === "response-ready" ||
+        event.data?.type === "notification-click";
+      if (
+        isCompletionSignal &&
+        event.data.data?.conversation_id === conversationId
+      ) {
+        void syncFromServer(true);
+      }
+    };
+
+    navigator.serviceWorker?.addEventListener(
+      "message",
+      handleServiceWorkerMessage,
+    );
+    return () =>
+      navigator.serviceWorker?.removeEventListener(
+        "message",
+        handleServiceWorkerMessage,
+      );
+  }, [conversationId, syncFromServer]);
+
+  // Confirm every submitted turn against the authoritative DB copy. The
+  // marker survives remounts, so switching tabs/conversations or reloading
+  // cannot unlock a conversation while its backend run is still active.
+  useEffect(() => {
+    const isRecoverableInterruption =
+      lastChatHttpStatusRef.current === null ||
+      (lastChatHttpStatusRef.current >= 200 &&
+        lastChatHttpStatusRef.current < 300);
+
+    if (status === "submitted" || status === "streaming") {
+      setRecoveryState("idle");
+      return;
     }
-  }, [status, syncFromServer]);
+
+    if (status === "error" && !isRecoverableInterruption) {
+      // A non-2xx response means the server rejected the request before a run
+      // began, so there is no background work to protect from overlap.
+      storePendingRequest(null);
+      setRecoveryState("failed");
+      return;
+    }
+
+    if (status !== "ready" && status !== "error") {
+      setRecoveryState("idle");
+      return;
+    }
+
+    if (!pendingRequestMarker) {
+      setRecoveryState(status === "error" ? "failed" : "idle");
+      return;
+    }
+
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    // Long tool-heavy runs regularly take close to a minute. Keep checking
+    // for ~85 seconds before asking the user to intervene.
+    const retryDelays = [
+      0, 1000, 2000, 4000, 8000, 10000, 10000, 10000, 10000, 10000, 10000,
+      10000,
+    ];
+
+    const wait = (delay: number) =>
+      new Promise<void>((resolve) => {
+        retryTimer = setTimeout(resolve, delay);
+      });
+
+    const recover = async () => {
+      setRecoveryState("checking");
+
+      for (const delay of retryDelays) {
+        if (delay > 0) await wait(delay);
+        const currentStatus = statusRef.current;
+        if (
+          cancelled ||
+          pendingRequestRef.current === null ||
+          (currentStatus !== "ready" && currentStatus !== "error")
+        ) {
+          return;
+        }
+
+        const recovered = await syncFromServer();
+        if (recovered) {
+          return;
+        }
+    }
+
+      if (!cancelled) setRecoveryState("failed");
+    };
+
+    void recover();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [
+    pendingRequestMarker,
+    recoveryCycle,
+    status,
+    storePendingRequest,
+    syncFromServer,
+  ]);
 
   // Extract ALL pending approvals from latest assistant message
   // PydanticAI requires results for all deferred tool calls, so we need to track all of them
@@ -378,6 +742,23 @@ function ChatView({
     }
   }, [messages, status]);
 
+  const isRecoverableStreamError =
+    status === "error" &&
+    (lastChatHttpStatusRef.current === null ||
+      (lastChatHttpStatusRef.current >= 200 &&
+        lastChatHttpStatusRef.current < 300));
+  const canRecoverResponse =
+    pendingRequestMarker !== null || isRecoverableStreamError;
+  const isRecoveringResponse =
+    canRecoverResponse &&
+    (status === "ready" || status === "error") &&
+    recoveryState !== "failed";
+  // A recoverable disconnect means the backend may still be executing. Keep
+  // this conversation locked even after automatic polling pauses so a second
+  // run cannot race and overwrite the first run's persisted history. The user
+  // can keep checking or start a separate conversation from the header.
+  const hasUnresolvedResponse = canRecoverResponse || isPreparingRequest;
+
   // Auto-resize textarea
   useEffect(() => {
     if (textareaRef.current) {
@@ -388,7 +769,16 @@ function ChatView({
 
   const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();
-    if (status === "submitted" || status === "streaming" || isProcessingApproval) return;
+    if (
+      status === "submitted" ||
+      status === "streaming" ||
+      isProcessingApproval ||
+      hasUnresolvedResponse ||
+      pendingRequestRef.current !== null ||
+      isPreparingRequestRef.current
+    ) {
+      return;
+    }
 
     const text = input.trim();
     const hasContent = text || attachment.hasFiles;
@@ -403,7 +793,7 @@ function ChatView({
     // This also collapses the old two-round-trip flow (deny → wait → type
     // feedback) into one LLM call.
     if (allPendingApprovals.length > 0 && text) {
-      setIsProcessingApproval(true);
+      handleApprovalProcessingChange(true);
       // Render the user's message optimistically so the chat feels responsive.
       // On refresh, the same text will load from the DB as a UserPromptPart;
       // IDs differ but the visible bubble is identical so there is no dupe.
@@ -430,9 +820,11 @@ function ChatView({
       } catch (err) {
         console.error("Deny-with-feedback error:", err);
         alert(err instanceof Error ? err.message : "Failed to submit feedback");
-        setMessages((prev: any[]) => prev.filter((m) => m.id !== optimisticUserMsg.id));
+        setMessages((prev: any[]) =>
+          prev.filter((m) => m.id !== optimisticUserMsg.id),
+        );
       } finally {
-        setIsProcessingApproval(false);
+        handleApprovalProcessingChange(false);
       }
       return;
     }
@@ -450,15 +842,28 @@ function ChatView({
     }
     setPendingApproval(null);
     setAllPendingApprovals([]);
+    await rememberPendingRequest(parts);
     sendMessage({ role: "user", parts });
     setInput("");
     attachment.clearFiles();
   };
 
-  const handleSuggestedPrompt = (prompt: string) => {
+  const handleSuggestedPrompt = async (prompt: string) => {
+    if (
+      status === "submitted" ||
+      status === "streaming" ||
+      isProcessingApproval ||
+      hasUnresolvedResponse ||
+      pendingRequestRef.current !== null ||
+      isPreparingRequestRef.current
+    ) {
+      return;
+    }
+    const parts: any[] = [{ type: "text", text: prompt }];
     setPendingApproval(null);
     setAllPendingApprovals([]);
-    sendMessage({ role: "user", parts: [{ type: "text", text: prompt }] });
+    await rememberPendingRequest(parts);
+    sendMessage({ role: "user", parts });
   };
 
   const handleApprovalComplete = useCallback(
@@ -492,9 +897,13 @@ function ChatView({
 
       setMessages((prev: any[]) => {
         const updated = [...prev];
-        const lastAssistantIdx = updated.findLastIndex(
-          (m: any) => m.role === "assistant"
-        );
+        let lastAssistantIdx = -1;
+        for (let index = updated.length - 1; index >= 0; index -= 1) {
+          if (updated[index].role === "assistant") {
+            lastAssistantIdx = index;
+            break;
+          }
+        }
         if (lastAssistantIdx >= 0) {
           const lastMsg = updated[lastAssistantIdx];
           if (lastMsg.parts) {
@@ -516,7 +925,8 @@ function ChatView({
                   ...part,
                   state: wasApproved ? "output-available" : "output-denied",
                   output:
-                    realResult || (wasApproved ? "Completed" : "Denied by user"),
+                    realResult ||
+                    (wasApproved ? "Completed" : "Denied by user"),
                 };
               }
               return part;
@@ -539,6 +949,7 @@ function ChatView({
           });
         }
 
+        authoritativeMessagesRef.current = updated;
         return updated;
       });
 
@@ -551,14 +962,47 @@ function ChatView({
             toolCallId: p.toolCallId,
             toolName: p.type.replace("tool-", ""),
             args: p.input,
-          })
+          }),
         );
         setPendingApproval(asPendingApprovals[0]);
         setAllPendingApprovals(asPendingApprovals);
       }
     },
-    [setMessages]
+    [setMessages],
   );
+
+  const isAiThinking =
+    status === "submitted" ||
+    status === "streaming" ||
+    isPreparingRequest ||
+    isProcessingApproval ||
+    isRecoveringResponse;
+  const lastMessageIsAssistant =
+    messages[messages.length - 1]?.role === "assistant";
+  const lastAssistantHasVisibleContent =
+    lastMessageIsAssistant &&
+    processMessage(messages[messages.length - 1]).segments.length > 0;
+  const activityLabel = isRecoveringResponse
+    ? status === "ready"
+      ? "Confirming your response"
+      : "Reconnecting to your response"
+    : isProcessingApproval
+      ? "Sernia AI is completing the action"
+      : "Sernia AI is thinking";
+  const allowRetryAfterUnresolvedResponse = useCallback(() => {
+    const confirmed = window.confirm(
+      "The original request may still finish and may already have performed actions. Allow another request in this conversation anyway? Start a new conversation instead if you are unsure.",
+    );
+    if (!confirmed) return;
+
+    invalidateServerSync();
+    storePendingRequest(null);
+    if (statusRef.current === "error") clearError();
+    setRecoveryState("idle");
+  }, [clearError, invalidateServerSync, storePendingRequest]);
+  const showStreamError =
+    (status === "error" && !isRecoverableStreamError) ||
+    (canRecoverResponse && recoveryState === "failed");
 
   return (
     <>
@@ -580,7 +1024,7 @@ function ChatView({
               <RefreshCw
                 className={cn(
                   "w-4 h-4 text-muted-foreground",
-                  pullProgress >= 1 && "text-primary"
+                  pullProgress >= 1 && "text-primary",
                 )}
                 style={{ transform: `rotate(${pullProgress * 360}deg)` }}
               />
@@ -613,43 +1057,43 @@ function ChatView({
             {messages.map((message, index) => {
               const { segments } = processMessage(message);
               const isLastAssistant =
-                message.role === "assistant" &&
-                index === messages.length - 1;
+                message.role === "assistant" && index === messages.length - 1;
 
               return (
                 <div
                   key={message.id || index}
                   className={cn(
                     "flex gap-3",
-                    message.role === "user"
-                      ? "justify-end"
-                      : "justify-start"
+                    message.role === "user" ? "justify-end" : "justify-start",
                   )}
                 >
                   {message.role === "assistant" && (
-                    <div className="shrink-0">
-                      <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center">
-                        <Building className="w-4 h-4 text-primary-foreground" />
-                      </div>
-                    </div>
+                    <AssistantAvatar active={isLastAssistant && isAiThinking} />
                   )}
 
                   <div
                     className={cn(
                       "flex flex-col gap-2 max-w-[85%] min-w-0",
-                      message.role === "user" && "items-end"
+                      message.role === "user" && "items-end",
                     )}
                   >
                     {message.role === "user" ? (
                       <>
                         <FileMessageDisplay
-                          files={segments.filter((s) => s.type === "file") as any}
+                          files={
+                            segments.filter((s) => s.type === "file") as any
+                          }
                         />
                         {segments.some((s) => s.type === "text") && (
                           <div className="bg-primary text-primary-foreground rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden max-w-full">
                             <p className="text-sm whitespace-pre-wrap [overflow-wrap:anywhere]">
-                              {segments.find((s) => s.type === "text")?.type === "text"
-                                ? (segments.find((s) => s.type === "text") as any).content
+                              {segments.find((s) => s.type === "text")?.type ===
+                              "text"
+                                ? (
+                                    segments.find(
+                                      (s) => s.type === "text",
+                                    ) as any
+                                  ).content
                                 : ""}
                             </p>
                           </div>
@@ -659,7 +1103,10 @@ function ChatView({
                       <>
                         {segments.map((seg, i) =>
                           seg.type === "text" ? (
-                            <div key={i} className="bg-muted/50 rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0">
+                            <div
+                              key={i}
+                              className="bg-muted/50 rounded-2xl px-4 py-2.5 shadow-sm overflow-hidden min-w-0"
+                            >
                               <div className="text-sm prose prose-sm dark:prose-invert max-w-none [overflow-wrap:anywhere]">
                                 <Markdown>{seg.content}</Markdown>
                               </div>
@@ -676,7 +1123,19 @@ function ChatView({
                               }
                               denied={seg.denied}
                             />
-                          ) : null
+                          ) : null,
+                        )}
+
+                        {isLastAssistant &&
+                          isAiThinking &&
+                          (segments.length === 0 || isRecoveringResponse) && (
+                            <div
+                              role="status"
+                              aria-live="polite"
+                              aria-atomic="true"
+                            >
+                              <ThinkingBubble label={activityLabel} />
+                            </div>
                         )}
 
                         {isLastAssistant && pendingApproval && (
@@ -685,6 +1144,7 @@ function ChatView({
                             allPending={allPendingApprovals}
                             conversationId={conversationId}
                             onApprovalComplete={handleApprovalComplete}
+                            onProcessingChange={handleApprovalProcessingChange}
                             isProcessing={isProcessingApproval}
                             getToken={getToken}
                             apiBase={API_BASE}
@@ -704,40 +1164,67 @@ function ChatView({
                 </div>
               );
             })}
-            {(status === "submitted" ||
-              (status === "streaming" &&
-                messages[messages.length - 1]?.role !== "assistant")) && (
-              <TypingIndicator />
-            )}
-            {status === "error" && (
-              <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:bg-red-950/20 px-4 py-3 text-sm text-red-700 dark:text-red-400">
-                <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <p>{formatStreamError(error)}</p>
-                  <p className="text-xs opacity-80 mt-1">
-                    If the response finished in the background, reloading will
-                    show it.
-                  </p>
-                </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="shrink-0"
-                  onClick={() => {
-                    clearError();
-                    syncFromServer();
-                  }}
-                >
-                  Reload messages
-                </Button>
-              </div>
-            )}
-            <div
-              ref={messagesEndRef}
-              className="shrink-0 min-w-[24px] min-h-[24px]"
-            />
           </div>
         )}
+        <div className="mx-auto w-full max-w-3xl px-4 space-y-6">
+          {isAiThinking && !lastMessageIsAssistant && (
+            <ThinkingIndicator label={activityLabel} />
+          )}
+          {isAiThinking &&
+            lastMessageIsAssistant &&
+            lastAssistantHasVisibleContent &&
+            !isRecoveringResponse && (
+              <span className="sr-only" role="status" aria-live="polite">
+                {activityLabel}
+              </span>
+          )}
+          {showStreamError && (
+            <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:bg-red-950/20 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+              <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p>{formatStreamError(error)}</p>
+                {canRecoverResponse && (
+                  <p className="text-xs opacity-80 mt-1">
+                    {pendingRequestMarker?.createdAt
+                      ? `Request started at ${new Date(
+                          pendingRequestMarker.createdAt,
+                        ).toLocaleTimeString()}. `
+                      : ""}
+                    The response may still finish in the background. This
+                    conversation stays locked to prevent overlapping runs;
+                    check again, start a new conversation, or explicitly allow
+                    a retry.
+                  </p>
+                )}
+              </div>
+              {canRecoverResponse && (
+                <div className="flex shrink-0 flex-col gap-1">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setRecoveryState("checking");
+                      setRecoveryCycle((cycle) => cycle + 1);
+                    }}
+                  >
+                    Check again
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={allowRetryAfterUnresolvedResponse}
+                  >
+                    Allow retry
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+          <div
+            ref={messagesEndRef}
+            className="shrink-0 min-w-[24px] min-h-[24px]"
+          />
+        </div>
       </div>
 
       {/* Hidden file input */}
@@ -779,6 +1266,12 @@ function ChatView({
                   variant="ghost"
                   type="button"
                   onClick={() => handleSuggestedPrompt(suggestion.prompt)}
+                    disabled={
+                      status === "submitted" ||
+                      status === "streaming" ||
+                      isProcessingApproval ||
+                      hasUnresolvedResponse
+                    }
                   className="text-left border rounded-xl px-4 py-3.5 text-sm h-auto justify-start"
                 >
                   {suggestion.title}
@@ -792,7 +1285,12 @@ function ChatView({
             <div className="flex gap-2 items-end">
               <FileAttachmentButton
                 onClick={attachment.openFilePicker}
-                disabled={status === "submitted" || status === "streaming"}
+                  disabled={
+                    status === "submitted" ||
+                    status === "streaming" ||
+                    isProcessingApproval ||
+                    hasUnresolvedResponse
+                  }
               />
               <Textarea
                 ref={textareaRef}
@@ -810,7 +1308,10 @@ function ChatView({
                 className="min-h-0 max-h-[calc(75dvh)] overflow-hidden resize-none rounded-lg py-2 text-base md:text-sm bg-muted"
                 rows={1}
                 disabled={
-                  status === "submitted" || status === "streaming"
+                    status === "submitted" ||
+                    status === "streaming" ||
+                    isProcessingApproval ||
+                    hasUnresolvedResponse
                 }
               />
               <Button
@@ -820,7 +1321,9 @@ function ChatView({
                 disabled={
                   (!input.trim() && !attachment.hasFiles) ||
                   status === "submitted" ||
-                  status === "streaming"
+                    status === "streaming" ||
+                    isProcessingApproval ||
+                    hasUnresolvedResponse
                 }
                 className="h-9 w-9 shrink-0 rounded-lg"
               >
@@ -832,7 +1335,9 @@ function ChatView({
           <div className="flex flex-col gap-2 w-full">
             {pendingApproval && (
               <p className="text-xs text-amber-700 dark:text-amber-400 px-1">
-                Sending a message will deny the pending action{allPendingApprovals.length > 1 ? "s" : ""} — your text becomes the feedback the AI sees.
+                  Sending a message will deny the pending action
+                  {allPendingApprovals.length > 1 ? "s" : ""} — your text
+                  becomes the feedback the AI sees.
               </p>
             )}
             <FilePreviewStrip
@@ -846,7 +1351,8 @@ function ChatView({
                   status === "submitted" ||
                   status === "streaming" ||
                   !!pendingApproval ||
-                  isProcessingApproval
+                    isProcessingApproval ||
+                    hasUnresolvedResponse
                 }
               />
               <Textarea
@@ -871,13 +1377,14 @@ function ChatView({
                 disabled={
                   status === "submitted" ||
                   status === "streaming" ||
-                  isProcessingApproval
+                    isProcessingApproval ||
+                    hasUnresolvedResponse
                 }
               />
               {status === "streaming" ? (
                 <Button
                   type="button"
-                  onClick={stop}
+                    onClick={handleStop}
                   size="icon"
                   variant="outline"
                   className="h-9 w-9 shrink-0 rounded-lg"
@@ -893,6 +1400,7 @@ function ChatView({
                     (!input.trim() && !attachment.hasFiles) ||
                     status === "submitted" ||
                     isProcessingApproval ||
+                      hasUnresolvedResponse ||
                     (!!pendingApproval && !input.trim())
                   }
                   className="h-9 w-9 shrink-0 rounded-lg"
@@ -968,10 +1476,9 @@ function SystemInstructionsView({
       const token = await getToken();
       const params = new URLSearchParams({ modality });
       if (userName.trim()) params.set("user_name", userName.trim());
-      const res = await fetch(
-        `${API_BASE}/admin/context?${params}`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
+      const res = await fetch(`${API_BASE}/admin/context?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       const data = await res.json();
       setSections(data.sections);
@@ -1002,9 +1509,7 @@ function SystemInstructionsView({
                 <>
                   {" "}
                   Model:{" "}
-                  <code className="text-xs bg-muted px-1 rounded">
-                    {model}
-                  </code>
+                  <code className="text-xs bg-muted px-1 rounded">{model}</code>
                 </>
               )}
             </p>
@@ -1093,9 +1598,12 @@ function SystemInstructionsView({
             <div className="flex items-baseline gap-2">
               <h3 className="text-base font-semibold">Tools</h3>
               <p className="text-xs text-muted-foreground">
-                {totalTools} custom + {builtinTools.length} builtin — exactly what
-                pydantic-ai packages for the model via{" "}
-                <code className="bg-muted px-1 rounded">Toolset.get_tools()</code>.
+                {totalTools} custom + {builtinTools.length} builtin — exactly
+                what pydantic-ai packages for the model via{" "}
+                <code className="bg-muted px-1 rounded">
+                  Toolset.get_tools()
+                </code>
+                .
               </p>
             </div>
 
@@ -1109,7 +1617,9 @@ function SystemInstructionsView({
                     <div key={bt.name} className="text-xs space-y-1">
                       <div>
                         <code className="font-mono text-sm">{bt.name}</code>{" "}
-                        <span className="text-muted-foreground">({bt.type})</span>
+                        <span className="text-muted-foreground">
+                          ({bt.type})
+                        </span>
                       </div>
                       {Object.keys(bt.config).length > 0 && (
                         <pre className="text-xs bg-muted/50 rounded p-2 overflow-x-auto">
@@ -1141,7 +1651,10 @@ function SystemInstructionsView({
                 </summary>
                 <div className="px-4 pb-3 space-y-3">
                   {ts.tools.map((t) => (
-                    <div key={t.name} className="space-y-1 border-t pt-2 first:border-t-0 first:pt-0">
+                    <div
+                      key={t.name}
+                      className="space-y-1 border-t pt-2 first:border-t-0 first:pt-0"
+                    >
                       <div className="flex items-baseline gap-2 flex-wrap">
                         <code className="font-mono text-sm">{t.name}</code>
                         {t.kind && t.kind !== "function" && (
@@ -1149,7 +1662,9 @@ function SystemInstructionsView({
                             {t.kind}
                           </Badge>
                         )}
-                        {t.metadata && (t.metadata as { requires_approval?: boolean }).requires_approval && (
+                        {t.metadata &&
+                          (t.metadata as { requires_approval?: boolean })
+                            .requires_approval && (
                           <Badge variant="destructive" className="text-xs">
                             HITL approval
                           </Badge>
@@ -1282,20 +1797,29 @@ export default function SerniaChatPage() {
     user?.primaryEmailAddress?.emailAddress === "emilio@serniacapital.com";
   const urlConversationId = searchParams.get("id");
   const [conversationId, setConversationId] = useState<string>(
-    () => urlConversationId || crypto.randomUUID()
+    () => urlConversationId || crypto.randomUUID(),
   );
 
   // Loaded messages for the current conversation (null = new conversation)
   const [loadedMessages, setLoadedMessages] = useState<any[] | null>(
-    urlConversationId ? null : []
+    urlConversationId ? null : [],
   );
-  const [loadedPending, setLoadedPending] =
-    useState<PendingApproval | null>(null);
-  const [loadedAllPending, setLoadedAllPending] =
-    useState<PendingApproval[]>([]);
+  const [loadedPending, setLoadedPending] = useState<PendingApproval | null>(
+    null,
+  );
+  const [loadedAllPending, setLoadedAllPending] = useState<PendingApproval[]>(
+    [],
+  );
   const [conversationModality, setConversationModality] =
     useState<string>("web_chat");
   const push = usePushNotifications();
+  const intendedConversationIdRef = useRef(conversationId);
+  const conversationLoadGenerationRef = useRef(0);
+  const conversationLoadAbortRef = useRef<AbortController | null>(null);
+  const chatViewMountedRef = useRef(false);
+  const handleChatViewMountedChange = useCallback((mounted: boolean) => {
+    chatViewMountedRef.current = mounted;
+  }, []);
 
   // Track IDs created locally so the URL-change effect skips the API call
   const newConversationIds = useRef<Set<string>>(new Set());
@@ -1315,26 +1839,48 @@ export default function SerniaChatPage() {
   const loadConversation = useCallback(
     async (
       convId: string,
-      opts?: { updateUrl?: boolean; modality?: string }
+      opts?: {
+        updateUrl?: boolean;
+        modality?: string;
+        silent?: boolean;
+        clearPendingMarkerOnSuccess?: boolean;
+      },
     ) => {
-      if (!isSignedIn) return;
-      setLoadedMessages(null);
+      if (!isSignedIn) return false;
+      intendedConversationIdRef.current = convId;
+      const generation = conversationLoadGenerationRef.current + 1;
+      conversationLoadGenerationRef.current = generation;
+      conversationLoadAbortRef.current?.abort();
+      const controller = new AbortController();
+      conversationLoadAbortRef.current = controller;
+      if (!opts?.silent) setLoadedMessages(null);
 
       try {
         const token = await getToken();
-        const res = await fetch(
-          `${API_BASE}/conversation/${convId}/messages`,
-          { headers: { Authorization: `Bearer ${token}` } }
-        );
+        if (generation !== conversationLoadGenerationRef.current) return false;
+        const res = await fetch(`${API_BASE}/conversation/${convId}/messages`, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
+        });
 
+        if (generation !== conversationLoadGenerationRef.current) return false;
         if (!res.ok) {
           console.error("Failed to load conversation");
+          if (!opts?.silent) {
           navigate("/sernia-chat", { replace: true });
           setLoadedMessages([]);
-          return;
+          }
+          return false;
         }
 
         const data = await res.json();
+        if (
+          controller.signal.aborted ||
+          generation !== conversationLoadGenerationRef.current ||
+          intendedConversationIdRef.current !== convId
+        ) {
+          return false;
+        }
         const allPending = convertAllPendingFromApi(data.pending);
         setLoadedPending(allPending.length > 0 ? allPending[0] : null);
         setLoadedAllPending(allPending);
@@ -1342,19 +1888,44 @@ export default function SerniaChatPage() {
         setLoadedMessages(data.messages || []);
         setConversationModality(
           opts?.modality ||
-            (convId.startsWith("ai_sms_from_") ? "sms" : "web_chat")
+            (convId.startsWith("ai_sms_from_") ? "sms" : "web_chat"),
         );
 
         if (opts?.updateUrl !== false) {
           navigate(`/sernia-chat?id=${convId}`, { replace: true });
         }
+        if (opts?.clearPendingMarkerOnSuccess) {
+          clearPendingRequestMarkerStorage(convId);
+        }
+        return true;
       } catch (err) {
+        if (
+          controller.signal.aborted ||
+          generation !== conversationLoadGenerationRef.current
+        ) {
+          return false;
+        }
         console.error("Failed to load conversation:", err);
+        if (!opts?.silent) {
         navigate("/sernia-chat", { replace: true });
         setLoadedMessages([]);
       }
+        return false;
+      } finally {
+        if (conversationLoadAbortRef.current === controller) {
+          conversationLoadAbortRef.current = null;
+        }
+      }
     },
-    [isSignedIn, getToken, navigate]
+    [isSignedIn, getToken, navigate],
+  );
+
+  useEffect(
+    () => () => {
+      conversationLoadGenerationRef.current += 1;
+      conversationLoadAbortRef.current?.abort();
+    },
+    [],
   );
 
   // Load from URL on mount or when URL conversation ID changes
@@ -1377,14 +1948,33 @@ export default function SerniaChatPage() {
   // `messages` option at mount, so updating loadedMessages here wouldn't
   // reach the rendered chat.
 
-  // Listen for service worker messages (notification click)
+  // Listen for service worker completion signals and notification clicks.
+  // This lives outside ChatView so it remains active on the admin Context tab.
   useEffect(() => {
     const handler = (event: MessageEvent) => {
-      if (event.data?.type === "notification-click" && isSignedIn) {
-        const convId = event.data.data?.conversation_id;
-        if (convId) {
+      if (!isSignedIn) return;
+      const convId = event.data?.data?.conversation_id;
+      if (!convId) return;
+
+      if (event.data?.type === "notification-click") {
+        if (
+          convId !== intendedConversationIdRef.current ||
+          !chatViewMountedRef.current
+        ) {
           loadConversation(convId, { updateUrl: true });
         }
+      } else if (
+        event.data?.type === "response-ready" &&
+        convId === intendedConversationIdRef.current &&
+        !chatViewMountedRef.current
+      ) {
+        // ChatView may be unmounted on the admin Context tab. Refresh its next
+        // initial snapshot silently while preserving the active tab and UI.
+        loadConversation(convId, {
+          updateUrl: false,
+          silent: true,
+          clearPendingMarkerOnSuccess: true,
+        });
       }
     };
     navigator.serviceWorker?.addEventListener("message", handler);
@@ -1394,6 +1984,9 @@ export default function SerniaChatPage() {
 
   const startNewConversation = useCallback(() => {
     const newId = crypto.randomUUID();
+    conversationLoadGenerationRef.current += 1;
+    conversationLoadAbortRef.current?.abort();
+    intendedConversationIdRef.current = newId;
     newConversationIds.current.add(newId);
     setConversationId(newId);
     setLoadedMessages([]);
@@ -1407,7 +2000,7 @@ export default function SerniaChatPage() {
     (convId: string, modality?: string) => {
       loadConversation(convId, { modality });
     },
-    [loadConversation]
+    [loadConversation],
   );
 
   const handleDeleteConversation = useCallback(
@@ -1416,7 +2009,7 @@ export default function SerniaChatPage() {
         startNewConversation();
       }
     },
-    [conversationId, startNewConversation]
+    [conversationId, startNewConversation],
   );
 
   // Loading state (waiting for messages to load from API)
@@ -1475,6 +2068,7 @@ export default function SerniaChatPage() {
                   initialAllPending={loadedAllPending}
                   getToken={getToken}
                   readOnly={conversationModality === "sms"}
+                  onMountedChange={handleChatViewMountedChange}
                 />
               </TabsContent>
 

--- a/apps/web-react-router/package.json
+++ b/apps/web-react-router/package.json
@@ -7,6 +7,7 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "node server.js",
+    "test": "tsx --test app/lib/*.test.ts test/*.test.mjs",
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
@@ -67,6 +68,7 @@
     "@types/react-dom": "^19.2.3",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.23.9",
     "typescript": "^5.9.3",
     "vite": "^7.3.2",
     "vite-tsconfig-paths": "^5.1.4"

--- a/apps/web-react-router/public/sw.js
+++ b/apps/web-react-router/public/sw.js
@@ -1,5 +1,47 @@
 // Minimal service worker for Sernia Capital PWA push notifications.
-// No caching — only handles push events and notification clicks.
+// No caching — only handles worker lifecycle and push notifications.
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+async function shouldShowNotification(data) {
+  if (data.type !== "response") return true;
+
+  const windowClients = await self.clients.matchAll({
+    type: "window",
+    includeUncontrolled: true,
+  });
+
+  const focusedConversation = windowClients.find((client) => {
+    if (!client.focused) return false;
+
+    try {
+      const clientUrl = new URL(client.url);
+      return (
+        clientUrl.pathname === "/sernia-chat" &&
+        clientUrl.searchParams.get("id") === data.conversation_id
+      );
+    } catch {
+      return false;
+    }
+  });
+
+  if (!focusedConversation) return true;
+
+  // Suppressing the system notification must not suppress the completion
+  // signal itself. The focused page uses this to replace a stuck/lost stream
+  // with the newly persisted authoritative response.
+  focusedConversation.postMessage({
+    type: "response-ready",
+    data,
+  });
+  return false;
+}
 
 self.addEventListener("push", (event) => {
   if (!event.data) return;
@@ -13,19 +55,28 @@ self.addEventListener("push", (event) => {
 
   const { title = "Sernia Capital", body = "", data = {} } = payload;
 
-  // Approval notifications persist until acted on; alerts auto-dismiss
+  // Approval notifications persist until acted on; alerts auto-dismiss.
   const isApproval = data.type === "approval";
-  const tag = data.conversation_id || "sernia-default";
+  const notificationType = isApproval
+    ? "approval"
+    : data.type === "response"
+      ? "response"
+      : "alert";
+  const tag = `${notificationType}-${data.conversation_id || "sernia-default"}`;
 
   event.waitUntil(
-    self.registration.showNotification(title, {
-      body,
-      icon: "/favicon.png",
-      badge: "/favicon.png",
-      tag: isApproval ? `approval-${tag}` : `alert-${tag}`,
-      data,
-      requireInteraction: isApproval,
-    })
+    (async () => {
+      if (!(await shouldShowNotification(data))) return;
+
+      await self.registration.showNotification(title, {
+        body,
+        icon: "/favicon.png",
+        badge: "/favicon.png",
+        tag,
+        data,
+        requireInteraction: isApproval,
+      });
+    })()
   );
 });
 
@@ -36,10 +87,10 @@ self.addEventListener("notificationclick", (event) => {
 
   event.waitUntil(
     clients.matchAll({ type: "window", includeUncontrolled: true }).then((windowClients) => {
-      // Focus an existing sernia-chat tab if one exists
+      // Focus an existing sernia-chat tab if one exists.
       for (const client of windowClients) {
         if (client.url.includes("/sernia-chat") && "focus" in client) {
-          // Tell the page to reload conversation data before navigating
+          // Tell the page to refresh conversation data before navigating.
           client.postMessage({
             type: "notification-click",
             url,
@@ -49,7 +100,6 @@ self.addEventListener("notificationclick", (event) => {
           return client.focus();
         }
       }
-      // Otherwise open a new window
       return clients.openWindow(url);
     })
   );

--- a/apps/web-react-router/server.js
+++ b/apps/web-react-router/server.js
@@ -24,6 +24,36 @@ app.use(compression());
 app.use(express.static("build/client", { maxAge: "1h" }));
 
 /**
+ * Wait until a downstream response can accept more data.
+ * Returns false if the browser disconnects while backpressure is active.
+ * @param {import("express").Response} res
+ */
+function waitForDrain(res) {
+  if (res.destroyed || res.writableEnded) return Promise.resolve(false);
+
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      res.off("drain", onDrain);
+      res.off("close", onClose);
+      res.off("error", onClose);
+    };
+    const settle = (drained) => {
+      cleanup();
+      resolve(drained);
+    };
+    const onDrain = () => settle(true);
+    const onClose = () => settle(false);
+
+    res.once("drain", onDrain);
+    res.once("close", onClose);
+    res.once("error", onClose);
+
+    // Close may have raced with listener registration.
+    if (res.destroyed || res.writableEnded) settle(false);
+  });
+}
+
+/**
  * Stream-proxy a request to the backend.
  * @param {import("express").Request} req
  * @param {import("express").Response} res
@@ -51,23 +81,29 @@ async function proxyToBackend(req, res, targetUrl, logTag) {
     }
 
     res.status(response.status);
+    res.flushHeaders?.();
 
     if (response.body) {
       const reader = response.body.getReader();
-      const pump = async () => {
+      try {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          res.write(value);
+
+          // If the browser disconnected, keep draining the upstream stream so
+          // the backend can finish its work and persist the conversation.
+          if (res.destroyed || res.writableEnded) continue;
+
+          if (!res.write(value) && !(await waitForDrain(res))) continue;
+          if (!res.destroyed && !res.writableEnded) res.flush?.();
         }
-        res.end();
-      };
-      pump().catch((err) => {
-        console.error(`[${logTag}] Stream error:`, err);
-        if (!res.headersSent) {
-          res.status(502).json({ error: "Proxy Error", detail: err.message });
+
+        if (!res.destroyed && !res.writableEnded) {
+          res.end();
         }
-      });
+      } finally {
+        reader.releaseLock();
+      }
     } else {
       res.end();
     }
@@ -78,6 +114,11 @@ async function proxyToBackend(req, res, targetUrl, logTag) {
         error: "Proxy Error",
         detail: error instanceof Error ? error.message : "Unknown error",
       });
+    } else if (!res.destroyed && !res.writableEnded) {
+      // Headers (and possibly part of an SSE response) are already on the
+      // wire, so an HTTP error body is no longer valid. Terminate the socket
+      // to make the browser's fetch fail instead of hanging indefinitely.
+      res.destroy();
     }
   }
 }

--- a/apps/web-react-router/test/service-worker.test.mjs
+++ b/apps/web-react-router/test/service-worker.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const handlers = {};
+const shownNotifications = [];
+const postedMessages = [];
+
+globalThis.self = {
+  addEventListener(name, handler) {
+    handlers[name] = handler;
+  },
+  clients: {
+    matchAll: async () => [],
+    claim: async () => {},
+  },
+  registration: {
+    async showNotification(title, options) {
+      shownNotifications.push({ title, options });
+    },
+  },
+  skipWaiting: async () => {},
+};
+globalThis.clients = globalThis.self.clients;
+
+await import("../public/sw.js");
+
+async function dispatchResponsePush() {
+  let completion;
+  handlers.push({
+    data: {
+      json: () => ({
+        title: "Sernia AI",
+        body: "Your response is ready.",
+        data: {
+          type: "response",
+          conversation_id: "conversation-123",
+        },
+      }),
+    },
+    waitUntil(promise) {
+      completion = promise;
+    },
+  });
+  await completion;
+}
+
+test("suppresses a response notification for the focused conversation", async () => {
+  shownNotifications.length = 0;
+  postedMessages.length = 0;
+  self.clients.matchAll = async () => [
+    {
+      focused: true,
+      url: "https://example.test/sernia-chat?id=conversation-123",
+      postMessage(message) {
+        postedMessages.push(message);
+      },
+    },
+  ];
+
+  await dispatchResponsePush();
+
+  assert.equal(shownNotifications.length, 0);
+  assert.deepEqual(postedMessages, [
+    {
+      type: "response-ready",
+      data: {
+        type: "response",
+        conversation_id: "conversation-123",
+      },
+    },
+  ]);
+});
+
+test("shows a response notification when the conversation is not focused", async () => {
+  shownNotifications.length = 0;
+  postedMessages.length = 0;
+  self.clients.matchAll = async () => [
+    {
+      focused: false,
+      url: "https://example.test/sernia-chat?id=conversation-123",
+    },
+  ];
+
+  await dispatchResponsePush();
+
+  assert.equal(shownNotifications.length, 1);
+  assert.equal(postedMessages.length, 0);
+  assert.equal(shownNotifications[0].options.tag, "response-conversation-123");
+});

--- a/apps/web-react-router/tsconfig.json
+++ b/apps/web-react-router/tsconfig.json
@@ -6,11 +6,12 @@
     ".react-router/types/**/*"
   ],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "types": ["node", "vite/client"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
     "baseUrl": ".",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch@>=9.0.0 <9.0.6: '>=9.0.6'
+  rollup@>=4.0.0 <4.59.0: '>=4.59.0'
+  ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
+
 importers:
 
   .:
@@ -221,7 +226,7 @@ importers:
         version: 7.14.0(express@4.22.1)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@react-router/fs-routes':
         specifier: ^7.14.0
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.23.9)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)))(typescript@5.9.3)
       '@react-router/node':
         specifier: ^7.14.0
         version: 7.14.0(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -297,10 +302,10 @@ importers:
     devDependencies:
       '@react-router/dev':
         specifier: ^7.14.0
-        version: 7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+        version: 7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.23.9)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9))
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+        version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9))
       '@types/compression':
         specifier: ^1.8.1
         version: 1.8.1
@@ -322,15 +327,18 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      tsx:
+        specifier: ^4.23.9
+        version: 4.23.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9))
 
   packages/features:
     dependencies:
@@ -1116,8 +1124,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1128,8 +1148,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1140,8 +1172,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1152,8 +1196,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1164,8 +1220,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1176,8 +1244,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1188,8 +1268,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1200,8 +1292,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1212,8 +1316,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1224,8 +1340,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1236,8 +1364,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1248,8 +1388,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1260,8 +1412,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2409,79 +2573,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2714,28 +2865,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3129,49 +3276,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3294,7 +3433,7 @@ packages:
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: '>=8.18.0'
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -3302,7 +3441,7 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: '>=8.18.0'
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -3310,13 +3449,10 @@ packages:
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
-      ajv: ^8.8.2
+      ajv: '>=8.18.0'
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
-
-  ajv@8.11.0:
-    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -4373,6 +4509,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5769,56 +5910,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.27.0:
     resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.27.0:
     resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
@@ -7538,6 +7671,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -7554,6 +7688,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.9:
+    resolution: {integrity: sha512-6q8uTORRGauQVjqMQnKUucLFoeXZAfw6zKvG35GLbdKWbLdeOtZ3H4mhyA5mxuUd2o2cRTskhj59nLLQseUvUw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -9084,79 +9223,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -10599,7 +10816,7 @@ snapshots:
     dependencies:
       nanoid: 3.3.11
 
-  '@react-router/dev@7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))':
+  '@react-router/dev@7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.23.9)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -10629,8 +10846,8 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10656,9 +10873,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(typescript@5.9.3)':
+  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.23.9)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)))(typescript@5.9.3)':
     dependencies:
-      '@react-router/dev': 7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+      '@react-router/dev': 7.14.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.23.9)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9))
       minimatch: 9.0.9
     optionalDependencies:
       typescript: 5.9.3
@@ -11063,12 +11280,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))':
+  '@tailwindcss/vite@4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)
 
   '@tanstack/query-core@5.87.4': {}
 
@@ -11641,13 +11858,6 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
-  ajv@8.11.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
       uri-js: 4.4.1
 
   ajv@8.18.0:
@@ -12890,6 +13100,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -13275,7 +13514,7 @@ snapshots:
 
   expo-dev-launcher@5.1.16(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(graphql@16.13.2)(react-native-webview@13.13.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ajv: 8.11.0
+      ajv: 8.18.0
       expo: 53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(graphql@16.13.2)(react-native-webview@13.13.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6)
       expo-dev-menu: 6.1.14(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(graphql@16.13.2)(react-native-webview@13.13.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))
       expo-manifests: 0.16.6(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(graphql@16.13.2)(react-native-webview@13.13.5(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@types/react@19.0.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(react@19.0.0)(utf-8-validate@6.0.6))
@@ -17026,6 +17265,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.9:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -17302,13 +17547,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17323,18 +17568,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1):
+  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.9):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -17348,6 +17593,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       terser: 5.46.1
+      tsx: 4.23.9
 
   vlq@1.0.1: {}
 


### PR DESCRIPTION
## Summary

- recover completed Sernia AI responses automatically when the browser stream is interrupted, without requiring a page reload
- show an animated assistant activity indicator during generation, recovery, and approval processing
- send requester-only Web Push notifications after responses are durably persisted, while silently refreshing the focused conversation
- harden the production stream proxy so backend work can finish and persist after a browser disconnect
- reconcile push subscriptions safely across Clerk account changes

## Root cause

The rendered conversation depended too heavily on the live browser stream. If that stream broke or the tab was suspended, the backend could finish and persist the response while the client remained stale. The production proxy also stopped managing the upstream response lifecycle once pumping began. Completion pushes existed for approvals, but not for normal responses, and the targeted notification path could fall back to broadcasting.

## User impact

Users see an active thinking state while Sernia AI works. Completed responses are reconciled from the database automatically after network interruptions or tab suspension. When the conversation is not focused, the submitting user receives a generic lock-screen-safe notification; when it is focused, the page refreshes in place.

## Validation

- frontend recovery and service-worker tests: 7 passed
- backend push and persistence tests: 11 passed (1 live test deselected)
- TypeScript typecheck passed
- production frontend build passed
- JavaScript syntax checks passed
- Ruff checks passed
- git diff whitespace check passed
