### PR TITLE
Fetch ClickUp maintenance field options live instead of hardcoding them

### DIFF
--- a/api/src/sernia_ai/tools/clickup_tools.py
+++ b/api/src/sernia_ai/tools/clickup_tools.py
@@ -7,6 +7,7 @@ automated triggers (e.g. SMS → maintenance task) can operate autonomously.
 """
 
 import os
+import time
 from datetime import datetime
 
 import httpx
@@ -406,79 +407,39 @@ async def delete_task(
 
 
 # ---------------------------------------------------------------------------
-# Maintenance list custom fields — IDs and dropdown option mappings
+# Maintenance list custom fields — fetched live from ClickUp
 # ---------------------------------------------------------------------------
+#
+# These used to be a hardcoded dict. The field IDs in it were real, but every
+# drop_down `options` map was placeholder data (fake option IDs like
+# "opt-req-plumbing", and labels for properties/units that don't exist). The
+# agent passed those straight through to ClickUp, which rejected every
+# drop_down write with HTTP 400 FIELD_011 "Value must be an option index or
+# uuid". Fetching from the API instead means the option UUIDs are always real
+# and survive anyone editing the field options in the ClickUp UI.
 
-MAINTENANCE_CUSTOM_FIELDS: dict[str, dict] = {
-    "property_address": {
-        "id": "56c7f3d6-9cac-4e41-8be4-4c91b057fcfa",
-        "type": "drop_down",
-        "options": {
-            "639 South St, Philadelphia": "68dd9fac-f39b-4b73-8a4a-e8f5fbb1e76e",
-            "641 South St, Philadelphia": "1b88a5b7-e81f-4c3e-9bd4-c1b6e0b3b4a1",
-        },
-    },
-    "unit_number": {
-        "id": "de9c3009-1dc7-40eb-9bab-b3c48058355b",
-        "type": "drop_down",
-        "options": {
-            "1F": "a1b2c3d4-0001-4000-8000-000000000001",
-            "1R": "a1b2c3d4-0001-4000-8000-000000000002",
-            "2F": "a1b2c3d4-0001-4000-8000-000000000003",
-            "2R": "a1b2c3d4-0001-4000-8000-000000000004",
-            "3F": "a1b2c3d4-0001-4000-8000-000000000005",
-            "3R": "a1b2c3d4-0001-4000-8000-000000000006",
-            "BSMT": "a1b2c3d4-0001-4000-8000-000000000007",
-        },
-    },
-    "name": {
-        "id": "73199851-a57f-415b-ac3b-ae06dc7281d0",
-        "type": "short_text",
-    },
-    "phone": {
-        "id": "bf426280-c78e-41d7-a2a3-0683e0d597d6",
-        "type": "phone",
-    },
-    "email": {
-        "id": "1a5e7e1b-abc8-4f8c-9837-57e4b233e3a5",
-        "type": "email",
-    },
-    "request_type": {
-        "id": "dd9ef413-9d3a-4454-b05f-defd9acfeab9",
-        "type": "drop_down",
-        "options": {
-            "Plumbing": "opt-req-plumbing",
-            "Electrical": "opt-req-electrical",
-            "HVAC": "opt-req-hvac",
-            "Appliance": "opt-req-appliance",
-            "Pest Control": "opt-req-pest",
-            "General": "opt-req-general",
-            "Other": "opt-req-other",
-        },
-    },
-    "permission_to_enter": {
-        "id": "a06fd20c-c006-4a84-9e90-4705ff13446a",
-        "type": "drop_down",
-        "options": {
-            "Yes": "opt-pte-yes",
-            "No": "opt-pte-no",
-            "Not specified": "opt-pte-unspecified",
-        },
-    },
-    "pets_on_property": {
-        "id": "ec310d23-b2ee-4a75-b853-a542a17dd59c",
-        "type": "drop_down",
-        "options": {
-            "Yes": "opt-pets-yes",
-            "No": "opt-pets-no",
-            "Unknown": "opt-pets-unknown",
-        },
-    },
-    "description": {
-        "id": "4f52c17f-6d76-4d5b-81fa-286c5c6980b3",
-        "type": "text",
-    },
-}
+MAINTENANCE_FIELD_CACHE_TTL_SECONDS = 300
+_maintenance_fields_cache: tuple[float, str] | None = None
+
+
+def _format_custom_fields(fields: list[dict]) -> str:
+    """Render ClickUp's custom-field payload as an agent-readable reference."""
+    lines: list[str] = [
+        f"Maintenance list ID: {CLICKUP_MAINTENANCE_LIST_ID}",
+        "",
+    ]
+    for field in fields:
+        lines.append(
+            f"**{field.get('name', '(unnamed)')}** "
+            f"(id: {field.get('id')}, type: {field.get('type')})"
+        )
+        options = (field.get("type_config") or {}).get("options") or []
+        for option in options:
+            # drop_down options carry "name"; labels-type fields carry "label".
+            label = option.get("name") or option.get("label") or "(unnamed)"
+            lines.append(f"  - {label} → {option.get('id')}")
+        lines.append("")
+    return "\n".join(lines)
 
 
 @clickup_toolset.tool
