### PR TITLE
Break the MEMORY.md edit-retry loop that exhausts a run's request budget

### DIFF
--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -122,7 +122,7 @@ Git-backed persistent workspace at `/workspace/`:
 - `MEMORY.md` — Long-term memory (injected into every conversation)
 - `daily_notes/` — Date-stamped notes per topic
 - `areas/` — Deep knowledge by domain (properties, tenants, etc.)
-- `.claude/skills/` — Playbooks and procedures. The agent discovers and reads skills via the `SkillsToolset` tools (`list_skills`, `load_skill`, `read_skill_resource`, `run_skill_script`); the registry is auto-injected into the system prompt. Workspace file tools (`workspace_write` / `workspace_edit`) are reserved for **editing** skills. Path mirrors Claude Code's convention so the workspace is interoperable with `cd workspace && claude` runs.
+- `.claude/skills/` — Playbooks and procedures. The agent discovers and reads skills via the `SkillsToolset` tools (`list_skills`, `load_skill`, `read_skill_resource`, `run_skill_script`); the registry is auto-injected into the system prompt. Workspace file tools (`workspace_write_file` / `workspace_edit_file`) are reserved for **editing** skills. Path mirrors Claude Code's convention so the workspace is interoperable with `cd workspace && claude` runs.
 
 ### Server-Side vs Knowledge-Repo Content
 
@@ -133,7 +133,7 @@ The agent's behavior comes from two sources with different error boundaries:
 | **Server-side** | `api/src/sernia_ai/` (Python) | Developers (code deploys) | Bugs crash the app — standard software quality applies |
 | **Knowledge repo** | `.workspace/` (`sernia-knowledge` git repo) | Agent + humans at runtime | Must **never** crash the server — all reads are error-wrapped |
 
-This distinction matters most for **skills** (`/workspace/.claude/skills/<name>/SKILL.md`). Skills are runtime-editable YAML+markdown files that the agent itself can create and modify via `workspace_edit`. A malformed SKILL.md (bad YAML frontmatter, broken encoding, etc.) must degrade gracefully:
+This distinction matters most for **skills** (`/workspace/.claude/skills/<name>/SKILL.md`). Skills are runtime-editable YAML+markdown files that the agent itself can create and modify via `workspace_edit_file`. A malformed SKILL.md (bad YAML frontmatter, broken encoding, etc.) must degrade gracefully:
 
 - **Reload** (`reload_skills()` in `agent.py`): Per-directory try/except — a broken skill directory is skipped and logged, other skills still load.
 - **Injection** (`SkillsToolset.get_instructions()`): Operates on already-loaded `_skills` dict, so it only sees successfully parsed skills.

--- a/api/src/sernia_ai/instructions.py
+++ b/api/src/sernia_ai/instructions.py
@@ -40,8 +40,12 @@ conversations. `MEMORY.md` and a workspace filetree are auto-injected at the \
 start of every conversation.
 
 - **MEMORY.md** — proactively update when you learn something important (a \
-new property, tenant name, process, preference). Don't `workspace_read` it; \
-its contents are already injected.
+new property, tenant name, process, preference). Don't `workspace_read_file` \
+it up front; its contents are already injected. But the injected copy is a \
+**snapshot taken at the start of this run** — the moment you edit MEMORY.md \
+it is stale. Before a *second* edit in the same run, and after any failed \
+edit, `workspace_read_file` it to get the exact current text. Never retry an \
+edit by guessing at the whitespace.
 - **`/workspace/daily_notes/YYYY-MM-DD_<short-desc>.md`** — one file per \
 topic per day for ad-hoc notes.
 - **`/workspace/areas/<topic>.md`** — deep topic knowledge (properties, \
@@ -49,13 +53,18 @@ tenants, vendors, etc.).
 - **Skills** — domain playbooks. The skill registry (name + description) is \
 auto-injected. Use `list_skills` to browse, `load_skill <name>` to load full \
 instructions, `read_skill_resource` for supplementary files. **Never** use \
-`workspace_read` to read a skill — use `load_skill`. To CREATE or EDIT a \
+`workspace_read_file` to read a skill — use `load_skill`. To CREATE or EDIT a \
 skill, write to `/workspace/.claude/skills/<name>/SKILL.md` via \
-`workspace_write` / `workspace_edit`. The workspace tools are for editing \
-skills, not reading them.
-- **General workspace I/O** — `workspace_read`, `workspace_write`, \
-`workspace_edit`, `workspace_list_files`, `search_files`, `workspace_delete` \
-for everything else under `/workspace/`.
+`workspace_write_file` / `workspace_edit_file`. The workspace tools are for \
+editing skills, not reading them.
+- **General workspace I/O** — `workspace_read_file`, `workspace_write_file`, \
+`workspace_edit_file`, `workspace_list_files`, `search_files`, \
+`workspace_delete_file` for everything else under `/workspace/`.
+- **Editing any workspace file** — `workspace_edit_file` matches its search \
+text byte-for-byte. If it reports "text not found in file", do **not** retry \
+with a reworded or re-indented guess: `workspace_read_file` the file, copy \
+the exact lines, then edit once. Repeated blind retries burn the run's \
+request budget and abort the whole run.
 
 ## Merge Conflicts
 If you see git merge conflict markers (`<<<<<<`, `>>>>>>`) in any workspace \

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -128,4 +128,4 @@ One-time scheduled SMS and email delivery via APScheduler date trigger.
 | `clickup_tools.py` | Task management (list, search, create, update, delete) |
 | `db_search_tools.py` | Search past agent conversations and SMS history; chronological contact SMS history |
 | `code_tools.py` | Python sandbox (pydantic-monty) for math, formatting, data manipulation |
