### PR TITLE
Break the workspace-edit retry loop that exhausts the run request limit

### DIFF
--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -115,6 +115,7 @@ The agent operates in three modalities, each with distinct behavior:
 - **HITL approval** — External SMS, emails, task deletion, contact updates/deletes, and calendar writes (create or delete) for events with external attendees require human approval. Internal-only calendar writes are not gated.
 - **Universal kill switch** — DB-backed toggle disables all automated triggers
 - **Rate limiting** — Per-source cooldowns prevent runaway trigger loops
+- **Repeat-call loop breaker** — A tool call that fails identically twice in one run gets a "STOP, change approach" instruction appended to the error, so the agent can't spend its whole request budget re-sending arguments that already failed. See [`tools/README.md`](tools/README.md#repeat-call-loop-breaker-_loggingpy)
 
 ### Memory System
 

--- a/api/src/sernia_ai/deps.py
+++ b/api/src/sernia_ai/deps.py
@@ -2,7 +2,7 @@
 Dependencies dataclass for the Sernia AI agent.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -23,3 +23,8 @@ class SerniaDeps:
     # auto-reply with `require_approval=False`). Defaults to False so every
     # other code path keeps the standard HITL gate.
     bypass_external_email_approval: bool = False
+    # Per-run tally of recoverable tool failures, keyed by a hash of
+    # (tool_name, tool_args). Maintained by ErrorLoggingToolset so it can
+    # detect a model looping on byte-identical failing arguments. Lives on
+    # deps (not a module-level cache) so the scope is exactly one agent run.
+    recoverable_tool_error_counts: dict[str, int] = field(default_factory=dict)

