### PR TITLE
Give Sernia AI an emergency_trigger_escalation tool

### DIFF
--- a/api/src/open_phone/escalate.py
+++ b/api/src/open_phone/escalate.py
@@ -73,6 +73,13 @@ never_escalate_from_numbers = [
     "+16266125747",
 ]
 
+# Caller ID for escalation calls — tenants/team recognize this Twilio number,
+# and Emilio's/Peppino's phones allow it through Do Not Disturb.
+ESCALATE_FROM_NUMBER = "+14129001989"
+
+# Default escalation recipients, resolved from the contacts DB by slug.
+DEFAULT_ESCALATION_CONTACT_SLUGS = ["emilio", "peppino"]
+
 
 # --- Normalization function ---
 def normalize_text_for_keyword_search(text: str) -> str:
@@ -170,6 +177,97 @@ async def ai_assess_for_escalation(open_phone_event: dict, max_retries: int = 1)
     return False, f"AI assessment failed: {error_snippet}"
 
 
+async def resolve_escalation_numbers(escalate_to_numbers: list[str] | None = None) -> list[str]:
+    """Return the given numbers, or look up the default escalation contacts from the DB."""
+    if escalate_to_numbers:
+        return escalate_to_numbers
+    numbers: list[str] = []
+    for slug in DEFAULT_ESCALATION_CONTACT_SLUGS:
+        contact = await get_contact_by_slug(slug)
+        if contact and contact.phone_number:
+            numbers.append(contact.phone_number)
+        else:
+            logfire.error(f"Escalation contact '{slug}' not found or has no phone number")
+    return numbers
+
+
+@logfire.instrument()
+async def trigger_twilio_escalation(
+    message_text: str,
+    escalate_to_numbers: list[str] | None = None,
+    mock: bool = False,
+) -> int:
+    """
+    Trigger the Twilio Studio Flow escalation — a call from ESCALATE_FROM_NUMBER
+    (which bypasses Do Not Disturb) to each escalation number.
+
+    Returns the number of successful flow executions.
+    """
+    escalate_to_numbers = await resolve_escalation_numbers(escalate_to_numbers)
+    if not escalate_to_numbers:
+        logfire.error("No escalation contacts found, cannot escalate")
+        return 0
+
+    successful_escalations = 0
+    incident_id = random.randint(100, 999)
+
+    # Add incident ID to the message text
+    if message_text:
+        message_text += f"\nIncident ID: {incident_id}"
+    else:
+        message_text = f"Escalation Triggered\nIncident ID: {incident_id}"
+
+    logfire.info(
+        f"Escalation triggered. INCIDENT_ID: {incident_id} to numbers {escalate_to_numbers}"
+    )
+    try:
+        # Construct the API URL
+        studio_api_url = f"https://studio.twilio.com/v2/Flows/{TWILIO_FLOW_ID}/Executions"
+
+        for escalate_to_number in escalate_to_numbers:
+            # Prepare the payload
+            payload = {
+                "To": escalate_to_number,
+                "From": ESCALATE_FROM_NUMBER,
+                "Parameters": json.dumps(
+                    {"message_text": message_text}
+                ),  # Parameters must be a JSON string
+            }
+
+            if mock:
+                result_message = f"Mocking Twilio escalation to {escalate_to_number} with message: {message_text}"
+                logfire.info(result_message)
+                successful_escalations += 1
+            else:
+                # Make the request using Basic Auth
+                response = requests.post(
+                    studio_api_url,
+                    auth=(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN),
+                    data=payload,
+                )
+                response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+
+                execution_data = response.json()
+                execution_sid = execution_data.get("sid")
+                result_message = f"Successfully created Twilio execution: {execution_sid} for INCIDENT_ID {incident_id}"
+                logfire.info(result_message)
+                successful_escalations += 1
+    except requests.exceptions.RequestException as e:
+        # Log the error, including the response text if available
+        error_message = f"Failed to create Twilio execution for INCIDENT_ID {incident_id}: {str(e)}"
+        if e.response is not None:
+            error_message += f"\nResponse status: {e.response.status_code}"
+            error_message += f"\nResponse text: {e.response.text}"
+        logfire.exception(error_message)  # exc_info=True adds traceback
+    except Exception as e:
+        # Catch any other unexpected errors during the process
+        logfire.exception(
+            f"An unexpected error occurred during Twilio escalation for INCIDENT_ID {incident_id}: {str(e)}"
+        )
+
+    return successful_escalations
+
+
 @logfire.instrument()
 async def analyze_for_twilio_escalation(
     open_phone_event: dict, escalate_to_numbers: list[str] = None, mock: bool = False
@@ -178,34 +276,12 @@ async def analyze_for_twilio_escalation(
     Analyzes an OpenPhone event and potentially triggers a Twilio Studio Flow execution.
     """
 
-    if escalate_to_numbers is None:
-        escalate_to_numbers = []
     should_escalate = False  # default to false
-    successful_escalations = 0
 
-    incident_id = random.randint(100, 999)
     event_from_number = open_phone_event.get("from_number")
     event_message_text = open_phone_event.get("message_text")
     event_id = open_phone_event.get("event_id", "")
     logfire.info(f"AI Assessment: Analyzing for Twilio escalation. OpenPhone event_id: {event_id}")
-
-    result_message = "No result message"
-
-    # Default flow numbers, adjust as needed or make dynamic
-    escalate_from_number = ""
-
-    if len(escalate_to_numbers) == 0:
-        # Look up escalation contacts from DB instead of hardcoding phone numbers
-        escalation_slugs = ["emilio", "peppino"]
-        for slug in escalation_slugs:
-            contact = await get_contact_by_slug(slug)
-            if contact and contact.phone_number:
-                escalate_to_numbers.append(contact.phone_number)
-            else:
-                logfire.error(f"Escalation contact '{slug}' not found or has no phone number")
-        if not escalate_to_numbers:
-            logfire.error("No escalation contacts found, cannot escalate")
-            return 0
 
     # # 320-09 Escalation between 8pm and 7am
     # unit32009_numbers = ["+14124786168", "+14122280772"]
@@ -232,16 +308,9 @@ async def analyze_for_twilio_escalation(
     #     reason = f"Keyword fallback escalation triggered for event_id={event_id}"
     #     logfire.info(f"Explicit keyword escalation triggered. event_id={event_id} message_text={event_message_text}")
 
-    escalate_from_number = "+14129001989"
     event_message_text = (
         f"URGENT! {event_from_number} said: {event_message_text}"  # Prepend identifier
     )
-
-    # Add incident ID to the message text
-    if event_message_text:
-        event_message_text += f"\nIncident ID: {incident_id}"
-    else:
-        event_message_text = f"Escalation Triggered\nIncident ID: {incident_id}"
 
     # override should_escalate if the from number is in the never_escalate_from_numbers list
     if should_escalate and event_from_number in never_escalate_from_numbers:
@@ -250,58 +319,13 @@ async def analyze_for_twilio_escalation(
             f"Event from number {event_from_number} is in the never_escalate_from_numbers list, so not escalating"
         )
 
-    if should_escalate:
-        logfire.info(
-            f"Escalation triggered. INCIDENT_ID: {incident_id} for EVENT_ID {open_phone_event.get('event_id')} to numbers {escalate_to_numbers}"
-        )
-        try:
-            # Construct the API URL
-            studio_api_url = f"https://studio.twilio.com/v2/Flows/{TWILIO_FLOW_ID}/Executions"
-
-            for escalate_to_number in escalate_to_numbers:
-                # Prepare the payload
-                payload = {
-                    "To": escalate_to_number,
-                    "From": escalate_from_number,
-                    "Parameters": json.dumps(
-                        {"message_text": event_message_text}
-                    ),  # Parameters must be a JSON string
-                }
-
-                if mock:
-                    result_message = f"Mocking Twilio escalation for event {open_phone_event.get('event_id')} to {escalate_to_number} with message: {event_message_text}"
-                    logfire.info(result_message)
-                    successful_escalations += 1
-                else:
-                    # Make the request using Basic Auth
-                    response = requests.post(
-                        studio_api_url,
-                        auth=(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN),
-                        data=payload,
-                    )
-                    response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
-
-                    execution_data = response.json()
-                    execution_sid = execution_data.get("sid")
-                    result_message = f"Successfully created Twilio execution: {execution_sid} for INCIDENT_ID {incident_id} and EVENT_ID {open_phone_event.get('event_id')}"
-                    logfire.info(result_message)
-                    successful_escalations += 1
-        except requests.exceptions.RequestException as e:
-            # Log the error, including the response text if available
-            error_message = f"Failed to create Twilio execution for event {open_phone_event.get('event_id')}: {str(e)}"
-            if e.response is not None:
-                error_message += f"\nResponse status: {e.response.status_code}"
-                error_message += f"\nResponse text: {e.response.text}"
-            logfire.exception(error_message)  # exc_info=True adds traceback
-        except Exception as e:
-            # Catch any other unexpected errors during the process
-            logfire.exception(
-                f"An unexpected error occurred during Twilio escalation for event {open_phone_event.get('event_id')}: {str(e)}"
-            )
-
-    else:
+    if not should_escalate:
         logfire.debug(
             f"Event {open_phone_event.get('event_id')} (type: {open_phone_event.get('event_type')}) did not meet Twilio escalation criteria."
         )
+        return 0
 
-    return successful_escalations
+    logfire.info(f"Escalation triggered for EVENT_ID {event_id}")
+    return await trigger_twilio_escalation(
+        event_message_text, escalate_to_numbers=escalate_to_numbers, mock=mock
+    )

--- a/api/src/open_phone/escalate.py
+++ b/api/src/open_phone/escalate.py
@@ -7,11 +7,10 @@ load_dotenv(find_dotenv(".env"), override=True)
 import json
 import random
 
-import logfire
-
 # from twilio.rest import Client # removed to reduce bundle size
+import httpx
+import logfire
 import pytz
-import requests
 from fastapi import HTTPException
 from openai import OpenAI
 from pydantic import BaseModel
@@ -220,10 +219,14 @@ async def trigger_twilio_escalation(
     logfire.info(
         f"Escalation triggered. INCIDENT_ID: {incident_id} to numbers {escalate_to_numbers}"
     )
-    try:
-        # Construct the API URL
-        studio_api_url = f"https://studio.twilio.com/v2/Flows/{TWILIO_FLOW_ID}/Executions"
+    # Construct the API URL
+    studio_api_url = f"https://studio.twilio.com/v2/Flows/{TWILIO_FLOW_ID}/Executions"
 
+    # Failures are isolated per recipient: one failed execution must not
+    # suppress the escalation calls to everyone after it.
+    async with httpx.AsyncClient(
+        auth=(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN), timeout=30
+    ) as client:
         for escalate_to_number in escalate_to_numbers:
             # Prepare the payload
             payload = {
@@ -234,36 +237,33 @@ async def trigger_twilio_escalation(
                 ),  # Parameters must be a JSON string
             }
 
-            if mock:
-                result_message = f"Mocking Twilio escalation to {escalate_to_number} with message: {message_text}"
-                logfire.info(result_message)
-                successful_escalations += 1
-            else:
-                # Make the request using Basic Auth
-                response = requests.post(
-                    studio_api_url,
-                    auth=(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN),
-                    data=payload,
-                )
-                response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+            try:
+                if mock:
+                    result_message = f"Mocking Twilio escalation to {escalate_to_number} with message: {message_text}"
+                    logfire.info(result_message)
+                    successful_escalations += 1
+                else:
+                    response = await client.post(studio_api_url, data=payload)
+                    response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
 
-                execution_data = response.json()
-                execution_sid = execution_data.get("sid")
-                result_message = f"Successfully created Twilio execution: {execution_sid} for INCIDENT_ID {incident_id}"
-                logfire.info(result_message)
-                successful_escalations += 1
-    except requests.exceptions.RequestException as e:
-        # Log the error, including the response text if available
-        error_message = f"Failed to create Twilio execution for INCIDENT_ID {incident_id}: {str(e)}"
-        if e.response is not None:
-            error_message += f"\nResponse status: {e.response.status_code}"
-            error_message += f"\nResponse text: {e.response.text}"
-        logfire.exception(error_message)  # exc_info=True adds traceback
-    except Exception as e:
-        # Catch any other unexpected errors during the process
-        logfire.exception(
-            f"An unexpected error occurred during Twilio escalation for INCIDENT_ID {incident_id}: {str(e)}"
-        )
+                    execution_data = response.json()
+                    execution_sid = execution_data.get("sid")
+                    result_message = f"Successfully created Twilio execution: {execution_sid} for INCIDENT_ID {incident_id}"
+                    logfire.info(result_message)
+                    successful_escalations += 1
+            except httpx.HTTPError as e:
+                # Log the error, including the response text if available
+                error_message = f"Failed to create Twilio execution to {escalate_to_number} for INCIDENT_ID {incident_id}: {str(e)}"
+                response = getattr(e, "response", None)
+                if response is not None:
+                    error_message += f"\nResponse status: {response.status_code}"
+                    error_message += f"\nResponse text: {response.text}"
+                logfire.exception(error_message)  # exc_info=True adds traceback
+            except Exception as e:
+                # Catch any other unexpected errors during the process
+                logfire.exception(
+                    f"An unexpected error occurred during Twilio escalation to {escalate_to_number} for INCIDENT_ID {incident_id}: {str(e)}"
+                )
 
     return successful_escalations
 

--- a/api/src/sernia_ai/agent.py
+++ b/api/src/sernia_ai/agent.py
@@ -41,6 +41,7 @@ from api.src.sernia_ai.tools.clickup_tools import clickup_toolset
 from api.src.sernia_ai.tools.code_tools import code_toolset
 from api.src.sernia_ai.tools.db_search_tools import db_search_toolset
 from api.src.sernia_ai.tools.duckdb_tools import duckdb_toolset
+from api.src.sernia_ai.tools.escalation_tools import escalation_toolset
 from api.src.sernia_ai.tools.google_tools import google_toolset
 from api.src.sernia_ai.tools.quo_tools import quo_toolset
 from api.src.sernia_ai.tools.scheduling_tools import scheduling_toolset
@@ -98,6 +99,7 @@ sernia_agent = Agent(
         ErrorLoggingToolset(clickup_toolset.prefixed("clickup"), name="clickup"),
         ErrorLoggingToolset(db_search_toolset.prefixed("db"), name="db"),
         ErrorLoggingToolset(scheduling_toolset, name="scheduling"),
+        ErrorLoggingToolset(escalation_toolset.prefixed("emergency"), name="emergency"),
         ErrorLoggingToolset(code_toolset, name="code"),
         ErrorLoggingToolset(duckdb_toolset, name="duckdb"),
     ],

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -120,6 +120,20 @@ One-time scheduled SMS and email delivery via APScheduler date trigger.
 - **Job IDs** use `scheduled_sms_` / `scheduled_email_` prefixes to distinguish from system jobs.
 - **Timezone handling** — `send_at` is a naive datetime interpreted in the given `timezone` (default `America/New_York`).
 
+## Emergency Escalation (`escalation_tools.py`)
+
+| Tool | Approval | Description |
+|------|----------|-------------|
+| `trigger_escalation` | No | Trigger the Twilio Studio Flow escalation: an immediate phone call to the escalation contacts (Emilio + Peppino, resolved from the contacts DB) from the dedicated Twilio number that bypasses Do Not Disturb. Registered on the agent with the `emergency` prefix, so the model sees it as `emergency_trigger_escalation`. |
+
+Deliberately **not** behind HITL approval — the tool exists to reach a human
+immediately when nobody is watching, so an approval gate would defeat it. The
+tool docstring carries strict use criteria (fires/floods/break-ins yes;
+lockouts/outages/drips no), the message is capped at 500 chars, and every call
+logs the conversation ID + message to Logfire. The underlying flow execution is
+`trigger_twilio_escalation()` in `api/src/open_phone/escalate.py`, shared with
+the automatic SMS-webhook escalation pipeline (`analyze_for_twilio_escalation`).
+
 ## Other Tool Modules
 
 | Module | Description |

--- a/api/src/sernia_ai/tools/escalation_tools.py
+++ b/api/src/sernia_ai/tools/escalation_tools.py
@@ -1,0 +1,87 @@
+"""
+Emergency escalation tools for the Sernia AI agent.
+
+Wraps the Twilio Studio Flow escalation in ``api/src/open_phone/escalate.py``:
+a phone call from the dedicated Twilio number that Emilio's and Peppino's
+phones allow through Do Not Disturb.
+
+No HITL approval on purpose — the whole point of the tool is to reach a human
+immediately when nobody is watching the inbox. The guardrails live in the tool
+docstring (strict use criteria) plus the automatic escalation pipeline's
+existing observability (Logfire incident IDs).
+"""
+
+import logfire
+from pydantic_ai import FunctionToolset, RunContext
+
+from api.src.open_phone.escalate import trigger_twilio_escalation
+from api.src.sernia_ai.deps import SerniaDeps
+
+escalation_toolset = FunctionToolset()
+
+# Twilio Studio Flow message params are read aloud / texted — keep them short.
+MAX_ESCALATION_MESSAGE_CHARS = 500
+
+
+@escalation_toolset.tool
+async def trigger_escalation(ctx: RunContext[SerniaDeps], message: str) -> str:
+    """Trigger an EMERGENCY escalation: an immediate phone call to the Sernia
+    escalation contacts (Emilio and Peppino) from a special Twilio number that
+    bypasses Do Not Disturb, so it gets through even overnight.
+
+    Use ONLY for genuine, time-sensitive emergencies that would worsen if not
+    addressed immediately, e.g.:
+    * Water actively leaking/gushing (into walls, from ceilings, onto floors)
+    * Fire, smoke, or explosion
+    * Active break-in, burglary, or violence
+    * Gas smell / carbon monoxide alarm
+    * Active, ongoing property damage
+    * A tenant in danger
+
+    Do NOT use for anything that can wait for normal channels (use SMS/email
+    instead): lockouts, power outages, dripping faucets, chirping smoke-alarm
+    batteries, routine maintenance, or incidents already mitigated. False
+    escalations cause alarm fatigue and are worse than a slightly delayed
+    response.
+
+    Args:
+        message: Short description of the emergency (max 500 chars). Include
+            who reported it, the property/unit, and their phone number when
+            known, e.g. "Anna (320-02, +14125551234) reports water pouring
+            through her kitchen ceiling."
+
+    Returns:
+        Confirmation of how many escalation calls were placed, or an error.
+    """
+    message = message.strip()
+    if not message:
+        return "Escalation NOT triggered: message must describe the emergency."
+    if len(message) > MAX_ESCALATION_MESSAGE_CHARS:
+        return (
+            f"Escalation NOT triggered: message is {len(message)} chars "
+            f"(max {MAX_ESCALATION_MESSAGE_CHARS}). Shorten it to the essential "
+            "facts and call the tool again."
+        )
+
+    logfire.info(
+        "Sernia AI trigger_escalation called",
+        conversation_id=ctx.deps.conversation_id,
+        user_identifier=ctx.deps.user_identifier,
+        modality=ctx.deps.modality,
+        message=message,
+    )
+
+    # Identify the source so recipients know this came from the agent, not the
+    # automatic SMS-webhook pipeline.
+    message_text = f"URGENT! Sernia AI escalation: {message}"
+
+    successful_escalations = await trigger_twilio_escalation(message_text)
+    if successful_escalations == 0:
+        return (
+            "Escalation FAILED: no escalation calls could be placed. "
+            "Fall back to send_sms/email to reach Emilio and Peppino directly."
+        )
+    return (
+        f"Escalation triggered: {successful_escalations} phone call(s) placed "
+        "to the escalation contacts via the DND-bypassing Twilio line."
+    )

--- a/api/src/tests/test_escalation_tools.py
+++ b/api/src/tests/test_escalation_tools.py
@@ -1,0 +1,147 @@
+"""
+Unit tests for the emergency escalation tool (``emergency_trigger_escalation``)
+and the extracted ``trigger_twilio_escalation`` core function.
+
+No network, no DB: Twilio is exercised via ``mock=True`` or patched entirely,
+and contact resolution is patched where the default lookup would hit the DB.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv(".env"), override=False)
+
+from api.src.open_phone.escalate import trigger_twilio_escalation
+from api.src.sernia_ai.tools.escalation_tools import (
+    MAX_ESCALATION_MESSAGE_CHARS,
+    escalation_toolset,
+    trigger_escalation,
+)
+
+
+def _make_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.deps.conversation_id = "conv-1"
+    ctx.deps.user_identifier = "+14125550000"
+    ctx.deps.modality = "sms"
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# trigger_twilio_escalation (core function in api/src/open_phone/escalate.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trigger_twilio_escalation_mock_counts_each_number():
+    """With explicit numbers and mock=True, one execution per number, no network."""
+    count = await trigger_twilio_escalation(
+        "test emergency",
+        escalate_to_numbers=["+14123703550", "+14125551234"],
+        mock=True,
+    )
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_trigger_twilio_escalation_no_contacts_returns_zero():
+    """When the default contact lookup yields nothing, no executions are attempted."""
+    with patch(
+        "api.src.open_phone.escalate.get_contact_by_slug",
+        AsyncMock(return_value=None),
+    ):
+        count = await trigger_twilio_escalation("test emergency", mock=True)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_trigger_twilio_escalation_resolves_default_contacts():
+    """With no explicit numbers, emilio + peppino are resolved from the DB."""
+    contact = MagicMock()
+    contact.phone_number = "+14123703550"
+    with patch(
+        "api.src.open_phone.escalate.get_contact_by_slug",
+        AsyncMock(return_value=contact),
+    ) as lookup:
+        count = await trigger_twilio_escalation("test emergency", mock=True)
+    assert count == 2  # one per slug (emilio, peppino)
+    assert {c.args[0] for c in lookup.call_args_list} == {"emilio", "peppino"}
+
+
+# ---------------------------------------------------------------------------
+# trigger_escalation (agent tool in api/src/sernia_ai/tools/escalation_tools.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_triggers_and_reports_success():
+    with patch(
+        "api.src.sernia_ai.tools.escalation_tools.trigger_twilio_escalation",
+        AsyncMock(return_value=2),
+    ) as trigger:
+        result = await trigger_escalation(
+            _make_ctx(), "Anna (320-02) reports water pouring through her ceiling"
+        )
+
+    assert "Escalation triggered: 2 phone call(s)" in result
+    # The agent's message is prefixed so recipients know the source.
+    sent_message = trigger.call_args.args[0]
+    assert sent_message.startswith("URGENT! Sernia AI escalation: ")
+    assert "water pouring" in sent_message
+
+
+@pytest.mark.asyncio
+async def test_tool_reports_failure_when_no_calls_placed():
+    with patch(
+        "api.src.sernia_ai.tools.escalation_tools.trigger_twilio_escalation",
+        AsyncMock(return_value=0),
+    ):
+        result = await trigger_escalation(_make_ctx(), "fire in the building")
+
+    assert "Escalation FAILED" in result
+    assert "send_sms" in result  # tells the model the fallback path
+
+
+@pytest.mark.asyncio
+async def test_tool_rejects_empty_message_without_calling_twilio():
+    with patch(
+        "api.src.sernia_ai.tools.escalation_tools.trigger_twilio_escalation",
+        AsyncMock(),
+    ) as trigger:
+        result = await trigger_escalation(_make_ctx(), "   ")
+
+    trigger.assert_not_called()
+    assert "NOT triggered" in result
+
+
+@pytest.mark.asyncio
+async def test_tool_rejects_overlong_message_without_calling_twilio():
+    with patch(
+        "api.src.sernia_ai.tools.escalation_tools.trigger_twilio_escalation",
+        AsyncMock(),
+    ) as trigger:
+        result = await trigger_escalation(_make_ctx(), "x" * (MAX_ESCALATION_MESSAGE_CHARS + 1))
+
+    trigger.assert_not_called()
+    assert "NOT triggered" in result
+    assert "Shorten" in result
+
+
+# ---------------------------------------------------------------------------
+# Agent wiring
+# ---------------------------------------------------------------------------
+
+
+def test_toolset_exposes_trigger_escalation():
+    assert "trigger_escalation" in escalation_toolset.tools
+
+
+def test_agent_registers_emergency_toolset():
+    """The agent carries the escalation toolset under the `emergency` prefix,
+    so the model sees the tool as `emergency_trigger_escalation`."""
+    from api.src.sernia_ai.agent import sernia_agent
+
+    named = {getattr(ts, "name", None) for ts in sernia_agent.toolsets}
+    assert "emergency" in named

--- a/api/src/tests/test_escalation_tools.py
+++ b/api/src/tests/test_escalation_tools.py
@@ -46,6 +46,40 @@ async def test_trigger_twilio_escalation_mock_counts_each_number():
 
 
 @pytest.mark.asyncio
+async def test_trigger_twilio_escalation_isolates_per_recipient_failures():
+    """A failed Twilio execution for one recipient must not suppress the rest."""
+    import httpx
+
+    resp_fail = MagicMock()
+    resp_fail.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500",
+        request=MagicMock(),
+        response=MagicMock(status_code=500, text="twilio down"),
+    )
+    resp_ok = MagicMock()
+    resp_ok.raise_for_status.return_value = None
+    resp_ok.json.return_value = {"sid": "FN123"}
+
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=[resp_fail, resp_ok])
+    async_client_cm = MagicMock()
+    async_client_cm.__aenter__ = AsyncMock(return_value=client)
+    async_client_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "api.src.open_phone.escalate.httpx.AsyncClient",
+        MagicMock(return_value=async_client_cm),
+    ):
+        count = await trigger_twilio_escalation(
+            "test emergency",
+            escalate_to_numbers=["+14123703550", "+14125551234"],
+        )
+
+    assert client.post.await_count == 2  # second recipient still attempted
+    assert count == 1  # only the successful execution is counted
+
+
+@pytest.mark.asyncio
 async def test_trigger_twilio_escalation_no_contacts_returns_zero():
     """When the default contact lookup yields nothing, no executions are attempted."""
     with patch(

--- a/apps/sernia_mcp/TODOS.md
+++ b/apps/sernia_mcp/TODOS.md
@@ -236,6 +236,7 @@ ChatGPT) explicitly needs one of these.
 | `code_tools.py` | `run_python` | Heavy `pydantic-monty` dep + RestrictedPython sandbox; trust model is murkier when the caller is a remote MCP client. |
 | `data_export.py` + `duckdb_tools.py` | `list_datasets`, `load_dataset`, `describe_table`, `run_sql` | Per-conversation CSV storage; MCP is stateless across requests. Remote clients can do data analysis themselves. |
 | `scheduling_tools.py` | `schedule_sms`, `schedule_email`, `list_scheduled_messages`, `cancel_scheduled_message` | Needs APScheduler with persistent jobstore (DB-backed); not worth standing up on MCP. |