-| `_logging.py` | Shared error logging wrapper for tool failures |
+| `_logging.py` | Shared error logging wrapper for tool failures. Sandbox file-tool errors log at warn (not error) so they don't page; `EditError` also gets a "re-read the file, don't guess whitespace" hint appended to the string the model sees, because blind edit retries have exhausted a run's request budget. |

--- a/api/src/sernia_ai/tools/_logging.py
+++ b/api/src/sernia_ai/tools/_logging.py
@@ -8,10 +8,26 @@ import logfire
 from pydantic_ai import RunContext
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, ToolRetryError
 from pydantic_ai.toolsets import WrapperToolset
-from pydantic_ai_filesystem_sandbox import SandboxError
+from pydantic_ai_filesystem_sandbox import EditError, SandboxError
 
 # PydanticAI control-flow exceptions that must propagate — never catch these.
 _PASSTHROUGH_EXCEPTIONS = (ApprovalRequired, CallDeferred, ModelRetry, ToolRetryError)
+
+# Appended to every EditError returned to the model. A bare EditError only says
+# the search text wasn't found, which the model tends to answer by retrying the
+# same edit with slightly different indentation — a loop that has burned entire
+# runs' request budgets (a scheduled run on 2026-08-08 spent 11 workspace_edit_file
+# calls on MEMORY.md and died on pydantic-ai's 50-request limit). The one thing
+# that actually breaks the loop is re-reading the file, so say so explicitly.
+# The stale-snapshot note matters most for MEMORY.md, which is injected into the
+# prompt once per run and goes out of date the moment the model edits it.
+_EDIT_RECOVERY_HINT = (
+    " → Do not retry with a re-indented or reworded guess. Call "
+    "workspace_read_file on this path first and copy the exact current text "
+    "(if this is MEMORY.md, the copy injected into your prompt is a snapshot "
+    "from the start of this run and is stale once you have edited it), then "
+    "make a single corrected edit."
+)
 
 # Expected, model-recoverable tool errors. These are caused by the model's tool
 # *arguments* (e.g. an edit whose search text isn't in the file, a path outside
@@ -68,7 +84,9 @@ class ErrorLoggingToolset(WrapperToolset):
     Expected, model-recoverable errors (``_RECOVERABLE_EXCEPTIONS`` — sandbox
     file-tool errors like ``EditError``) are logged at warning level instead
     of error: the model fixes its arguments and retries, so they shouldn't
-    page like a genuine failure. The returned error string is unchanged.
+    page like a genuine failure. ``EditError`` additionally gets
+    ``_EDIT_RECOVERY_HINT`` appended to the string the model sees, telling it
+    to re-read the file instead of retrying a re-indented guess.
 
     The optional ``name`` kwarg labels the toolset for admin/debug surfaces
     (e.g. the Context tab). Pydantic-ai's stock ``label`` property bakes in
@@ -93,7 +111,8 @@ class ErrorLoggingToolset(WrapperToolset):
         except _RECOVERABLE_EXCEPTIONS as e:
             conversation_id = getattr(ctx.deps, "conversation_id", "")
             log_tool_error(name, e, conversation_id=conversation_id, level="warn")
-            return f"Error in {name}: {e}"
+            hint = _EDIT_RECOVERY_HINT if isinstance(e, EditError) else ""
+            return f"Error in {name}: {e}{hint}"
         except Exception as e:
             conversation_id = getattr(ctx.deps, "conversation_id", "")
             log_tool_error(name, e, conversation_id=conversation_id)

--- a/api/src/tests/test_logging_toolset.py
+++ b/api/src/tests/test_logging_toolset.py
@@ -13,7 +13,7 @@ import pytest
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai_filesystem_sandbox import EditError, PathNotInSandboxError
 
-from api.src.sernia_ai.tools._logging import ErrorLoggingToolset
+from api.src.sernia_ai.tools._logging import _EDIT_RECOVERY_HINT, ErrorLoggingToolset
 
 
 class _FakeToolset:
@@ -49,6 +49,35 @@ async def test_recoverable_sandbox_error_logged_as_warning(exc):
     lf.warn.assert_called_once()
     lf.exception.assert_not_called()
     assert "Error in workspace_edit_file" in result