@@ -489,18 +450,24 @@ async def get_maintenance_field_options(ctx: RunContext[SerniaDeps]) -> str:
     maintenance tasks. For drop_down fields, the value you pass must be the
     option **UUID**, not the label.
 
+    Fetched live from ClickUp (cached briefly), so the option UUIDs always
+    match the current field configuration.
+
     Returns:
         A formatted reference of field names, IDs, types, and option mappings.
     """
-    lines: list[str] = [
-        f"Maintenance list ID: {CLICKUP_MAINTENANCE_LIST_ID}",
-        "",
-    ]
-    for field_name, field_def in MAINTENANCE_CUSTOM_FIELDS.items():
-        lines.append(f"**{field_name}** (id: {field_def['id']}, type: {field_def['type']})")
-        options = field_def.get("options")
-        if options:
-            for label, uuid_val in options.items():
-                lines.append(f"  - {label} → {uuid_val}")
-        lines.append("")
-    return "\n".join(lines)
+    global _maintenance_fields_cache
+
+    if _maintenance_fields_cache is not None:
+        cached_at, cached_text = _maintenance_fields_cache
+        if time.monotonic() - cached_at < MAINTENANCE_FIELD_CACHE_TTL_SECONDS:
+            return cached_text
+
+    resp = await _clickup_request("GET", f"/list/{CLICKUP_MAINTENANCE_LIST_ID}/field")
+    if resp.status_code != 200:
+        # Don't cache failures — the next call should retry.
+        return f"ClickUp API error (HTTP {resp.status_code}): {resp.text[:300]}"
+
+    rendered = _format_custom_fields(resp.json().get("fields", []))
+    _maintenance_fields_cache = (time.monotonic(), rendered)
+    return rendered

--- a/api/src/tests/test_clickup_maintenance_fields.py
+++ b/api/src/tests/test_clickup_maintenance_fields.py
@@ -1,0 +1,136 @@
+"""Unit tests for the ClickUp maintenance custom-field reference.
+
+The maintenance field options used to be a hardcoded dict whose drop_down
+option IDs were placeholder strings ("opt-req-plumbing", "a1b2c3d4-0001-...").
+The agent read them from ``get_maintenance_field_options`` and passed them to
+``set_task_custom_field``, so every drop_down write came back HTTP 400
+``FIELD_011 Value must be an option index or uuid``. These tests pin the
+replacement behavior: options are fetched from ClickUp, cached briefly, and
+failures are not cached.
+
+No network — the shared ``_clickup_request`` helper is patched.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import api.src.sernia_ai.tools.clickup_tools as clickup_tools
+from api.src.sernia_ai.tools.clickup_tools import (
+    _format_custom_fields,
+    get_maintenance_field_options,
+)
+
+FIELDS_PAYLOAD = {
+    "fields": [
+        {
+            "id": "56c7f3d6-9cac-4e41-8be4-4c91b057fcfa",
+            "name": "Property Address",
+            "type": "drop_down",
+            "type_config": {
+                "options": [
+                    {"id": "b45526fd-f602-458d-9f51-620e837dec02", "name": "320 S Mathilda St"},
+                    {"id": "a27ec554-e1e3-4819-838a-f34fe84d866c", "name": "324 S Mathilda St"},
+                ]
+            },
+        },
+        {
+            "id": "bf426280-c78e-41d7-a2a3-0683e0d597d6",
+            "name": "Phone",
+            "type": "phone",
+            "type_config": {},
+        },
+    ]
+}
+
+
+def _ok_resp(payload: dict) -> MagicMock:
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def clear_field_cache():
+    """The rendered reference is module-cached — reset around each test."""
+    clickup_tools._maintenance_fields_cache = None
+    yield
+    clickup_tools._maintenance_fields_cache = None
+
+
+class TestFormatCustomFields:
+    def test_renders_label_to_option_uuid(self):
+        out = _format_custom_fields(FIELDS_PAYLOAD["fields"])
+
+        assert "320 S Mathilda St → b45526fd-f602-458d-9f51-620e837dec02" in out
+        assert "324 S Mathilda St → a27ec554-e1e3-4819-838a-f34fe84d866c" in out
+
+    def test_renders_field_id_and_type(self):
+        out = _format_custom_fields(FIELDS_PAYLOAD["fields"])
+
+        assert (
+            "**Property Address** (id: 56c7f3d6-9cac-4e41-8be4-4c91b057fcfa, type: drop_down)"
+            in out
+        )
+        assert "**Phone** (id: bf426280-c78e-41d7-a2a3-0683e0d597d6, type: phone)" in out
+
+    def test_handles_labels_type_options(self):
+        """`labels` fields carry "label" instead of "name"."""
+        fields = [
+            {
+                "id": "f1",
+                "name": "Tags",
+                "type": "labels",
+                "type_config": {"options": [{"id": "o1", "label": "Urgent"}]},
+            }
+        ]
+
+        assert "Urgent → o1" in _format_custom_fields(fields)
+
+    def test_tolerates_missing_type_config(self):
+        fields = [{"id": "f1", "name": "Notes", "type": "text"}]
+
+        assert "**Notes** (id: f1, type: text)" in _format_custom_fields(fields)
+
+
+class TestGetMaintenanceFieldOptions:
+    @pytest.mark.asyncio
+    async def test_fetches_options_from_clickup(self):
+        fake = AsyncMock(return_value=_ok_resp(FIELDS_PAYLOAD))
+        with patch.object(clickup_tools, "_clickup_request", fake):
+            out = await get_maintenance_field_options(MagicMock())
+
+        args, _ = fake.await_args
+        assert args[0] == "GET"
+        assert args[1].endswith("/field")
+        assert "320 S Mathilda St → b45526fd-f602-458d-9f51-620e837dec02" in out
+
+    @pytest.mark.asyncio
+    async def test_no_placeholder_option_ids_remain(self):
+        """Regression guard for the FIELD_011 bug — the fabricated IDs are gone."""
+        fake = AsyncMock(return_value=_ok_resp(FIELDS_PAYLOAD))
+        with patch.object(clickup_tools, "_clickup_request", fake):
+            out = await get_maintenance_field_options(MagicMock())
+
+        assert "opt-req-" not in out
+        assert "opt-pte-" not in out
+        assert "a1b2c3d4-0001-4000-8000-" not in out
+
+    @pytest.mark.asyncio
+    async def test_second_call_uses_cache(self):
+        fake = AsyncMock(return_value=_ok_resp(FIELDS_PAYLOAD))
+        with patch.object(clickup_tools, "_clickup_request", fake):
+            first = await get_maintenance_field_options(MagicMock())
+            second = await get_maintenance_field_options(MagicMock())
+
+        assert first == second
+        assert fake.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_returns_error_string_and_is_not_cached(self):
+        bad = AsyncMock(return_value=MagicMock(status_code=401, text="token invalid"))
+        with patch.object(clickup_tools, "_clickup_request", bad):
+            out = await get_maintenance_field_options(MagicMock())
+
+        assert "ClickUp API error (HTTP 401)" in out
+        assert clickup_tools._maintenance_fields_cache is None