+| `escalation_tools.py` | `emergency_trigger_escalation` | Places DND-bypassing Twilio calls with no HITL gate — exactly the kind of destructive primitive a remote MCP client should never hold. Needs the contacts DB + Twilio creds anyway. |
 
 ---
 


### PR DESCRIPTION
## Description

Gives the Sernia AI agent a tool to trigger an emergency escalation — the Twilio Studio Flow call from `+14129001989` (the special Twilio number that bypasses Do Not Disturb), previously only reachable through the automatic SMS-webhook pipeline in `api/src/open_phone/escalate.py`.

**Changes:**

- **`api/src/open_phone/escalate.py`** — extracted the flow-execution logic out of `analyze_for_twilio_escalation()` into a reusable `trigger_twilio_escalation(message_text, escalate_to_numbers=None, mock=False)`, plus `resolve_escalation_numbers()` for the default emilio/peppino contact-DB lookup. The webhook pipeline's behavior is unchanged — it now delegates to the extracted function after its AI assessment and never-escalate-list checks.
- **`api/src/sernia_ai/tools/escalation_tools.py`** (new) — `trigger_escalation` agent tool wrapping the extracted function. Registered on the agent with the `emergency` prefix, so the model sees it as **`emergency_trigger_escalation`**. Deliberately no HITL approval (the point is to reach a human immediately, e.g. overnight); guardrails instead: strict docstring use criteria mirroring the escalation pipeline's do/don't examples, empty-message rejection, 500-char message cap, `URGENT! Sernia AI escalation:` source prefix, and Logfire logging of conversation ID + message on every call.
- **`api/src/sernia_ai/agent.py`** — registers the toolset.
- **`api/src/tests/test_escalation_tools.py`** (new) — 9 non-live tests: mock-mode flow execution, default-contact resolution, no-contact failure, tool success/failure strings, empty/overlong message rejection, and agent wiring. All pass, along with the existing `test_open_phone_service.py` escalation tests and `test_triggers.py`.
- Docs: `tools/README.md` section + `apps/sernia_mcp/TODOS.md` inventory row (this tool intentionally stays off the remote MCP surface).

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yisyeu128dMxSMAkAu2i9

---
_Generated by [Claude Code](https://claude.ai/code/session_017yisyeu128dMxSMAkAu2i9)_