+
+
+@pytest.mark.asyncio
+async def test_edit_error_tells_model_to_reread_the_file():
+    """An EditError carries the re-read hint that breaks the blind-retry loop.
+
+    Without it the model answers "text not found" by retrying the same edit
+    with different indentation, which has exhausted a run's request budget
+    (pydantic-ai's UsageLimitExceeded) instead of failing one tool call.
+    """
+    exc = EditError("/workspace/MEMORY.md", "text not found", "  - 2026-07-31 | SMS to …")
+    ts = ErrorLoggingToolset(_FakeToolset(exc), name="workspace")
+    with patch("api.src.sernia_ai.tools._logging.logfire"):
+        result = await ts.call_tool("workspace_edit_file", {}, _make_ctx(), MagicMock())
+
+    assert result.endswith(_EDIT_RECOVERY_HINT)
+    assert "workspace_read_file" in result
+    # The original sandbox message survives ahead of the hint.
+    assert "text not found" in result
+
+
+@pytest.mark.asyncio
+async def test_non_edit_sandbox_error_has_no_edit_hint():
+    """The re-read hint is EditError-specific — a bad path doesn't get it."""
+    ts = ErrorLoggingToolset(_FakeToolset(PathNotInSandboxError("/etc/passwd", ["/workspace"])))
+    with patch("api.src.sernia_ai.tools._logging.logfire"):
+        result = await ts.call_tool("workspace_read_file", {}, _make_ctx(), MagicMock())
+
+    assert _EDIT_RECOVERY_HINT not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Found by the daily Logfire triage. Addresses two alerts that turned out to be one incident:

- **`Error-level records (non-local)`** — two `pydantic_ai.exceptions.UsageLimitExceeded` ("The next request would exceed the request_limit of 50") on production, 2026-08-08 13:00 and 13:03 ([trace](https://logfire-us.pydantic.dev/espo412/portfolio?q=trace_id%3D%27019fe175860aa95b1d649d21d6828066%27), [trace](https://logfire-us.pydantic.dev/espo412/portfolio?q=trace_id%3D%27019fe178cc4adc1123374054e2d39f19%27))
- **`Sernia recoverable tool-error loop`** — 7 `workspace_edit_file` EditErrors on [conversation `6166109b`](https://logfire-us.pydantic.dev/espo412/portfolio?q=attributes%5B%27conversation_id%27%5D%3D%276166109b-ff81-4147-8d84-a6e9756b8c44%27), the same conversation

### What happened

A scheduled run did ~1 minute of useful work (email / SMS / ClickUp), then spent 13:01:00–13:02:07 making 11 `workspace_edit_file` calls against `/workspace/MEMORY.md`. Seven failed with `EditError: text not found in file`, the successive attempts differing only in leading whitespace (`'  - 2026-07-31 | SMS to …'` → `'   - 2026-07-31 | SMS to …'`). The retries burned the remaining budget and the run aborted on pydantic-ai's default `request_limit=50`.

`workspace_edit_file` EditErrors are not new — 1–7 a day for the past week. This is the first run they killed outright.

### Why the model stayed in the loop

Two reinforcing causes:

1. **The prompt told it the injected copy was authoritative.** `instructions.py` said "Don't `workspace_read` it; its contents are already injected". That's true at the start of a run, but `inject_memory()` reads `MEMORY.md` once into the (prompt-cached) system prompt — so the snapshot goes stale the instant the agent edits the file. In the failing run the first two edits succeeded; every later edit searched the pre-edit text. Successes and failures interleaved exactly as that predicts.
2. **A bare `EditError` isn't actionable.** It reports only that the search text wasn't found, so the model answered by re-guessing the indentation. The run never called `workspace_read_file` once — it alternated edits with `search_files`, which doesn't return exact leading whitespace.

### Changes

- `instructions.py` — the injected `MEMORY.md` is described as a run-start snapshot that is stale after an edit; re-read before a second edit or after a failed one. Adds a general "editing any workspace file" rule: on "text not found", re-read rather than re-guess.
- `tools/_logging.py` — `ErrorLoggingToolset` appends `_EDIT_RECOVERY_HINT` to `EditError` (only `EditError`; other `SandboxError`s are unchanged), telling the model to `workspace_read_file` the path and noting the stale-snapshot caveat for `MEMORY.md`. Log levels are untouched, so neither alert is silenced — a recurrence still fires.
- **Tool-name correction.** The prompt advertised `workspace_read` / `workspace_write` / `workspace_edit` / `workspace_delete`. None exist; the real tools are `workspace_read_file`, `workspace_write_file`, `workspace_edit_file`, `workspace_delete_file`. Plausibly why the model reached for `search_files` instead of a plain re-read. Corrected in the prompt and in `sernia_ai/README.md` per the module's `CLAUDE.md` doc-cleanup rule.
- Two tests in `test_logging_toolset.py` covering hint presence on `EditError` and absence on `PathNotInSandboxError`.

Prompt-only behavior change plus one appended string — no control flow or log-level changes. Deliberately does **not** raise `request_limit`: the budget cap is what surfaced the loop, and raising it would hide the next one.

### Testing

`pytest` — 527 passed, 5 skipped, 98 deselected. (Nine DB tests failed on a first run because Postgres stopped mid-session, the known sandbox constraint in `CLAUDE.md`; all pass after `sudo service postgresql start`.)

Preview: https://react-router-portfolio-pr-292.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165tutQsbyaYP3QCF5eSDpm)_