--- a/api/src/sernia_ai/instructions.py
+++ b/api/src/sernia_ai/instructions.py
@@ -40,8 +40,13 @@ conversations. `MEMORY.md` and a workspace filetree are auto-injected at the \
 start of every conversation.
 
 - **MEMORY.md** — proactively update when you learn something important (a \
-new property, tenant name, process, preference). Don't `workspace_read` it; \
-its contents are already injected.
+new property, tenant name, process, preference). Don't `workspace_read` it \
+up front; its contents are already injected. One exception: the injected copy \
+is a snapshot taken before your first tool call, so once you have edited \
+MEMORY.md in this run it is stale. If an edit fails with "text not found in \
+file", read the file to get its current text, then retry with search text \
+copied verbatim from what you read. Never re-send an edit whose arguments \
+already failed — it will fail the same way and burn your request budget.
 - **`/workspace/daily_notes/YYYY-MM-DD_<short-desc>.md`** — one file per \
 topic per day for ad-hoc notes.
 - **`/workspace/areas/<topic>.md`** — deep topic knowledge (properties, \

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -128,4 +128,14 @@ One-time scheduled SMS and email delivery via APScheduler date trigger.
 | `clickup_tools.py` | Task management (list, search, create, update, delete) |
 | `db_search_tools.py` | Search past agent conversations and SMS history; chronological contact SMS history |
 | `code_tools.py` | Python sandbox (pydantic-monty) for math, formatting, data manipulation |
-| `_logging.py` | Shared error logging wrapper for tool failures |
+| `_logging.py` | Shared error logging wrapper for tool failures, plus the repeat-call loop breaker (see below) |
+
+## Repeat-call loop breaker (`_logging.py`)
+
+`ErrorLoggingToolset` counts *recoverable* tool failures per run, keyed by tool name + arguments. Once the same call has failed identically `REPEAT_ERROR_THRESHOLD` (2) times, the returned error string gains a "STOP — change approach" instruction with concrete recovery steps.
+
+Why: a model that re-sends byte-identical arguments after an identical error learns nothing from the repeat, so it loops — and each attempt spends one of the run's ~50 model requests. On 2026-08-08 a scheduled check died with `UsageLimitExceeded` after seven `workspace_edit_file` EditErrors on `MEMORY.md`, four of them byte-for-byte identical. The first failure still returns the bare error (state can legitimately change between calls); only the repeat escalates.
+
+Counts live on `SerniaDeps.recoverable_tool_error_counts`, so they are scoped to one agent run — a module-level cache would leak across runs. Deps objects without the attribute simply never escalate.
+
+The matching instruction lives in `instructions.py`: MEMORY.md's injected copy is a snapshot taken before the first tool call, so after the agent edits MEMORY.md the snapshot is stale — the agent is told to re-read the file rather than guess at whitespace.

--- a/api/src/sernia_ai/tools/_logging.py
+++ b/api/src/sernia_ai/tools/_logging.py
@@ -1,6 +1,8 @@
 """Shared error-logging helpers for Sernia AI tools."""
 
 import asyncio
+import hashlib
+import json
 from collections.abc import Coroutine
 from typing import Any
 
@@ -22,6 +24,62 @@ _PASSTHROUGH_EXCEPTIONS = (ApprovalRequired, CallDeferred, ModelRetry, ToolRetry
 # failures. SandboxError is the base of all pydantic_ai_filesystem_sandbox
 # input/content errors (EditError, PathNotInSandboxError, FileTooLargeError, …).
 _RECOVERABLE_EXCEPTIONS = (SandboxError,)
+
+# How many identical failing calls (same tool, byte-identical arguments) it
+# takes before the returned error string carries extra guidance telling the
+# model to change approach.
+#
+# A model that re-sends identical arguments after an identical error is stuck:
+# the plain error string gave it no new information, so the next attempt fails
+# the same way, and each attempt spends one of the run's ~50 model requests.
+# That is how a scheduled run died with UsageLimitExceeded on 2026-08-08 —
+# seven `workspace_edit_file` EditErrors on MEMORY.md, four of them byte-for-
+# byte identical. Escalating on the SECOND identical failure still leaves one
+# free retry (state can legitimately change between calls) while cutting the
+# loop short well before the request budget runs out.
+REPEAT_ERROR_THRESHOLD = 2
+
+
+def _call_fingerprint(tool_name: str, tool_args: dict[str, Any]) -> str:
+    """Stable hash of a tool call's name + arguments."""
+    try:
+        payload = json.dumps(tool_args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        payload = repr(tool_args)
+    return hashlib.sha256(f"{tool_name}:{payload}".encode()).hexdigest()
+
+
+def _count_identical_failure(ctx: RunContext, tool_name: str, tool_args: dict[str, Any]) -> int:
+    """Record an identical failing call; return how many times it has failed.
+
+    Returns 1 for the first failure of a given (tool, args) pair in this run.
+    Counts live on ``SerniaDeps.recoverable_tool_error_counts`` so their scope
+    is exactly one agent run — a module-level cache would leak across runs
+    (and across tests). Deps objects without the attribute never escalate.
+    """
+    counts = getattr(ctx.deps, "recoverable_tool_error_counts", None)
+    if not isinstance(counts, dict):
+        return 1
+    key = _call_fingerprint(tool_name, tool_args)
+    counts[key] = counts.get(key, 0) + 1
+    return counts[key]
+
+
+def _repeat_guidance(tool_name: str, attempts: int) -> str:
+    """Extra instruction appended once a tool call has failed identically."""
+    return (
+        f"\n\nSTOP — you have called `{tool_name}` {attempts} times with identical "
+        "arguments and it failed identically every time. Retrying the same call will "
+        "fail again, and every attempt spends part of this run's request budget. "
+        "Change approach before calling this tool again:\n"
+        "- If you are editing a file, its current contents may differ from the copy "
+        "you have in context (your own earlier edits in this run changed it, or it "
+        "was updated elsewhere). Read the file, then copy the search text verbatim "
+        "from what you just read.\n"
+        "- If the text you are searching for is genuinely gone, the edit is already "
+        "applied — move on.\n"
+        "- If you cannot make it work, say so in your response instead of retrying."
+    )
 
 
 def log_tool_error(
@@ -68,7 +126,13 @@ class ErrorLoggingToolset(WrapperToolset):
     Expected, model-recoverable errors (``_RECOVERABLE_EXCEPTIONS`` — sandbox
     file-tool errors like ``EditError``) are logged at warning level instead
     of error: the model fixes its arguments and retries, so they shouldn't
-    page like a genuine failure. The returned error string is unchanged.
+    page like a genuine failure.
+
+    Recoverable failures are also counted per run, keyed by tool name +
+    arguments. Once the same call has failed ``REPEAT_ERROR_THRESHOLD`` times
+    the error string gains a "STOP, change approach" instruction — a model
+    re-sending identical arguments learns nothing from an identical error and
+    will otherwise loop until the run's request limit is exhausted.
 
     The optional ``name`` kwarg labels the toolset for admin/debug surfaces
     (e.g. the Context tab). Pydantic-ai's stock ``label`` property bakes in
@@ -93,6 +157,9 @@ class ErrorLoggingToolset(WrapperToolset):
         except _RECOVERABLE_EXCEPTIONS as e:
             conversation_id = getattr(ctx.deps, "conversation_id", "")
             log_tool_error(name, e, conversation_id=conversation_id, level="warn")
+            attempts = _count_identical_failure(ctx, name, tool_args)
+            if attempts >= REPEAT_ERROR_THRESHOLD:
+                return f"Error in {name}: {e}{_repeat_guidance(name, attempts)}"
             return f"Error in {name}: {e}"
         except Exception as e:
             conversation_id = getattr(ctx.deps, "conversation_id", "")

--- a/api/src/tests/test_logging_toolset.py
+++ b/api/src/tests/test_logging_toolset.py
@@ -1,10 +1,14 @@
 """
-Unit tests for ErrorLoggingToolset log-level routing.
+Unit tests for ErrorLoggingToolset log-level routing and repeat-loop guidance.
 
 The wrapper catches unhandled tool exceptions and returns a friendly error
 string so the conversation continues. Expected, model-recoverable errors
 (sandbox file-tool errors) must log at WARNING level so they don't trip the
 error-level Logfire alert, while genuinely unexpected failures stay at ERROR.
+
+It also counts identical recoverable failures per run and appends a "STOP,
+change approach" instruction once a call has failed the same way twice — the
+loop that exhausted a scheduled run's request limit on 2026-08-08.
 """
 
 from unittest.mock import MagicMock, patch
@@ -26,9 +30,17 @@ class _FakeToolset:
         raise self._exc
 
 
-def _make_ctx(conversation_id: str = "conv-1"):
+def _make_ctx(conversation_id: str = "conv-1", *, track_repeats: bool = False):
+    """Fake RunContext.
+
+    ``track_repeats`` gives deps the real ``recoverable_tool_error_counts``
+    dict that ``SerniaDeps`` carries. Without it (the default) deps is a bare
+    MagicMock, mirroring a deps object that lacks the attribute — repeat
+    counting must then stay inert.
+    """
     ctx = MagicMock()
     ctx.deps.conversation_id = conversation_id
+    ctx.deps.recoverable_tool_error_counts = {} if track_repeats else MagicMock()
     return ctx
 
 
@@ -61,6 +73,93 @@ async def test_unexpected_error_logged_as_error():
     lf.exception.assert_called_once()
     lf.warn.assert_not_called()
     assert "Error in db_search_sms_history" in result
+
+
+@pytest.mark.asyncio
+async def test_identical_recoverable_failure_escalates_to_stop_guidance():
+    """A second byte-identical failing call gets "STOP" + recovery steps.
+
+    This is the loop-breaker: the first failure returns the bare error (state
+    can legitimately change between calls), the repeat tells the model to stop
+    re-sending the same arguments.
+    """
+    exc = EditError("/workspace/MEMORY.md", "text not found in file", "  - 2026-07-31 | SMS")
+    ts = ErrorLoggingToolset(_FakeToolset(exc), name="workspace")
+    ctx = _make_ctx(track_repeats=True)
+    args = {"path": "/workspace/MEMORY.md", "old_text": "  - 2026-07-31 | SMS", "new_text": ""}
+
+    with patch("api.src.sernia_ai.tools._logging.logfire"):
+        first = await ts.call_tool("workspace_edit_file", args, ctx, MagicMock())
+        second = await ts.call_tool("workspace_edit_file", dict(args), ctx, MagicMock())
+
+    assert "STOP" not in first
+    assert "STOP" in second
+    # Both still carry the underlying error so the model knows what failed.
+    assert "text not found in file" in first
+    assert "text not found in file" in second
+
+
+@pytest.mark.asyncio
+async def test_different_arguments_do_not_escalate():
+    """Retrying with *changed* arguments is legitimate — no STOP guidance."""
+    exc = EditError("/workspace/MEMORY.md", "text not found in file", "x")
+    ts = ErrorLoggingToolset(_FakeToolset(exc), name="workspace")
+    ctx = _make_ctx(track_repeats=True)
+
+    with patch("api.src.sernia_ai.tools._logging.logfire"):
+        first = await ts.call_tool("workspace_edit_file", {"old_text": "  - a"}, ctx, MagicMock())
+        second = await ts.call_tool("workspace_edit_file", {"old_text": "   - a"}, ctx, MagicMock())
+
+    assert "STOP" not in first
+    assert "STOP" not in second
+
+
+@pytest.mark.asyncio
+async def test_repeat_counts_are_scoped_to_one_run():
+    """Counts live on deps, so a fresh run starts clean."""
+    exc = EditError("/workspace/MEMORY.md", "text not found in file", "x")
+    ts = ErrorLoggingToolset(_FakeToolset(exc), name="workspace")
+    args = {"old_text": "  - a"}
+
+    with patch("api.src.sernia_ai.tools._logging.logfire"):
+        ctx_run_1 = _make_ctx(track_repeats=True)
+        await ts.call_tool("workspace_edit_file", args, ctx_run_1, MagicMock())
+        ctx_run_2 = _make_ctx(track_repeats=True)
+        first_of_run_2 = await ts.call_tool(
+            "workspace_edit_file", dict(args), ctx_run_2, MagicMock()
+        )
+
+    assert "STOP" not in first_of_run_2
+
+
+@pytest.mark.asyncio
+async def test_deps_without_counter_never_escalates():
+    """Deps lacking the attribute degrade to the old behavior, not a crash."""
+    exc = EditError("/workspace/MEMORY.md", "text not found in file", "x")
+    ts = ErrorLoggingToolset(_FakeToolset(exc), name="workspace")
+    ctx = _make_ctx()  # deps.recoverable_tool_error_counts is a MagicMock, not a dict
+
+    with patch("api.src.sernia_ai.tools._logging.logfire"):
+        for _ in range(4):
+            result = await ts.call_tool("workspace_edit_file", {"old_text": "a"}, ctx, MagicMock())
+
+    assert "STOP" not in result
+
+
+@pytest.mark.asyncio
+async def test_non_json_arguments_still_fingerprint_consistently():
+    """Arguments JSON can't encode natively still compare equal across calls."""
+    exc = EditError("/workspace/MEMORY.md", "text not found in file", "x")
+    ts = ErrorLoggingToolset(_FakeToolset(exc), name="workspace")
+    ctx = _make_ctx(track_repeats=True)
+    args = {"old_text": {1, 2, 3}}  # a set is not JSON-serializable
+
+    with patch("api.src.sernia_ai.tools._logging.logfire"):
+        first = await ts.call_tool("workspace_edit_file", args, ctx, MagicMock())
+        second = await ts.call_tool("workspace_edit_file", args, ctx, MagicMock())
+
+    assert "STOP" not in first
+    assert "STOP" in second
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

**Alert addressed:** `Error-level records (non-local)`, fired 2026-08-08 13:07Z — plus the two Logfire issues from the same run (`pydantic_ai.exceptions.UsageLimitExceeded: The next request would exceed the request_limit of 50`, fingerprints `03063da9…` and `88d265c7…`).

Preview: https://react-router-portfolio-pr-293.up.railway.app/

### What happened

The 13:00 ET scheduled check (conversation `6166109b-ff81-4147-8d84-a6e9756b8c44`) ran for ~3.5 minutes and died at 13:03:38 having spent all 50 model requests. [Trace](https://logfire-us.pydantic.dev/espo412/portfolio?q=trace_id%3D%27019fe175860aa95b1d649d21d6828066%27).

Both Logfire issues are the same event, logged twice: once on the `agent run` span, once by `run_agent_for_trigger`'s `trigger agent run failed` handler in its own trace.

The run made 11 `workspace_edit_file` calls against `/workspace/MEMORY.md` while pruning the scheduled-check ledger. Seven failed with `EditError: text not found in file`. The first two searched for the same ledger line with different leading indentation (2 spaces, then 3) — whitespace guessing. The next four were **byte-for-byte identical** to each other and failed identically each time. Interleaved with 7 `search_files` calls, that consumed the request budget.

Two things made the loop possible:

1. An identical error carries no new information, so a model re-sending identical arguments has no signal to change course — it just re-sends again.
2. `instructions.py` told the agent never to `workspace_read` MEMORY.md because its contents are injected. But the injected copy is a snapshot taken before the first tool call, so once the agent has edited MEMORY.md in that run, its context copy is stale — and it had no sanctioned way to re-sync. Guessing at whitespace was the only move left to it.

`workspace_edit_file` EditErrors are a chronic background signal (1–7/day for the last 14 days); 2026-08-08 is the first time one escalated into a failed run.

### Changes

- **`tools/_logging.py`** — `ErrorLoggingToolset` counts recoverable tool failures per run, keyed by a hash of tool name + arguments. The second identical failure returns `STOP — change approach` plus concrete recovery steps (re-read the file, or accept the edit is already applied, or say so) instead of the same bare error. The first failure is unchanged, since state can legitimately change between calls.
- **`deps.py`** — counts live on `SerniaDeps.recoverable_tool_error_counts`, so their scope is exactly one agent run. A module-level cache would leak across runs and across tests. Deps objects without the attribute never escalate.
- **`instructions.py`** — MEMORY.md's bullet now explains that the injected copy goes stale after the agent's own edits, and permits re-reading after a failed edit.
- **`tools/README.md`** — documents the loop breaker and why it exists.

Deliberately *not* raising `request_limit` (currently pydantic-ai's default 50): 50 requests is generous for a scheduled check, and raising it would buy the loop more room rather than ending it.

### Testing

Five new cases in `test_logging_toolset.py`: escalation on the identical repeat, no escalation when arguments change, counts reset across runs, deps without the counter degrade rather than crash, and non-JSON arguments still fingerprint consistently.

Full suite: 529 passed, 5 skipped. (9 DB tests failed on the first run from the known mid-session Postgres stop in Claude Code on web; they pass after `sudo service postgresql start`.)

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.