### PR TITLE
Preview Sernia AI responses in notifications

### DIFF
--- a/api/src/sernia_ai/push/README.md
+++ b/api/src/sernia_ai/push/README.md
@@ -5,7 +5,7 @@ Notifications for Sernia AI chat responses, HITL approvals, and trigger alerts. 
 1. **Web Push** — PWA push notifications to phones and desktops (no native app required). Normal web-chat completions are sent only to the Clerk user who submitted the request. HITL approvals and trigger alerts remain team-wide.
 2. **SMS to shared team number** — persistent record in the team's OpenPhone thread with a deeplink to web chat for trigger alerts
 
-Normal response notifications use a generic body (`Your response is ready.`) rather than response text so sensitive content is not exposed in lock-screen previews. If the requesting user has no active subscription, delivery is skipped; targeted notifications never fall back to broadcasting to all Sernia users.
+Normal response notifications include a whitespace-normalized preview of up to 180 characters and fall back to `Your response is ready.` when no text is available. The preview may be visible on a device lock screen depending on the user's operating-system notification settings. If the requesting user has no active subscription, delivery is skipped; targeted notifications never fall back to broadcasting to all Sernia users.
 
 ## Protocol
 

--- a/api/src/sernia_ai/push/service.py
+++ b/api/src/sernia_ai/push/service.py
@@ -24,6 +24,9 @@ VAPID_CLAIMS_EMAIL = os.environ.get("VAPID_CLAIM_EMAIL", "mailto:admin@serniacap
 _vapid: Vapid | None = None
 _vapid_loaded: bool = False
 
+_RESPONSE_PREVIEW_MAX_CHARS = 180
+_RESPONSE_READY_FALLBACK = "Your response is ready."
+
 
 def _get_vapid() -> Vapid | None:
     """Return the cached Vapid object, loading from env on first call.
@@ -265,11 +268,11 @@ async def notify_user_push(
 async def notify_chat_response(
     conversation_id: str,
     clerk_user_id: str,
+    response_text: str | None = None,
 ) -> None:
     """Notify only the user who requested a completed web-chat response.
 
-    The notification intentionally contains no response text because OS-level
-    notification previews can be visible on a locked or shared device.
+    The notification includes a short, whitespace-normalized response preview.
     ``notify_user_push`` does not broadcast when the user has no subscription.
     """
     if not conversation_id or not clerk_user_id:
@@ -286,11 +289,17 @@ async def notify_chat_response(
         "type": "response",
     }
 
+    preview = " ".join((response_text or "").split())
+    if not preview:
+        preview = _RESPONSE_READY_FALLBACK
+    elif len(preview) > _RESPONSE_PREVIEW_MAX_CHARS:
+        preview = preview[: _RESPONSE_PREVIEW_MAX_CHARS - 1].rstrip() + "…"
+
     try:
         await notify_user_push(
             clerk_user_id=clerk_user_id,
             title="Sernia AI",
-            body="Your response is ready.",
+            body=preview,
             data=data,
         )
     except Exception:

--- a/api/src/sernia_ai/routes.py
+++ b/api/src/sernia_ai/routes.py
@@ -310,6 +310,7 @@ async def chat_sernia(
                 notify_chat_response(
                     conversation_id=conversation_id,
                     clerk_user_id=clerk_user_id,
+                    response_text=result.output,
                 ),
                 name="notify_chat_response",
             )
@@ -520,6 +521,7 @@ async def approve_conversation(
                 notify_chat_response(
                     conversation_id=conversation_id,
                     clerk_user_id=clerk_user_id,
+                    response_text=result.output,
                 ),
                 name="notify_chat_response",
             )

--- a/api/src/tests/test_web_push.py
+++ b/api/src/tests/test_web_push.py
@@ -62,7 +62,7 @@ class TestSmoke:
 
 
 @pytest.mark.asyncio
-async def test_chat_response_notification_is_private_and_user_targeted(monkeypatch):
+async def test_chat_response_notification_has_preview_and_is_user_targeted(monkeypatch):
     from api.src.sernia_ai.push import service
 
     notify_user = AsyncMock()
@@ -71,18 +71,44 @@ async def test_chat_response_notification_is_private_and_user_targeted(monkeypat
     await service.notify_chat_response(
         conversation_id="conversation-123",
         clerk_user_id="user-456",
+        response_text="  First line.\n\nSecond line.  ",
     )
 
     notify_user.assert_awaited_once_with(
         clerk_user_id="user-456",
         title="Sernia AI",
-        body="Your response is ready.",
+        body="First line. Second line.",
         data={
             "url": "/sernia-chat?id=conversation-123",
             "conversation_id": "conversation-123",
             "type": "response",
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_response_preview_falls_back_and_is_bounded(monkeypatch):
+    from api.src.sernia_ai.push import service
+
+    notify_user = AsyncMock()
+    monkeypatch.setattr(service, "notify_user_push", notify_user)
+
+    await service.notify_chat_response(
+        conversation_id="conversation-123",
+        clerk_user_id="user-456",
+        response_text=" \n ",
+    )
+    assert notify_user.await_args.kwargs["body"] == "Your response is ready."
+
+    notify_user.reset_mock()
+    await service.notify_chat_response(
+        conversation_id="conversation-123",
+        clerk_user_id="user-456",
+        response_text="x" * 240,
+    )
+    preview = notify_user.await_args.kwargs["body"]
+    assert len(preview) == 180
+    assert preview.endswith("…")
 
 
 @pytest.mark.asyncio
@@ -209,6 +235,15 @@ async def test_cancelled_chat_waits_for_commit_then_schedules_response_push(monk
     user.last_name = "User"
     user.email_addresses = []
     scheduled_tasks: list[str | None] = []
+    response_notification: dict[str, str] = {}
+
+    def capture_response_notification(**kwargs):
+        response_notification.update(kwargs)
+
+        async def completed():
+            return None
+
+        return completed()
 
     def capture_task(coro, *, name=None):
         scheduled_tasks.append(name)
@@ -222,6 +257,7 @@ async def test_cancelled_chat_waits_for_commit_then_schedules_response_push(monk
     monkeypatch.setattr(routes, "get_conversation_messages", AsyncMock(return_value=[]))
     monkeypatch.setattr(routes, "resolve_active_run_kwargs", AsyncMock(return_value={}))
     monkeypatch.setattr(routes, "extract_pending_approvals", MagicMock(return_value=[]))
+    monkeypatch.setattr(routes, "notify_chat_response", capture_response_notification)
     monkeypatch.setattr(routes, "create_logged_task", capture_task)
     monkeypatch.setattr(routes.VercelAIAdapter, "dispatch_request", dispatch_after_persistence)
 
@@ -241,6 +277,11 @@ async def test_cancelled_chat_waits_for_commit_then_schedules_response_push(monk
 
     assert response.status_code == 200
     assert scheduled_tasks == ["git_sync", "notify_chat_response"]
+    assert response_notification == {
+        "conversation_id": "conversation-123",
+        "clerk_user_id": "user-456",
+        "response_text": "Completed response",
+    }
 
 
 @pytest.mark.asyncio
@@ -343,6 +384,75 @@ async def test_approval_route_skips_push_when_persistence_fails(monkeypatch):
 
     assert response["status"] == "pending_approval"
     assert scheduled_tasks == ["git_sync"]
+
+
+@pytest.mark.asyncio
+async def test_approval_route_schedules_response_preview_after_persistence(monkeypatch):
+    from api.src.sernia_ai import routes
+
+    body = routes.ApprovalRequest(
+        decisions=[
+            routes.ApprovalDecisionRequest(
+                tool_call_id="tool-123",
+                approved=True,
+            )
+        ]
+    )
+    user = MagicMock()
+    user.id = "user-456"
+    user.first_name = "Test"
+    user.last_name = "User"
+    user.email_addresses = []
+
+    result = MagicMock()
+    result.output = "Approval follow-up"
+    scheduled_tasks: list[str | None] = []
+    response_notification: dict[str, str] = {}
+
+    class FakeCaptureContext:
+        def __enter__(self):
+            return []
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def capture_task(coro, *, name=None):
+        scheduled_tasks.append(name)
+        coro.close()
+        return MagicMock()
+
+    def capture_response_notification(**kwargs):
+        response_notification.update(kwargs)
+
+        async def completed():
+            return None
+
+        return completed()
+
+    monkeypatch.setattr(routes, "capture_run_messages", FakeCaptureContext)
+    monkeypatch.setattr(routes, "resume_with_approvals", AsyncMock(return_value=result))
+    monkeypatch.setattr(routes, "persist_agent_run_result", AsyncMock(return_value=True))
+    monkeypatch.setattr(routes, "resolve_active_run_kwargs", AsyncMock(return_value={}))
+    monkeypatch.setattr(routes, "get_agent_conversation", AsyncMock(return_value=None))
+    monkeypatch.setattr(routes, "extract_pending_approvals", MagicMock(return_value=[]))
+    monkeypatch.setattr(routes, "extract_tool_results", MagicMock(return_value={}))
+    monkeypatch.setattr(routes, "notify_chat_response", capture_response_notification)
+    monkeypatch.setattr(routes, "create_logged_task", capture_task)
+
+    response = await routes.approve_conversation(
+        conversation_id="conversation-123",
+        body=body,
+        user=user,
+        session=MagicMock(),
+    )
+
+    assert response["status"] == "completed"
+    assert scheduled_tasks == ["git_sync", "notify_chat_response"]
+    assert response_notification == {
+        "conversation_id": "conversation-123",
+        "clerk_user_id": "user-456",
+        "response_text": "Approval follow-up",
+    }
 
 
 @pytest.mark.live


### PR DESCRIPTION
## Summary

- include the completed Sernia AI response text in requester-only Web Push notifications
- normalize response whitespace and cap previews at 180 characters
- retain `Your response is ready.` as the fallback when no text is available
- pass previews through both normal chat completions and approval continuations

## Why

The initial completion-notification implementation intentionally used a generic body. Users want enough response content in the notification to understand the answer without reopening the page immediately.

## User impact

Completion notifications now display a concise message preview. Depending on operating-system settings, that preview may also be visible on the device lock screen.

## Validation

- focused backend push suite: 13 passed, 1 live test deselected
- Ruff lint passed
- Ruff formatting check passed
- git diff whitespace check passed