--- a/apps/sernia_mcp/src/sernia_mcp/core/clickup/reads.py
+++ b/apps/sernia_mcp/src/sernia_mcp/core/clickup/reads.py
@@ -1,13 +1,15 @@
 """Read-only ClickUp tools — list browsing, list/view tasks, custom-field reference.
 
 Lifted from ``api/src/sernia_ai/tools/clickup_tools.py``. The maintenance
-custom-field map is hardcoded here (same values as sernia_ai); if Quo or
-ClickUp ever rotates these UUIDs, both copies need updating until the
-sernia_ai → sernia_mcp migration completes (see ``apps/sernia_mcp/TODOS.md``).
+custom-field reference is fetched live from ClickUp in both copies, so
+rotating a field's options in the ClickUp UI needs no code change. The two
+implementations stay duplicated until the sernia_ai → sernia_mcp migration
+completes (see ``apps/sernia_mcp/TODOS.md``).
 """
 
 from __future__ import annotations
 
+import time
 from datetime import datetime
 
 from sernia_mcp.config import (
@@ -115,97 +117,62 @@ async def get_tasks_core(list_or_view_id: str | None = None) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Maintenance custom fields — hardcoded UUID reference
+# Maintenance custom fields — fetched live from ClickUp
 # ---------------------------------------------------------------------------
+#
+# These used to be a hardcoded dict. The field IDs in it were real, but every
+# drop_down ``options`` map was placeholder data (fake option IDs like
+# "opt-req-plumbing", and labels for properties/units that don't exist). The
+# agent passed those straight through to ClickUp, which rejected every
+# drop_down write with HTTP 400 FIELD_011 "Value must be an option index or
+# uuid". Fetching from the API instead means the option UUIDs are always real
+# and survive anyone editing the field options in the ClickUp UI.
 
-MAINTENANCE_CUSTOM_FIELDS: dict[str, dict] = {
-    "property_address": {
-        "id": "56c7f3d6-9cac-4e41-8be4-4c91b057fcfa",
-        "type": "drop_down",
-        "options": {
-            "639 South St, Philadelphia": "68dd9fac-f39b-4b73-8a4a-e8f5fbb1e76e",
-            "641 South St, Philadelphia": "1b88a5b7-e81f-4c3e-9bd4-c1b6e0b3b4a1",
-        },
-    },
-    "unit_number": {
-        "id": "de9c3009-1dc7-40eb-9bab-b3c48058355b",
-        "type": "drop_down",
-        "options": {
-            "1F": "a1b2c3d4-0001-4000-8000-000000000001",
-            "1R": "a1b2c3d4-0001-4000-8000-000000000002",
-            "2F": "a1b2c3d4-0001-4000-8000-000000000003",
-            "2R": "a1b2c3d4-0001-4000-8000-000000000004",
-            "3F": "a1b2c3d4-0001-4000-8000-000000000005",
-            "3R": "a1b2c3d4-0001-4000-8000-000000000006",
-            "BSMT": "a1b2c3d4-0001-4000-8000-000000000007",
-        },
-    },
-    "name": {
-        "id": "73199851-a57f-415b-ac3b-ae06dc7281d0",
-        "type": "short_text",
-    },
-    "phone": {
-        "id": "bf426280-c78e-41d7-a2a3-0683e0d597d6",
-        "type": "phone",
-    },
-    "email": {
-        "id": "1a5e7e1b-abc8-4f8c-9837-57e4b233e3a5",
-        "type": "email",
-    },
-    "request_type": {
-        "id": "dd9ef413-9d3a-4454-b05f-defd9acfeab9",
-        "type": "drop_down",
-        "options": {
-            "Plumbing": "opt-req-plumbing",
-            "Electrical": "opt-req-electrical",
-            "HVAC": "opt-req-hvac",
-            "Appliance": "opt-req-appliance",
-            "Pest Control": "opt-req-pest",
-            "General": "opt-req-general",
-            "Other": "opt-req-other",
-        },
-    },
-    "permission_to_enter": {
-        "id": "a06fd20c-c006-4a84-9e90-4705ff13446a",
-        "type": "drop_down",
-        "options": {
-            "Yes": "opt-pte-yes",
-            "No": "opt-pte-no",
-            "Not specified": "opt-pte-unspecified",
-        },
-    },
-    "pets_on_property": {
-        "id": "ec310d23-b2ee-4a75-b853-a542a17dd59c",
-        "type": "drop_down",
-        "options": {
-            "Yes": "opt-pets-yes",
-            "No": "opt-pets-no",
-            "Unknown": "opt-pets-unknown",
-        },
-    },
-    "description": {
-        "id": "4f52c17f-6d76-4d5b-81fa-286c5c6980b3",
-        "type": "text",
-    },
-}
+MAINTENANCE_FIELD_CACHE_TTL_SECONDS = 300
+_maintenance_fields_cache: tuple[float, str] | None = None
+
+
+def _format_custom_fields(fields: list[dict]) -> str:
+    """Render ClickUp's custom-field payload as an agent-readable reference."""
+    lines: list[str] = [
+        f"Maintenance list ID: {CLICKUP_MAINTENANCE_LIST_ID}",
+        "",
+    ]
+    for field in fields:
+        lines.append(
+            f"**{field.get('name', '(unnamed)')}** "
+            f"(id: {field.get('id')}, type: {field.get('type')})"
+        )
+        options = (field.get("type_config") or {}).get("options") or []
+        for option in options:
+            # drop_down options carry "name"; labels-type fields carry "label".
+            label = option.get("name") or option.get("label") or "(unnamed)"
+            lines.append(f"  - {label} → {option.get('id')}")
+        lines.append("")
+    return "\n".join(lines)
 
 
 async def get_maintenance_field_options_core() -> str:
     """Return the maintenance list's custom-field IDs and dropdown UUIDs.
 
-    Pure formatter — no API call. Pairs with ``clickup_create_task`` /
-    ``clickup_set_task_custom_field``: drop_down values must be the option
-    UUID, not the human label.
+    Fetched live from ClickUp and cached briefly. Pairs with
+    ``clickup_create_task`` / ``clickup_set_task_custom_field``: drop_down
+    values must be the option UUID, not the human label.
     """
-    lines: list[str] = [
-        f"Maintenance list ID: {CLICKUP_MAINTENANCE_LIST_ID}",
-        "",
-    ]
-    for field_name, field_def in MAINTENANCE_CUSTOM_FIELDS.items():
-        lines.append(f"**{field_name}** (id: {field_def['id']}, type: {field_def['type']})")
-        options = field_def.get("options")
-        if options:
-            for label, uuid_val in options.items():
-                lines.append(f"  - {label} → {uuid_val}")
-        lines.append("")
-    return "\n".join(lines)
+    global _maintenance_fields_cache
+
+    if _maintenance_fields_cache is not None:
+        cached_at, cached_text = _maintenance_fields_cache
+        if time.monotonic() - cached_at < MAINTENANCE_FIELD_CACHE_TTL_SECONDS:
+            return cached_text
+
+    resp = await clickup_request("GET", f"/list/{CLICKUP_MAINTENANCE_LIST_ID}/field")
+    if resp.status_code != 200:
+        # Don't cache failures — the next call should retry.
+        raise ExternalServiceError(
+            f"ClickUp API HTTP {resp.status_code} fetching custom fields: {resp.text[:200]}"
+        )
+
+    rendered = _format_custom_fields(resp.json().get("fields", []))
+    _maintenance_fields_cache = (time.monotonic(), rendered)
+    return rendered

--- a/apps/sernia_mcp/src/sernia_mcp/tools/clickup.py
+++ b/apps/sernia_mcp/src/sernia_mcp/tools/clickup.py
@@ -198,7 +198,8 @@ async def clickup_get_maintenance_field_options() -> str:
     Use this before calling ``clickup_create_task`` or
     ``clickup_set_task_custom_field`` on the maintenance list — drop_down
     custom-field values must be the option UUID, not the human label.
-    Pure formatter; no API call.
+    Fetched live from ClickUp (cached briefly), so the UUIDs always match
+    the current field configuration.
     """
     try:
         return await get_maintenance_field_options_core()

--- a/apps/sernia_mcp/tests/test_easy_lifts.py
+++ b/apps/sernia_mcp/tests/test_easy_lifts.py
@@ -7,7 +7,7 @@ Covers:
 - ``list_calendar_events_core``  — Calendar API list
 - ``list_clickup_lists_core``    — ClickUp workspace browse
 - ``get_tasks_core``             — ClickUp list/view tasks
-- ``get_maintenance_field_options_core`` — pure formatter
+- ``get_maintenance_field_options_core`` — ClickUp custom-field reference
 
 All Google calls patch the discovery-built service mock; ClickUp calls
 patch the shared ``clickup_request`` helper. No network.
@@ -418,16 +418,87 @@ async def test_get_tasks_defaults_to_configured_view_when_no_id():
     assert args[1].startswith("/view/")
 
 
+_MAINTENANCE_FIELDS_PAYLOAD = {
+    "fields": [
+        {
+            "id": "56c7f3d6-9cac-4e41-8be4-4c91b057fcfa",
+            "name": "Property Address",
+            "type": "drop_down",
+            "type_config": {
+                "options": [
+                    {"id": "b45526fd-f602-458d-9f51-620e837dec02", "name": "320 S Mathilda St"},
+                    {"id": "a27ec554-e1e3-4819-838a-f34fe84d866c", "name": "324 S Mathilda St"},
+                ]
+            },
+        },
+        {
+            "id": "bf426280-c78e-41d7-a2a3-0683e0d597d6",
+            "name": "Phone",
+            "type": "phone",
+            "type_config": {},
+        },
+    ]
+}
+
+
+@pytest.fixture
+def clear_maintenance_field_cache():
+    """The formatted reference is module-cached — reset around each test."""
+    import sernia_mcp.core.clickup.reads as reads
+
+    reads._maintenance_fields_cache = None
+    yield
+    reads._maintenance_fields_cache = None
+
+
 @pytest.mark.asyncio
-async def test_get_maintenance_field_options_returns_all_fields():
-    """Pure formatter — no API call. Verify each known field appears with
-    its UUID and dropdown options."""
-    from sernia_mcp.core.clickup.reads import get_maintenance_field_options_core
+async def test_get_maintenance_field_options_renders_live_options(clear_maintenance_field_cache):
+    """Option UUIDs come from the ClickUp API, not a hardcoded table."""
+    fake = AsyncMock(return_value=_ok_resp(_MAINTENANCE_FIELDS_PAYLOAD))
+    with patch("sernia_mcp.core.clickup.reads.clickup_request", fake):
+        from sernia_mcp.core.clickup.reads import get_maintenance_field_options_core
 
-    out = await get_maintenance_field_options_core()
+        out = await get_maintenance_field_options_core()
 
-    assert "property_address" in out
+    args, _ = fake.await_args
+    assert args[0] == "GET"
+    assert args[1].endswith("/field")
+
+    assert "Property Address" in out
     assert "drop_down" in out
-    assert "639 South St, Philadelphia" in out
-    # Key UUIDs should be present so consumers can paste them as field IDs.
+    # The real option UUID must be rendered next to its label.
+    assert "320 S Mathilda St → b45526fd-f602-458d-9f51-620e837dec02" in out
+    # Field IDs still appear so consumers can paste them as field IDs.
     assert "56c7f3d6-9cac-4e41-8be4-4c91b057fcfa" in out
+    # A non-dropdown field renders with no options beneath it.
+    assert "**Phone** (id: bf426280-c78e-41d7-a2a3-0683e0d597d6, type: phone)" in out
+
+
+@pytest.mark.asyncio
+async def test_get_maintenance_field_options_caches_between_calls(clear_maintenance_field_cache):
+    fake = AsyncMock(return_value=_ok_resp(_MAINTENANCE_FIELDS_PAYLOAD))
+    with patch("sernia_mcp.core.clickup.reads.clickup_request", fake):
+        from sernia_mcp.core.clickup.reads import get_maintenance_field_options_core
+
+        first = await get_maintenance_field_options_core()
+        second = await get_maintenance_field_options_core()
+
+    assert first == second
+    assert fake.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_maintenance_field_options_does_not_cache_failures(
+    clear_maintenance_field_cache,
+):
+    """A failed fetch must raise and leave the cache empty so the next call retries."""
+    import sernia_mcp.core.clickup.reads as reads
+    from sernia_mcp.core.errors import ExternalServiceError
+
+    bad_resp = MagicMock(status_code=401, text="token invalid")
+    bad = AsyncMock(return_value=bad_resp)
+    with patch("sernia_mcp.core.clickup.reads.clickup_request", bad):
+        with pytest.raises(ExternalServiceError):
+            await reads.get_maintenance_field_options_core()
+
+    assert reads._maintenance_fields_cache is None


### PR DESCRIPTION
## Description

Fixes the cause of the **"Error-level records (non-local)"** Logfire alert that fired at 13:07 UTC on 2026-08-12 (two ClickUp `POST .../field/...` spans at HTTP 400).

The maintenance custom-field reference was a hardcoded dict in two places. Its **field IDs were real**, but every `drop_down` `options` map was placeholder data:

| Field | Hardcoded (fake) | Actual in ClickUp |
|---|---|---|
| Request Type | `Plumbing → opt-req-plumbing`, HVAC, Electrical, … | `Maintenance Request → c7498161-…`, `Other → d610bc41-…` |
| Permission to Enter? | `Yes → opt-pte-yes` | `Yes → 4c201a6b-…` |
| Pets on Property? | `Yes → opt-pets-yes` | `Yes → 3afb4668-…` |
| Property Address | `639 / 641 South St, Philadelphia` | `320 / 324 / 332 S Mathilda St`, `659 / 665 Maryland Ave`, `5807 Elmer` |
| Unit # | `1F`, `2R`, `BSMT` → `a1b2c3d4-0001-…` | `01`–`12` → real UUIDs |

`get_maintenance_field_options` handed those to the agent as option UUIDs, so **every** drop_down write bounced with `HTTP 400 FIELD_011 "Value must be an option index or uuid"`. In the production trace the two text fields on the same task (Name, Phone) returned 200 because they accept any value, which is why only the dropdown writes failed.

The option *labels* were fabricated too, so the agent was also being told about properties that don't exist in the business.

### Change

Both copies — `api/src/sernia_ai/tools/clickup_tools.py` (the one that served the failing production run) and `apps/sernia_mcp/src/sernia_mcp/core/clickup/reads.py` — now fetch `GET /list/{list_id}/field` and render the real option UUIDs:

- Cached for 5 minutes, so repeated calls within a run cost one request.
- Failures are **not** cached, so the next call retries.
- Handles both `drop_down` (`options[].name`) and `labels` (`options[].label`) shapes, and fields with no `type_config`.
- Editing a field's options in the ClickUp UI no longer needs a code change — this also retires the "if ClickUp rotates these UUIDs, both copies need updating" caveat in the `sernia_mcp` module docstring.

### Verification

- New `api/src/tests/test_clickup_maintenance_fields.py` (8 tests): formatter output, live fetch, cache hit, uncached failure, and a regression guard asserting no `opt-req-` / `opt-pte-` / `a1b2c3d4-0001-` placeholders survive.
- Rewrote `apps/sernia_mcp/tests/test_easy_lifts.py::test_get_maintenance_field_options_*` — it previously asserted on the fabricated `639 South St, Philadelphia` value.
- Ran the real tool against production ClickUp: it now renders the true six properties, units `01`–`12`, and real option UUIDs — plus a `Pics/Attachments` field the hardcoded table omitted entirely.
- `pytest api/src/tests/` → 535 passed. `apps/sernia_mcp` → 193 passed; the 4 `test_git_sync_flow.py` failures are pre-existing on a clean checkout of `main` in this sandbox and unrelated to this change.

Preview: https://react-router-portfolio-pr-295.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mt6PfUaKptw5eZdrURmjHt)_