### PR TITLE
Add group text support via Quo API multi-recipient messages

### DIFF
--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -110,8 +110,8 @@ The agent operates in three modalities, each with distinct behavior:
 
 ### Safety Gates
 
-- **Internal/external SMS separation** — Internal phone numbers never appear in external threads
-- **Unit isolation** — Cross-unit tenant group texts blocked (see [`tools/README.md`](tools/README.md))
+- **Internal/external SMS separation** — Routing keeps internal phone numbers out of external threads; a mixed internal+external **group text** is the one deliberate exception and always requires HITL approval (see [`tools/README.md`](tools/README.md))
+- **Unit isolation** — Cross-unit tenant group texts blocked; roommates within a unit share one group thread (see [`tools/README.md`](tools/README.md))
 - **HITL approval** — External SMS, emails, task deletion, contact updates/deletes, and calendar writes (create or delete) for events with external attendees require human approval. Internal-only calendar writes are not gated.
 - **Universal kill switch** — DB-backed toggle disables all automated triggers
 - **Rate limiting** — Per-source cooldowns prevent runaway trigger loops

--- a/api/src/sernia_ai/config.py
+++ b/api/src/sernia_ai/config.py
@@ -121,6 +121,9 @@ INTERNAL_EMAIL_DOMAIN = "serniacapital.com"
 # SMS length limits — AT&T rejects messages around 670 chars.
 # Auto-split long messages into chunks at this threshold.
 SMS_SPLIT_THRESHOLD = 500
+# Group SMS: max recipients per message. Matches the Quo API's `to` array
+# limit (maxItems: 10 on POST /v1/messages) — verified live 2026-08-13.
+GROUP_SMS_MAX_RECIPIENTS = 10
 # Hard reject at the tool level — LLM must shorten the message.
 SMS_MAX_LENGTH = 1000
 

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -44,6 +44,10 @@ Routing for group sends (`resolve_group_sms_routing`):
 
 To message multiple people *privately*, the agent calls `send_sms` once per recipient instead of passing a list.
 
+> **Known limitation — replies to all-internal groups:** the AI SMS event trigger handles inbound messages on the AI line keyed by sender only (`from_number`), so a reply to an all-internal group text is loaded as the sender's 1:1 history and the AI's answer is sent back 1:1 — it does not land in the group thread. Propagating the webhook's `conversation_id`/participants through the trigger (history loading + reply send) is tracked as follow-up work. The agent is instructed to prefer 1:1 sends for conversational exchanges and reserve internal group texts for announcements.
+
+The group-conversation lookup used by the read tools (`_find_group_conversation`) searches **both** lines — the shared team number and the AI line — since all-internal groups are created on the AI line.
+
 ### Auto-Splitting
 
 Messages between 500–1000 chars are auto-split into multiple SMS at sentence/newline boundaries by `split_sms()` in `quo_tools.py`. The splitting logic tries to break at (in priority order): sentence-ending punctuation, newlines, spaces, then hard cut. This applies to all SMS paths: tool calls, AI SMS replies, and post-approval replies.

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -31,6 +31,7 @@ Every SMS goes through a chain of gates before sending:
 2. **Contact resolution** — Every recipient must exist as a Quo contact. Unknown numbers are blocked (a group send is blocked entirely if any member is unknown).
 3. **Internal/external routing** — Internal contacts use `QUO_SERNIA_AI_PHONE_ID` (AI direct line); external contacts use `QUO_SHARED_EXTERNAL_PHONE_ID` (shared team number). This prevents exposing internal phone numbers in tenant threads.
 4. **Group size** — Group texts are capped at `GROUP_SMS_MAX_RECIPIENTS` (10) unique recipients, matching the Quo API's `to` array limit on `POST /v1/messages`.
+5. **Unit isolation (group sends)** — Tenants from **different units** can never share a group thread: `resolve_group_sms_routing` reads each external recipient's `Property` / `Unit #` custom fields and hard-blocks the send when more than one distinct unit appears in the group. This gate runs **before** the approval gate, so a human approval cannot override it. Roommates in the same unit are fine; contacts without unit fields (vendors, team) don't trigger it.
 
 ### Group Texts (sending)
 
@@ -41,6 +42,9 @@ Routing for group sends (`resolve_group_sms_routing`):
 - **All internal** → AI line, no approval (team group chat).
 - **Any external** → shared team number + HITL approval.
 - **Mixed internal + external** → allowed but flagged (`is_mixed`) — sending exposes the internal members' numbers to the external recipients, so the HITL approval is the safeguard. The agent is instructed to only do this deliberately.
+- **Cross-unit tenants** → hard-blocked deterministically (gate 5 above); approval cannot override.
+
+The same group support (same tool name, same gates) is mirrored in the standalone MCP server at `apps/sernia_mcp` — `quo_send_sms` accepts `str | list[str]` with the group approval card, backed by `resolve_group_sms_routing_core` / `send_group_sms_core`.
 
 To message multiple people *privately*, the agent calls `send_sms` once per recipient instead of passing a list.
 

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -10,8 +10,8 @@ SMS and contact management via the OpenPhone API, bridged through FastMCP.
 
 | Tool | Approval | Description |
 |------|----------|-------------|
-| `send_sms` | Conditional | Unified SMS — auto-detects internal vs external. Internal (Sernia Capital LLC) → AI line, no approval. External → shared team number, requires HITL. Single phone number per call. Supports optional `context` param for reply context seeding. |
-| `mass_text_tenants` | Yes (HITL) | Send the same message to all **current** tenants in one or more properties, with optional unit filter. Defaults to active-lease tenants only (excludes leads + future/past tenants); pass `include_inactive=True` to override. Auto-groups by unit and sends one SMS per unit. |
+| `send_sms` | Conditional | Unified SMS — auto-detects internal vs external. Internal (Sernia Capital LLC) → AI line, no approval. External → shared team number, requires HITL. Takes a single phone number **or a list of 2–10 numbers for a group text** (one shared thread — see _Group Texts_ below). Supports optional `context` param for reply context seeding (seeds every recipient on group sends). |
+| `mass_text_tenants` | Yes (HITL) | Send the same message to all **current** tenants in one or more properties, with optional unit filter. Defaults to active-lease tenants only (excludes leads + future/past tenants); pass `include_inactive=True` to override. Auto-groups by unit — roommates in a unit share **one group text thread**; different units are isolated. |
 
 ### Core SMS Logic (module-level, reused by scheduling)
 
@@ -19,15 +19,30 @@ SMS and contact management via the OpenPhone API, bridged through FastMCP.
 |----------|---------|
 | `SmsRouting` | Dataclass — resolved routing (contact, phone ID, line name, is_internal) |
 | `resolve_sms_routing(phone, client)` | Resolves phone → contact, determines internal/external, selects phone ID |
-| `execute_sms(client, phone, message, ...)` | Sends a single SMS via Quo API |
+| `GroupSmsRouting` | Dataclass — resolved group routing (per-recipient routings, all_internal / has_external / is_mixed flags, phone ID, line name) |
+| `resolve_group_sms_routing(phones, client)` | Resolves a recipient list for a group text: dedupes, enforces 2–10 unique recipients, blocks non-contacts, selects the line (all-internal → AI line; any external → shared team number) |
+| `execute_sms(client, phone, message, ...)` | Sends an SMS via Quo API — `phone` may be a single number or a list (group text, one shared thread) |
 
 ### Deterministic Gates
 
 Every SMS goes through a chain of gates before sending:
 
 1. **Message length** — Messages over 1000 chars are rejected at the tool level with feedback telling the LLM to shorten/summarize. This prevents carrier rejections (AT&T rejects around 670 chars).
-2. **Contact resolution** — The recipient must exist as a Quo contact. Unknown numbers are blocked.
+2. **Contact resolution** — Every recipient must exist as a Quo contact. Unknown numbers are blocked (a group send is blocked entirely if any member is unknown).
 3. **Internal/external routing** — Internal contacts use `QUO_SERNIA_AI_PHONE_ID` (AI direct line); external contacts use `QUO_SHARED_EXTERNAL_PHONE_ID` (shared team number). This prevents exposing internal phone numbers in tenant threads.
+4. **Group size** — Group texts are capped at `GROUP_SMS_MAX_RECIPIENTS` (10) unique recipients, matching the Quo API's `to` array limit on `POST /v1/messages`.
+
+### Group Texts (sending)
+
+The Quo API supports up to **10 recipients** per `POST /v1/messages` (`to` array, spec `maxItems: 10`) — the message lands in **one shared group thread** where all recipients see each other's numbers and replies. Verified live 2026-08-13 (HTTP 202, single `conversationId`, status `delivered`).
+
+Routing for group sends (`resolve_group_sms_routing`):
+
+- **All internal** → AI line, no approval (team group chat).
+- **Any external** → shared team number + HITL approval.
+- **Mixed internal + external** → allowed but flagged (`is_mixed`) — sending exposes the internal members' numbers to the external recipients, so the HITL approval is the safeguard. The agent is instructed to only do this deliberately.
+
+To message multiple people *privately*, the agent calls `send_sms` once per recipient instead of passing a list.
 
 ### Auto-Splitting
 
@@ -41,7 +56,7 @@ Example: The agent texts Anna "Is the faucet fixed?" with `context="Emilio asked
 
 ### Mass-Texting Pattern (Per-Unit Sharding)
 
-> **Note:** The Quo (OpenPhone) API currently only supports 1 recipient per `POST /v1/messages` call. `mass_text_tenants` loops internally to send one SMS per unit. If the API expands to support multiple recipients in the future, the per-unit sharding logic (grouping by `(Property, Unit #)`) would become relevant for privacy — roommates in the same unit could share a group text, while different units must be isolated to prevent sharing contact info.
+> **Note:** The Quo API now supports multiple recipients per `POST /v1/messages` (up to 10 — see _Group Texts_ above), so the per-unit sharding delivers on its privacy purpose: roommates in the same unit share **one group text thread**, while different units are isolated so tenants never see another unit's contact info. A solo tenant still gets a plain 1:1 send; a unit with more than 10 phones (never expected) falls back to individual sends.
 
 **Use `mass_text_tenants`** for building-wide notices. It automatically:
 1. Finds matching tenants from the cached contact list by `(Property, Unit #)`
@@ -51,7 +66,7 @@ Example: The agent texts Anna "Is the faucet fixed?" with `context="Emilio asked
    Lease End Date`). This is the safe default for building-wide notices so we
    never text someone who isn't a current tenant. Pass `include_inactive=True`
    to reach non-active contacts on purpose.
-4. Groups by unit and sends one SMS per unit group
+4. Groups by unit and sends one group SMS per unit (1:1 for solo tenants)
 
 > **Active-lease filtering** is enforced in `_filter_tenants_by_property_unit`
 > via the `_has_active_lease()` helper, which reads the `Lease Start Date` /
@@ -91,7 +106,7 @@ Whenever a call appears in either tool's output, the Call ID (`AC...`) is includ
 
 ### Group Threads
 
-OpenPhone supports multi-participant conversations (e.g. two roommates sharing one Quo thread), but the public API does **not** let you list a group thread's messages by participant: `/v1/messages?participants[]=A&participants[]=B` silently filters to the 1:1 conversation with the *first* participant, regardless of how many are passed.
+OpenPhone supports multi-participant conversations (e.g. two roommates sharing one Quo thread), and **sending** into a group thread works first-class via the `to` array on `POST /v1/messages` (see _Group Texts_ above). **Reading** is the limited side: the public API does **not** let you list a group thread's messages by participant: `/v1/messages?participants[]=A&participants[]=B` silently filters to the 1:1 conversation with the *first* participant, regardless of how many are passed.
 
 > **Gotcha — send `participants`, not `participants[]`, from Python.** The bracketed form above is *curl* syntax, where the brackets go over the wire literally. httpx percent-encodes them to `participants%5B%5D`, which OpenPhone does not recognise and answers with a **400**. Every call site here uses the plain `participants` key; `test_triggers.py::TestFetchSmsThreadRequest` guards the one that regressed. The group conversation is real (it appears in `/v1/conversations`), and individual messages can be fetched by ID via `/v1/messages/{id}`, but you can't enumerate them.
 

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -862,30 +862,35 @@ async def _find_group_conversation(
 ) -> dict | None:
     """Find the OpenPhone conversation whose participants exactly match
     the given set (regardless of ordering). Returns None if none found.
-    Pages through up to 5 pages of conversations (~500) — enough for an
-    active inbox of any realistic size.
+    Pages through up to 5 pages of conversations (~500) per line — enough
+    for an active inbox of any realistic size.
+
+    Searches the shared team number first, then the AI line: all-internal
+    group texts are created on the AI line (see ``resolve_group_sms_routing``),
+    so a shared-line-only lookup would never find them.
     """
     target = frozenset(participants)
-    page_token: str | None = None
-    for _ in range(5):
-        params: list[tuple[str, str]] = [
-            ("phoneNumbers[]", QUO_SHARED_EXTERNAL_PHONE_ID),
-            ("maxResults", "100"),
-        ]
-        if page_token:
-            params.append(("pageToken", page_token))
-        try:
-            resp = await client.get("/v1/conversations", params=params)
-            resp.raise_for_status()
-        except httpx.HTTPError:
-            return None
-        data = resp.json()
-        for conv in data.get("data", []):
-            if frozenset(conv.get("participants") or []) == target:
-                return conv
-        page_token = data.get("nextPageToken")
-        if not page_token:
-            break
+    for phone_id in (QUO_SHARED_EXTERNAL_PHONE_ID, QUO_SERNIA_AI_PHONE_ID):
+        page_token: str | None = None
+        for _ in range(5):
+            params: list[tuple[str, str]] = [
+                ("phoneNumbers[]", phone_id),
+                ("maxResults", "100"),
+            ]
+            if page_token:
+                params.append(("pageToken", page_token))
+            try:
+                resp = await client.get("/v1/conversations", params=params)
+                resp.raise_for_status()
+            except httpx.HTTPError:
+                break  # try the next line rather than giving up entirely
+            data = resp.json()
+            for conv in data.get("data", []):
+                if frozenset(conv.get("participants") or []) == target:
+                    return conv
+            page_token = data.get("nextPageToken")
+            if not page_token:
+                break
     return None
 
 
@@ -1864,6 +1869,12 @@ def _build_quo_toolset():
         external recipients — only do this when that's clearly intended.
         To message multiple people SEPARATELY (private 1:1 threads), call
         this tool once per recipient instead.
+
+        Known limitation: replies to an all-internal group (sent from the
+        AI line) are currently processed by the AI SMS trigger as 1:1
+        conversations — the AI's answer goes to the replier privately, not
+        into the group thread. Prefer 1:1 sends when you expect to hold a
+        conversation; use internal group texts for announcements.
 
         Max 1000 chars — messages over this limit are rejected (shorten/summarize
         and retry). Messages over 500 chars are auto-split into multiple texts.

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -464,6 +464,29 @@ async def resolve_group_sms_routing(
             return routing
         routings.append(routing)
 
+    # Deterministic unit-isolation gate: tenants from different units must
+    # NEVER share a group thread — they would see each other's phone numbers.
+    # This blocks before the approval gate, so a human approval cannot
+    # override it. Contacts without Property/Unit fields (vendors, team) are
+    # not unit-bound and don't trigger this gate.
+    units: dict[tuple[str, str], list[str]] = {}
+    for r in routings:
+        if r.is_internal:
+            continue
+        cu = _get_contact_unit(r.contact)
+        if cu is not None:
+            units.setdefault(cu, []).append(r.contact_name)
+    if len(units) > 1:
+        desc = "; ".join(
+            f"{prop} Unit {unit}: {', '.join(names)}"
+            for (prop, unit), names in sorted(units.items())
+        )
+        return (
+            "Blocked: tenants from different units can never share a group "
+            f"thread ({desc}). Send one message per unit instead — or use "
+            "mass_text_tenants, which shards by unit automatically."
+        )
+
     all_internal = all(r.is_internal for r in routings)
     has_external = any(not r.is_internal for r in routings)
     return GroupSmsRouting(
@@ -1867,6 +1890,9 @@ def _build_quo_toolset():
         from the shared team number and requires approval. A mixed
         internal+external group exposes the internal members' numbers to the
         external recipients — only do this when that's clearly intended.
+        Tenants from DIFFERENT units are always blocked from sharing a group
+        thread (deterministic — approval cannot override); roommates in the
+        same unit are fine.
         To message multiple people SEPARATELY (private 1:1 threads), call
         this tool once per recipient instead.
 

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -14,12 +14,15 @@ replaced by custom tools:
 
 - ``send_sms``: unified SMS with conditional approval — internal contacts
   send from the AI line (no approval), external contacts from the shared
-  team number (requires HITL).
+  team number (requires HITL). Accepts a single phone or a list of 2-10
+  phones for a group text (one shared thread — supported by the Quo API's
+  ``to`` array on ``POST /v1/messages``, verified live 2026-08-13).
 - ``search_contacts``: fuzzy search against a TTL-cached contact list (avoids
   dumping 50-item pages into the context window).
 
 Core routing and sending logic (``SmsRouting``, ``resolve_sms_routing``,
-``execute_sms``) is exposed at module level for reuse by scheduling tools.
+``GroupSmsRouting``, ``resolve_group_sms_routing``, ``execute_sms``) is
+exposed at module level for reuse by scheduling tools.
 """
 
 import json
@@ -50,6 +53,7 @@ from api.src.open_phone.service import (
     invalidate_contact_cache,
 )
 from api.src.sernia_ai.config import (
+    GROUP_SMS_MAX_RECIPIENTS,
     QUO_INTERNAL_COMPANY,
     QUO_SERNIA_AI_PHONE_ID,
     QUO_SHARED_EXTERNAL_PHONE_ID,
@@ -403,9 +407,79 @@ async def resolve_sms_routing(
     )
 
 
+@dataclass
+class GroupSmsRouting:
+    """Resolved routing for a group SMS (one shared thread, 2+ recipients).
+
+    Line selection: an all-internal group sends from the AI line (no
+    approval); any group containing an external contact sends from the
+    shared team number and requires HITL approval. A mixed group
+    (internal + external members) is allowed but flagged — sending it
+    exposes the internal members' numbers to the external recipients, so
+    the HITL approval is the safeguard.
+    """
+
+    routings: list[SmsRouting]
+    phones: list[str]  # deduped, original order preserved
+    all_internal: bool
+    has_external: bool
+    is_mixed: bool
+    from_phone_id: str
+    line_name: str
+
+    @property
+    def recipient_names(self) -> list[str]:
+        return [r.contact_name for r in self.routings]
+
+
+async def resolve_group_sms_routing(
+    phones: list[str],
+    client: httpx.AsyncClient,
+    conversation_id: str = "",
+) -> GroupSmsRouting | str:
+    """Resolve a list of phone numbers to group-SMS routing parameters.
+
+    Returns GroupSmsRouting on success, or an error string when the group
+    is invalid: fewer than 2 unique recipients, more than
+    ``GROUP_SMS_MAX_RECIPIENTS`` (the Quo API's per-message ``to`` limit),
+    or any recipient that is not a Quo contact.
+    """
+    unique_phones = list(dict.fromkeys(phones))  # dedupe, keep order
+    if len(unique_phones) < 2:
+        return (
+            "Blocked: a group SMS needs at least 2 unique recipients. "
+            "For a single recipient, pass a plain phone number string."
+        )
+    if len(unique_phones) > GROUP_SMS_MAX_RECIPIENTS:
+        return (
+            f"Blocked: group SMS supports at most {GROUP_SMS_MAX_RECIPIENTS} "
+            f"recipients per message (got {len(unique_phones)}). Split into "
+            "smaller groups or use mass_text_tenants for building-wide notices."
+        )
+
+    routings: list[SmsRouting] = []
+    for phone in unique_phones:
+        routing = await resolve_sms_routing(phone, client, conversation_id)
+        if isinstance(routing, str):
+            return routing
+        routings.append(routing)
+
+    all_internal = all(r.is_internal for r in routings)
+    has_external = any(not r.is_internal for r in routings)
+    return GroupSmsRouting(
+        routings=routings,
+        phones=unique_phones,
+        all_internal=all_internal,
+        has_external=has_external,
+        is_mixed=has_external and any(r.is_internal for r in routings),
+        from_phone_id=QUO_SERNIA_AI_PHONE_ID if all_internal else QUO_SHARED_EXTERNAL_PHONE_ID,
+        line_name="Sernia AI" if all_internal else "Sernia Capital Team",
+    )
+
+
 async def execute_sms(
     client: httpx.AsyncClient,
-    phone: str,
+    phone: str | list[str],
     message: str,
     from_phone_id: str,
     line_name: str,
@@ -413,6 +487,10 @@ async def execute_sms(
     tool_name: str = "send_sms",
 ) -> str:
     """Send an SMS via Quo API, auto-splitting if over SMS_SPLIT_THRESHOLD.
+
+    ``phone`` may be a single number (1:1 thread) or a list of numbers —
+    the Quo API supports up to ``GROUP_SMS_MAX_RECIPIENTS`` recipients per
+    message, which land in one shared group thread.
 
     Public API — used by send_sms tool and scheduling executor.
     Delegates to ``_send_sms`` which handles chunking.
@@ -1637,17 +1715,17 @@ def split_sms(text: str, limit: int = SMS_SPLIT_THRESHOLD) -> list[str]:
 async def _send_single_sms(
     client: httpx.AsyncClient,
     tool_name: str,
-    phone: str,
+    recipients: list[str],
     message: str,
     from_phone_id: str,
     conversation_id: str,
 ) -> tuple[bool, str]:
-    """Send one SMS via Quo API. Returns (success, detail)."""
-    payload = {"content": message, "from": from_phone_id, "to": [phone]}
+    """Send one SMS via Quo API (1:1 or group). Returns (success, detail)."""
+    payload = {"content": message, "from": from_phone_id, "to": recipients}
     logfire.info(
         "{tool_name} request",
         tool_name=tool_name,
-        to=phone,
+        to=recipients,
         from_phone_id=from_phone_id,
         message_length=len(message),
         payload=payload,
@@ -1662,7 +1740,7 @@ async def _send_single_sms(
         logfire.info(
             "{tool_name} success",
             tool_name=tool_name,
-            to=phone,
+            to=recipients,
             status=resp.status_code,
             response_body=resp.text[:500],
         )
@@ -1681,13 +1759,18 @@ async def _send_single_sms(
 async def _send_sms(
     client: httpx.AsyncClient,
     tool_name: str,
-    phone: str,
+    phone: str | list[str],
     message: str,
     from_phone_id: str,
     line_name: str,
     conversation_id: str,
 ) -> str:
-    """Send an SMS via Quo API, auto-splitting if over SMS_SPLIT_THRESHOLD."""
+    """Send an SMS via Quo API, auto-splitting if over SMS_SPLIT_THRESHOLD.
+
+    ``phone`` may be a single number or a list — a list sends every chunk
+    to all recipients in one shared group thread.
+    """
+    recipients = [phone] if isinstance(phone, str) else list(phone)
     chunks = split_sms(message)
     if len(chunks) > 1:
         logfire.info(
@@ -1700,7 +1783,7 @@ async def _send_sms(
         ok, err = await _send_single_sms(
             client,
             tool_name,
-            phone,
+            recipients,
             chunk,
             from_phone_id,
             conversation_id,
@@ -1709,7 +1792,9 @@ async def _send_sms(
             part_info = f" (part {i + 1}/{len(chunks)})" if len(chunks) > 1 else ""
             return f"{err}{part_info}"
     parts_note = f" ({len(chunks)} parts)" if len(chunks) > 1 else ""
-    return f"Message sent to {phone} from {line_name}.{parts_note}"
+    if len(recipients) > 1:
+        return f"Group message sent to {', '.join(recipients)} from {line_name}.{parts_note}"
+    return f"Message sent to {recipients[0]} from {line_name}.{parts_note}"
 
 
 def _build_quo_toolset():
@@ -1760,26 +1845,35 @@ def _build_quo_toolset():
     @custom_toolset.tool
     async def send_sms(
         ctx: RunContext[SerniaDeps],
-        to: str,
+        to: str | list[str],
         message: str,
         context: str = "",
     ) -> str:
-        """Send an SMS to any Quo contact.
+        """Send an SMS to one Quo contact, or a GROUP text to several.
 
-        Automatically determines routing based on the recipient:
+        Automatically determines routing based on the recipient(s):
         - Internal (Sernia Capital LLC) → sends from AI direct line, no approval.
         - External (tenants, vendors) → sends from shared team number, requires approval.
 
-        To message multiple people, call this tool once per recipient.
+        **Group texts**: pass a list of 2-10 phone numbers to start ONE shared
+        thread — all recipients see the message and each other's replies (and
+        each other's phone numbers). An all-internal group sends from the AI
+        line with no approval; a group containing ANY external contact sends
+        from the shared team number and requires approval. A mixed
+        internal+external group exposes the internal members' numbers to the
+        external recipients — only do this when that's clearly intended.
+        To message multiple people SEPARATELY (private 1:1 threads), call
+        this tool once per recipient instead.
 
         Max 1000 chars — messages over this limit are rejected (shorten/summarize
         and retry). Messages over 500 chars are auto-split into multiple texts.
 
         Args:
-            to: Recipient phone number in E.164 format (e.g. "+14125551234").
+            to: Recipient phone number in E.164 format (e.g. "+14125551234"),
+                or a list of 2-10 numbers for a group text (one shared thread).
             message: The text message body to send (max 1000 chars).
             context: Optional hidden context about why this message is being sent.
-                Not included in the SMS — saved to the recipient's conversation
+                Not included in the SMS — saved to each recipient's conversation
                 history so the AI has context if they reply later.
         """
         logfire.info("send_sms called", to=to, message_length=len(message))
@@ -1791,6 +1885,55 @@ def _build_quo_toolset():
                 "Please shorten or summarize the message and try again."
             )
 
+        # Normalize: a 1-element list is just a 1:1 send.
+        if isinstance(to, list) and len(to) == 1:
+            to = to[0]
+
+        # ---- Group send path ----
+        if isinstance(to, list):
+            group = await resolve_group_sms_routing(to, client, ctx.deps.conversation_id)
+            if isinstance(group, str):
+                return group
+
+            # Conditional approval: any external recipient requires HITL.
+            if group.has_external and not ctx.tool_call_approved:
+                raise ApprovalRequired()
+
+            logfire.info(
+                "send_sms sending group",
+                to=group.phones,
+                names=group.recipient_names,
+                all_internal=group.all_internal,
+                is_mixed=group.is_mixed,
+                from_phone_id=group.from_phone_id,
+            )
+
+            send_result = await execute_sms(
+                client,
+                group.phones,
+                message,
+                group.from_phone_id,
+                group.line_name,
+                ctx.deps.conversation_id,
+            )
+
+            # Seed each recipient's AI SMS conversation with hidden context
+            if context and "Failed" not in send_result:
+                for phone in group.phones:
+                    try:
+                        await _seed_sms_conversation(phone, message, context)
+                    except Exception:
+                        logfire.exception("send_sms: failed to seed conversation", to=phone)
+
+            if send_result.startswith("Group message sent"):
+                named = ", ".join(
+                    f"{name} ({phone})"
+                    for name, phone in zip(group.recipient_names, group.phones, strict=False)
+                )
+                return f"Group message sent to {named} from {group.line_name} (one shared thread)."
+            return send_result
+
+        # ---- Single-recipient path ----
         routing = await resolve_sms_routing(to, client, ctx.deps.conversation_id)
         if isinstance(routing, str):
             return routing
@@ -1841,7 +1984,9 @@ def _build_quo_toolset():
 
         Automatically finds matching tenants from the contact list, groups
         by (Property, Unit #), and sends one SMS per unit group. Roommates
-        in the same unit share a thread; different units are isolated.
+        in the same unit share ONE group text thread (they see each other's
+        replies); different units are isolated from each other so tenants
+        never see another unit's contact info.
 
         By default this targets only tenants with a **currently-active lease**
         (Lease Start Date <= today <= Lease End Date). Leads, prospects, and
@@ -1902,27 +2047,36 @@ def _build_quo_toolset():
                 failures.append(f"{prop} Unit {unit}: no phone numbers")
                 continue
 
-            # Send to each tenant in the unit individually
+            # Roommates in a unit share one group thread; a solo tenant gets a
+            # 1:1 send. Units larger than the API's per-message recipient cap
+            # (never expected in practice) fall back to individual sends.
+            if 1 < len(phones) <= GROUP_SMS_MAX_RECIPIENTS:
+                batches: list[str | list[str]] = [phones]
+            else:
+                batches = list(phones)
+
             unit_sent = 0
-            for phone in phones:
+            for batch in batches:
                 result = await execute_sms(
                     client,
-                    phone,
+                    batch,
                     message,
                     QUO_SHARED_EXTERNAL_PHONE_ID,
                     "Sernia Capital Team",
                     ctx.deps.conversation_id,
                     tool_name="mass_text_tenants",
                 )
-                if result.startswith("Message sent"):
-                    unit_sent += 1
+                if result.startswith(("Message sent", "Group message sent")):
+                    unit_sent += len(batch) if isinstance(batch, list) else 1
                 else:
-                    failures.append(f"{prop} Unit {unit} ({phone}): {result}")
+                    batch_desc = ", ".join(batch) if isinstance(batch, list) else batch
+                    failures.append(f"{prop} Unit {unit} ({batch_desc}): {result}")
 
             if unit_sent:
                 recipient_desc = ", ".join(names)
+                thread_note = " — one group thread" if unit_sent > 1 else ""
                 results.append(
-                    f"{prop} Unit {unit} ({unit_sent} recipient{'s' if unit_sent != 1 else ''}: {recipient_desc})"
+                    f"{prop} Unit {unit} ({unit_sent} recipient{'s' if unit_sent != 1 else ''}: {recipient_desc}{thread_note})"
                 )
 
         parts: list[str] = []

--- a/api/src/tests/test_quo_group_sms.py
+++ b/api/src/tests/test_quo_group_sms.py
@@ -229,6 +229,33 @@ class TestGroupSendPayload:
         assert "parts" in result
 
     @pytest.mark.asyncio
+    async def test_find_group_conversation_searches_ai_line_too(self):
+        """All-internal group texts are created on the AI line, so the
+        conversation lookup must not stop at the shared team number.
+        Regression test for the shared-line-only lookup that made
+        AI-line group threads unfindable via get_thread_messages."""
+        from api.src.sernia_ai.tools.quo_tools import _find_group_conversation
+
+        ai_line_conv = {
+            "id": "CNinternalgroup",
+            "participants": [INTERNAL_A, INTERNAL_B],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            phone_id = request.url.params.get("phoneNumbers[]")
+            if phone_id == QUO_SERNIA_AI_PHONE_ID:
+                return httpx.Response(200, json={"data": [ai_line_conv]})
+            return httpx.Response(200, json={"data": []})
+
+        client = httpx.AsyncClient(
+            base_url="https://api.openphone.com",
+            transport=httpx.MockTransport(handler),
+        )
+        conv = await _find_group_conversation(client, [INTERNAL_A, INTERNAL_B])
+        assert conv is not None
+        assert conv["id"] == "CNinternalgroup"
+
+    @pytest.mark.asyncio
     async def test_group_send_failure_surfaces_error(self):
         captured: list[dict] = []
         client = _capture_client(captured, status_code=400)

--- a/api/src/tests/test_quo_group_sms.py
+++ b/api/src/tests/test_quo_group_sms.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for group SMS support (Quo API multi-recipient messages).
+
+The Quo API's POST /v1/messages accepts up to GROUP_SMS_MAX_RECIPIENTS (10)
+numbers in its ``to`` array, landing the message in one shared group thread
+(verified live 2026-08-13 — see test_quo_tools.py for the live contract tests).
+
+Covers:
+- resolve_group_sms_routing: line selection, mixed-group flagging, size gates,
+  unknown-contact blocking, dedup.
+- _send_sms / execute_sms: group payload shape, auto-split fan-out.
+- mass_text_tenants batching: roommates share one group send per unit.
+
+⚠️  SMS SAFETY: All SMS tests here mock the send call. NEVER send real SMS
+to external contacts from tests. See CLAUDE.md.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from api.src.sernia_ai.config import (
+    GROUP_SMS_MAX_RECIPIENTS,
+    QUO_INTERNAL_COMPANY,
+    QUO_SERNIA_AI_PHONE_ID,
+    QUO_SHARED_EXTERNAL_PHONE_ID,
+)
+from api.src.sernia_ai.tools import quo_tools
+from api.src.sernia_ai.tools.quo_tools import (
+    GroupSmsRouting,
+    _send_sms,
+    execute_sms,
+    resolve_group_sms_routing,
+)
+
+INTERNAL_A = "+14125550001"
+INTERNAL_B = "+14125550002"
+EXTERNAL_A = "+14125550101"
+EXTERNAL_B = "+14125550102"
+UNKNOWN = "+19999999999"
+
+_CONTACTS = {
+    INTERNAL_A: {
+        "defaultFields": {
+            "firstName": "Emilio",
+            "lastName": "Esposito",
+            "company": QUO_INTERNAL_COMPANY,
+            "phoneNumbers": [{"value": INTERNAL_A}],
+        }
+    },
+    INTERNAL_B: {
+        "defaultFields": {
+            "firstName": "Anna",
+            "lastName": "Esposito",
+            "company": QUO_INTERNAL_COMPANY,
+            "phoneNumbers": [{"value": INTERNAL_B}],
+        }
+    },
+    EXTERNAL_A: {
+        "defaultFields": {
+            "firstName": "Sana",
+            "lastName": "Test",
+            "company": "Test2",
+            "phoneNumbers": [{"value": EXTERNAL_A}],
+        }
+    },
+    EXTERNAL_B: {
+        "defaultFields": {
+            "firstName": "Tenant",
+            "lastName": "Two",
+            "company": None,
+            "phoneNumbers": [{"value": EXTERNAL_B}],
+        }
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_contact_lookup(monkeypatch):
+    """Patch the contact lookup used by resolve_sms_routing."""
+
+    async def fake_find_contact_by_phone(phone: str, client) -> dict | None:
+        return _CONTACTS.get(phone)
+
+    monkeypatch.setattr(quo_tools, "find_contact_by_phone", fake_find_contact_by_phone)
+
+
+def _capture_client(captured: list[dict], status_code: int = 202) -> httpx.AsyncClient:
+    """An httpx client whose transport records POST /v1/messages payloads."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(status_code, json={"data": {"id": "ACtest"}})
+
+    return httpx.AsyncClient(
+        base_url="https://api.openphone.com",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+# ===========================================================================
+# resolve_group_sms_routing
+# ===========================================================================
+
+
+class TestResolveGroupSmsRouting:
+    @pytest.mark.asyncio
+    async def test_all_internal_uses_ai_line(self):
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([INTERNAL_A, INTERNAL_B], client)
+        assert isinstance(result, GroupSmsRouting)
+        assert result.all_internal is True
+        assert result.has_external is False
+        assert result.is_mixed is False
+        assert result.from_phone_id == QUO_SERNIA_AI_PHONE_ID
+        assert result.line_name == "Sernia AI"
+        assert result.recipient_names == ["Emilio Esposito", "Anna Esposito"]
+
+    @pytest.mark.asyncio
+    async def test_all_external_uses_shared_line(self):
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([EXTERNAL_A, EXTERNAL_B], client)
+        assert isinstance(result, GroupSmsRouting)
+        assert result.all_internal is False
+        assert result.has_external is True
+        assert result.is_mixed is False
+        assert result.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+        assert result.line_name == "Sernia Capital Team"
+
+    @pytest.mark.asyncio
+    async def test_mixed_group_flagged_and_uses_shared_line(self):
+        """Internal + external in one group: allowed, but routed to the shared
+        team line and flagged mixed — the HITL approval (has_external=True at
+        the tool level) is the safeguard for exposing internal numbers."""
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([INTERNAL_A, EXTERNAL_A], client)
+        assert isinstance(result, GroupSmsRouting)
+        assert result.is_mixed is True
+        assert result.has_external is True
+        assert result.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+
+    @pytest.mark.asyncio
+    async def test_unknown_contact_blocks_whole_group(self):
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([INTERNAL_A, UNKNOWN], client)
+        assert isinstance(result, str)
+        assert "not a Quo contact" in result
+
+    @pytest.mark.asyncio
+    async def test_fewer_than_two_unique_recipients_blocked(self):
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([INTERNAL_A, INTERNAL_A], client)
+        assert isinstance(result, str)
+        assert "at least 2 unique recipients" in result
+
+    @pytest.mark.asyncio
+    async def test_over_max_recipients_blocked(self):
+        client = _capture_client([])
+        phones = [f"+1412555{i:04d}" for i in range(GROUP_SMS_MAX_RECIPIENTS + 1)]
+        result = await resolve_group_sms_routing(phones, client)
+        assert isinstance(result, str)
+        assert f"at most {GROUP_SMS_MAX_RECIPIENTS}" in result
+
+    @pytest.mark.asyncio
+    async def test_duplicates_deduped_order_preserved(self):
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([INTERNAL_B, INTERNAL_A, INTERNAL_B], client)
+        assert isinstance(result, GroupSmsRouting)
+        assert result.phones == [INTERNAL_B, INTERNAL_A]
+
+
+# ===========================================================================
+# _send_sms / execute_sms — group payload shape
+# ===========================================================================
+
+
+class TestGroupSendPayload:
+    @pytest.mark.asyncio
+    async def test_group_send_puts_all_recipients_in_one_payload(self):
+        captured: list[dict] = []
+        client = _capture_client(captured)
+        result = await execute_sms(
+            client,
+            [INTERNAL_A, INTERNAL_B],
+            "hello group",
+            QUO_SERNIA_AI_PHONE_ID,
+            "Sernia AI",
+        )
+        assert len(captured) == 1
+        assert captured[0]["to"] == [INTERNAL_A, INTERNAL_B]
+        assert captured[0]["from"] == QUO_SERNIA_AI_PHONE_ID
+        assert captured[0]["content"] == "hello group"
+        assert result.startswith("Group message sent to")
+        assert INTERNAL_A in result and INTERNAL_B in result
+
+    @pytest.mark.asyncio
+    async def test_single_send_unchanged(self):
+        captured: list[dict] = []
+        client = _capture_client(captured)
+        result = await execute_sms(
+            client,
+            INTERNAL_A,
+            "hello",
+            QUO_SERNIA_AI_PHONE_ID,
+            "Sernia AI",
+        )
+        assert len(captured) == 1
+        assert captured[0]["to"] == [INTERNAL_A]
+        assert result == f"Message sent to {INTERNAL_A} from Sernia AI."
+
+    @pytest.mark.asyncio
+    async def test_auto_split_sends_every_chunk_to_full_group(self):
+        captured: list[dict] = []
+        client = _capture_client(captured)
+        long_msg = "First sentence goes here. " * 30  # > SMS_SPLIT_THRESHOLD
+        result = await _send_sms(
+            client,
+            "send_sms",
+            [EXTERNAL_A, EXTERNAL_B],
+            long_msg,
+            QUO_SHARED_EXTERNAL_PHONE_ID,
+            "Sernia Capital Team",
+            "",
+        )
+        assert len(captured) >= 2, "expected auto-split into multiple sends"
+        for payload in captured:
+            assert payload["to"] == [EXTERNAL_A, EXTERNAL_B]
+        assert "parts" in result
+
+    @pytest.mark.asyncio
+    async def test_group_send_failure_surfaces_error(self):
+        captured: list[dict] = []
+        client = _capture_client(captured, status_code=400)
+        result = await execute_sms(
+            client,
+            [INTERNAL_A, INTERNAL_B],
+            "hello group",
+            QUO_SERNIA_AI_PHONE_ID,
+            "Sernia AI",
+        )
+        assert result.startswith("Failed to send message")

--- a/api/src/tests/test_quo_group_sms.py
+++ b/api/src/tests/test_quo_group_sms.py
@@ -75,6 +75,31 @@ _CONTACTS = {
     },
 }
 
+# Tenant contacts with Property/Unit custom fields for the unit-isolation gate.
+TENANT_320_02_A = "+14125550201"
+TENANT_320_02_B = "+14125550202"
+TENANT_320_03 = "+14125550203"
+
+
+def _tenant_contact(name: str, phone: str, prop: str, unit: str) -> dict:
+    return {
+        "defaultFields": {
+            "firstName": name,
+            "lastName": "Tenant",
+            "company": None,
+            "phoneNumbers": [{"value": phone}],
+        },
+        "customFields": [
+            {"name": "Property", "value": prop},
+            {"name": "Unit #", "value": unit},
+        ],
+    }
+
+
+_CONTACTS[TENANT_320_02_A] = _tenant_contact("Aidan", TENANT_320_02_A, "320", "02")
+_CONTACTS[TENANT_320_02_B] = _tenant_contact("Adeline", TENANT_320_02_B, "320", "02")
+_CONTACTS[TENANT_320_03] = _tenant_contact("Hailey", TENANT_320_03, "320", "03")
+
 
 @pytest.fixture(autouse=True)
 def _mock_contact_lookup(monkeypatch):
@@ -161,6 +186,44 @@ class TestResolveGroupSmsRouting:
         result = await resolve_group_sms_routing(phones, client)
         assert isinstance(result, str)
         assert f"at most {GROUP_SMS_MAX_RECIPIENTS}" in result
+
+    @pytest.mark.asyncio
+    async def test_cross_unit_tenants_blocked_deterministically(self):
+        """Tenants from different units must NEVER share a group thread —
+        the unit-isolation gate blocks before approval, so approval cannot
+        override it."""
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([TENANT_320_02_A, TENANT_320_03], client)
+        assert isinstance(result, str)
+        assert "different units" in result
+        assert "320 Unit 02" in result and "320 Unit 03" in result
+
+    @pytest.mark.asyncio
+    async def test_same_unit_roommates_allowed(self):
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([TENANT_320_02_A, TENANT_320_02_B], client)
+        assert isinstance(result, GroupSmsRouting)
+        assert result.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+
+    @pytest.mark.asyncio
+    async def test_tenant_with_unitless_external_allowed(self):
+        """A tenant + an external contact with no Property/Unit fields (e.g.
+        a vendor) is not a cross-unit pairing — allowed, still behind HITL."""
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([TENANT_320_02_A, EXTERNAL_A], client)
+        assert isinstance(result, GroupSmsRouting)
+        assert result.has_external is True
+
+    @pytest.mark.asyncio
+    async def test_internal_member_does_not_trip_unit_gate(self):
+        """Internal team members have no unit; adding one to a single-unit
+        tenant group must not trigger the cross-unit block."""
+        client = _capture_client([])
+        result = await resolve_group_sms_routing(
+            [INTERNAL_A, TENANT_320_02_A, TENANT_320_02_B], client
+        )
+        assert isinstance(result, GroupSmsRouting)
+        assert result.is_mixed is True
 
     @pytest.mark.asyncio
     async def test_duplicates_deduped_order_preserved(self):

--- a/api/src/tests/test_quo_tools.py
+++ b/api/src/tests/test_quo_tools.py
@@ -699,11 +699,23 @@ TESTSANA_NUMBER = "+14128770257"
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("QUO_LIVE_GROUP_SMS_TEST"),
+    reason=(
+        "Sends a real group SMS to TestSana (classified external — company "
+        "'Test2'). Repo policy keeps external sends out of the default live "
+        "suite; set QUO_LIVE_GROUP_SMS_TEST=1 to opt in deliberately."
+    ),
+)
 async def test_send_group_sms_live_emilio_and_sana(quo_client: httpx.AsyncClient):
     """Send a real group text to Emilio + TestSana through execute_sms.
 
-    Both numbers are Emilio's own devices (internal number + dedicated test
-    contact), so this is safe to run live. Verifies the group code path
+    Both numbers are Emilio's own devices (internal number + the dedicated
+    TestSana test contact), and Emilio explicitly requested this live trial
+    (2026-08-13 — delivered, single group conversationId). But TestSana is
+    *classified* external (company 'Test2'), so per SMS test safety this
+    send is opt-in via QUO_LIVE_GROUP_SMS_TEST rather than part of the
+    default ``pytest -m live`` run. Verifies the group code path
     end-to-end: one API call, both recipients in one shared thread.
     """
     from api.src.sernia_ai.config import QUO_SHARED_EXTERNAL_PHONE_ID

--- a/api/src/tests/test_quo_tools.py
+++ b/api/src/tests/test_quo_tools.py
@@ -686,6 +686,62 @@ async def test_get_thread_messages_impl_chronological_order(quo_client: httpx.As
 INTERNAL_TEST_NUMBER = "+14123703550"
 SERNIA_AI_PHONE_ID = "PNWvNqsFFy"  # Sernia AI line (internal only)
 
+# Dedicated test contact "TestSana Test" (company "Test2") — one of Emilio's
+# own test devices, explicitly designated for live SMS testing. NOT a tenant.
+TESTSANA_NUMBER = "+14128770257"
+
+
+# ---- Live group SMS (new Quo API multi-recipient support) ----
+# The Quo API's POST /v1/messages `to` array accepts up to 10 recipients
+# (spec maxItems: 10), landing the message in ONE shared group thread.
+# First verified live 2026-08-13 with Emilio + TestSana: HTTP 202, single
+# conversationId, status reached "delivered".
+
+
+@pytest.mark.asyncio
+async def test_send_group_sms_live_emilio_and_sana(quo_client: httpx.AsyncClient):
+    """Send a real group text to Emilio + TestSana through execute_sms.
+
+    Both numbers are Emilio's own devices (internal number + dedicated test
+    contact), so this is safe to run live. Verifies the group code path
+    end-to-end: one API call, both recipients in one shared thread.
+    """
+    from api.src.sernia_ai.config import QUO_SHARED_EXTERNAL_PHONE_ID
+    from api.src.sernia_ai.tools.quo_tools import execute_sms
+
+    result = await execute_sms(
+        quo_client,
+        [INTERNAL_TEST_NUMBER, TESTSANA_NUMBER],
+        "[QUO GROUP TEST] Group text via execute_sms — Emilio + Sana in one thread. Please ignore.",
+        QUO_SHARED_EXTERNAL_PHONE_ID,
+        "Sernia Capital Team",
+        tool_name="test_group_sms",
+    )
+    print(f"\nGroup send result: {result}")
+    assert result.startswith("Group message sent to")
+    assert INTERNAL_TEST_NUMBER in result
+    assert TESTSANA_NUMBER in result
+
+
+@pytest.mark.asyncio
+async def test_resolve_group_sms_routing_live_mixed_group(quo_client: httpx.AsyncClient):
+    """Live routing resolution for the Emilio + TestSana group: Emilio is
+    internal, TestSana (company 'Test2') is external → mixed group, routed to
+    the shared team line with has_external=True (HITL at the tool level).
+    No SMS is sent — this only exercises contact resolution."""
+    from api.src.sernia_ai.config import QUO_SHARED_EXTERNAL_PHONE_ID
+    from api.src.sernia_ai.tools.quo_tools import (
+        GroupSmsRouting,
+        resolve_group_sms_routing,
+    )
+
+    result = await resolve_group_sms_routing([INTERNAL_TEST_NUMBER, TESTSANA_NUMBER], quo_client)
+    assert isinstance(result, GroupSmsRouting), result
+    assert result.is_mixed is True
+    assert result.has_external is True
+    assert result.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+    print(f"\nGroup routing: names={result.recipient_names}, line={result.line_name}")
+
 
 @pytest.mark.asyncio
 async def test_send_sms_short_160_chars(quo_client: httpx.AsyncClient):

--- a/apps/sernia_mcp/src/sernia_mcp/config.py
+++ b/apps/sernia_mcp/src/sernia_mcp/config.py
@@ -89,3 +89,6 @@ ALLOWED_EMAIL_DOMAINS: tuple[str, ...] = tuple(
 # ---- SMS limits ------------------------------------------------------------
 SMS_SPLIT_THRESHOLD: int = 500
 SMS_MAX_LENGTH: int = 1000
+# Group SMS: max recipients per message — matches the Quo API's `to` array
+# limit (maxItems: 10 on POST /v1/messages), verified live 2026-08-13.
+GROUP_SMS_MAX_RECIPIENTS: int = 10

--- a/apps/sernia_mcp/src/sernia_mcp/core/quo/send_sms.py
+++ b/apps/sernia_mcp/src/sernia_mcp/core/quo/send_sms.py
@@ -14,6 +14,7 @@ import logfire
 
 from sernia_mcp.clients.quo import build_quo_client, find_contact_by_phone
 from sernia_mcp.config import (
+    GROUP_SMS_MAX_RECIPIENTS,
     QUO_INTERNAL_COMPANY,
     QUO_SERNIA_AI_PHONE_ID,
     QUO_SHARED_EXTERNAL_PHONE_ID,
@@ -21,7 +22,7 @@ from sernia_mcp.config import (
     SMS_SPLIT_THRESHOLD,
 )
 from sernia_mcp.core.errors import ExternalServiceError, NotFoundError, ValidationError
-from sernia_mcp.core.types import SmsResult, SmsRouting
+from sernia_mcp.core.types import GroupSmsRouting, SmsResult, SmsRouting
 
 
 def _contact_display_name(contact: dict, phone: str) -> str:
@@ -33,6 +34,23 @@ def _contact_display_name(contact: dict, phone: str) -> str:
 
 def _is_internal_contact(contact: dict) -> bool:
     return (contact.get("defaultFields", {}).get("company") or "") == QUO_INTERNAL_COMPANY
+
+
+def _get_contact_unit(contact: dict) -> tuple[str, str] | None:
+    """Extract (property, unit) from a Quo contact's custom fields.
+
+    Returns None if either field is missing (non-tenant contact). Vendored
+    from ``api/src/sernia_ai/tools/quo_tools.py``.
+    """
+    prop = unit = None
+    for field in contact.get("customFields", []):
+        if field.get("name") == "Property":
+            prop = (field.get("value") or "").strip()
+        elif field.get("name") == "Unit #":
+            unit = (field.get("value") or "").strip()
+    if prop and unit:
+        return (prop, unit)
+    return None
 
 
 async def resolve_sms_routing_core(to_phone: str) -> SmsRouting:
@@ -54,6 +72,79 @@ async def resolve_sms_routing_core(to_phone: str) -> SmsRouting:
         is_internal=is_internal,
         from_phone_id=QUO_SERNIA_AI_PHONE_ID if is_internal else QUO_SHARED_EXTERNAL_PHONE_ID,
         line_name="Sernia AI" if is_internal else "Sernia Capital Team",
+    )
+
+
+async def resolve_group_sms_routing_core(phones: list[str]) -> GroupSmsRouting:
+    """Resolve a recipient list for a group SMS (one shared thread).
+
+    The Quo API's ``POST /v1/messages`` accepts up to
+    ``GROUP_SMS_MAX_RECIPIENTS`` (10) numbers in ``to`` — the message lands
+    in one shared group conversation (verified live 2026-08-13).
+
+    Deterministic gates (raise ``ValidationError`` / ``NotFoundError``):
+
+    - 2..GROUP_SMS_MAX_RECIPIENTS unique recipients.
+    - Every recipient must be a Quo contact.
+    - **Unit isolation**: tenants from different units (per the
+      Property / Unit # custom fields) can never share a group thread —
+      they would see each other's phone numbers. Approval cannot override
+      this; it blocks before the approval card is even shown.
+
+    Line selection: all-internal → AI line; any external → shared team line.
+    """
+    unique_phones = list(dict.fromkeys(phones))
+    if len(unique_phones) < 2:
+        raise ValidationError(
+            "a group SMS needs at least 2 unique recipients; "
+            "pass a single phone string for a 1:1 send"
+        )
+    if len(unique_phones) > GROUP_SMS_MAX_RECIPIENTS:
+        raise ValidationError(
+            f"group SMS supports at most {GROUP_SMS_MAX_RECIPIENTS} recipients "
+            f"per message (got {len(unique_phones)}); split into smaller groups"
+        )
+
+    contacts: list[dict] = []
+    async with build_quo_client() as client:
+        for phone in unique_phones:
+            contact = await find_contact_by_phone(phone, client)
+            if contact is None:
+                raise NotFoundError(
+                    f"{phone} is not a Quo contact. Messages can only be sent "
+                    "to numbers stored in Quo."
+                )
+            contacts.append(contact)
+
+    names = [_contact_display_name(c, p) for c, p in zip(contacts, unique_phones, strict=True)]
+    internal_flags = [_is_internal_contact(c) for c in contacts]
+
+    # Unit-isolation gate: block cross-unit tenant groups deterministically.
+    units: dict[tuple[str, str], list[str]] = {}
+    for contact, name, is_internal in zip(contacts, names, internal_flags, strict=True):
+        if is_internal:
+            continue
+        cu = _get_contact_unit(contact)
+        if cu is not None:
+            units.setdefault(cu, []).append(name)
+    if len(units) > 1:
+        desc = "; ".join(
+            f"{prop} Unit {unit}: {', '.join(unit_names)}"
+            for (prop, unit), unit_names in sorted(units.items())
+        )
+        raise ValidationError(
+            "tenants from different units can never share a group thread "
+            f"({desc}); send one message per unit instead"
+        )
+
+    all_internal = all(internal_flags)
+    return GroupSmsRouting(
+        phones=unique_phones,
+        recipient_names=names,
+        all_internal=all_internal,
+        is_mixed=(not all_internal) and any(internal_flags),
+        from_phone_id=QUO_SERNIA_AI_PHONE_ID if all_internal else QUO_SHARED_EXTERNAL_PHONE_ID,
+        line_name="Sernia AI" if all_internal else "Sernia Capital Team",
     )
 
 
@@ -86,26 +177,15 @@ def _split_sms(text: str, limit: int = SMS_SPLIT_THRESHOLD) -> list[str]:
     return chunks
 
 
-async def send_sms_core(
-    to_phone: str,
-    message: str,
-    *,
-    routing: SmsRouting | None = None,
-) -> SmsResult:
-    """Send an SMS via Quo. Caller handles approval gating."""
-    if len(message) > SMS_MAX_LENGTH:
-        raise ValidationError(
-            f"message is {len(message)} chars, max is {SMS_MAX_LENGTH}. "
-            "Shorten or summarize before sending."
-        )
-
-    if routing is None:
-        routing = await resolve_sms_routing_core(to_phone)
-
-    chunks = _split_sms(message)
+async def _post_sms_chunks(
+    recipients: list[str],
+    chunks: list[str],
+    from_phone_id: str,
+) -> None:
+    """POST each chunk to Quo with all recipients in one ``to`` array."""
     async with build_quo_client() as client:
         for i, chunk in enumerate(chunks):
-            payload = {"content": chunk, "from": routing.from_phone_id, "to": [to_phone]}
+            payload = {"content": chunk, "from": from_phone_id, "to": recipients}
             try:
                 resp = await client.post("/v1/messages", json=payload)
             except httpx.HTTPError as exc:
@@ -116,14 +196,67 @@ async def send_sms_core(
                 )
             logfire.info(
                 "send_sms_core part sent",
-                to=to_phone,
+                to=recipients,
                 part=f"{i + 1}/{len(chunks)}",
-                is_internal=routing.is_internal,
             )
+
+
+async def send_sms_core(
+    to_phone: str,
+    message: str,
+    *,
+    routing: SmsRouting | None = None,
+) -> SmsResult:
+    """Send a 1:1 SMS via Quo. Caller handles approval gating."""
+    if len(message) > SMS_MAX_LENGTH:
+        raise ValidationError(
+            f"message is {len(message)} chars, max is {SMS_MAX_LENGTH}. "
+            "Shorten or summarize before sending."
+        )
+
+    if routing is None:
+        routing = await resolve_sms_routing_core(to_phone)
+
+    chunks = _split_sms(message)
+    await _post_sms_chunks([to_phone], chunks, routing.from_phone_id)
 
     return SmsResult(
         to_phone=to_phone,
         contact_name=routing.contact_name,
+        line_name=routing.line_name,
+        parts_sent=len(chunks),
+        message_chars=len(message),
+    )
+
+
+async def send_group_sms_core(
+    phones: list[str],
+    message: str,
+    *,
+    routing: GroupSmsRouting | None = None,
+) -> SmsResult:
+    """Send a GROUP SMS via Quo — one shared thread, every recipient sees
+    the message and each other's replies. Caller handles approval gating;
+    the deterministic gates (contacts-only, 2-10 size, cross-unit tenant
+    isolation) live in ``resolve_group_sms_routing_core``.
+
+    Auto-splits long messages; every chunk goes to the full group.
+    """
+    if len(message) > SMS_MAX_LENGTH:
+        raise ValidationError(
+            f"message is {len(message)} chars, max is {SMS_MAX_LENGTH}. "
+            "Shorten or summarize before sending."
+        )
+
+    if routing is None:
+        routing = await resolve_group_sms_routing_core(phones)
+
+    chunks = _split_sms(message)
+    await _post_sms_chunks(routing.phones, chunks, routing.from_phone_id)
+
+    return SmsResult(
+        to_phone=", ".join(routing.phones),
+        contact_name=", ".join(routing.recipient_names),
         line_name=routing.line_name,
         parts_sent=len(chunks),
         message_chars=len(message),

--- a/apps/sernia_mcp/src/sernia_mcp/core/types.py
+++ b/apps/sernia_mcp/src/sernia_mcp/core/types.py
@@ -29,8 +29,29 @@ class SmsRouting(BaseModel):
     line_name: str
 
 
+class GroupSmsRouting(BaseModel):
+    """Resolved routing for a group SMS (one shared thread, 2+ recipients).
+
+    All-internal groups send from the AI line; any group containing an
+    external contact sends from the shared team number. ``is_mixed`` flags
+    internal+external groups (internal numbers become visible to external
+    recipients — the approval card is the safeguard).
+    """
+
+    phones: list[str]  # deduped, original order preserved
+    recipient_names: list[str]
+    all_internal: bool
+    is_mixed: bool
+    from_phone_id: str
+    line_name: str
+
+
 class SmsResult(BaseModel):
-    """Result of a send_sms_core call."""
+    """Result of a send_sms_core / send_group_sms_core call.
+
+    For group sends, ``to_phone`` and ``contact_name`` are comma-joined
+    lists of the recipients.
+    """
 
     to_phone: str
     contact_name: str | None

--- a/apps/sernia_mcp/src/sernia_mcp/tools/approvals.py
+++ b/apps/sernia_mcp/src/sernia_mcp/tools/approvals.py
@@ -50,9 +50,14 @@ from prefab_ui.components import (
 from prefab_ui.rx import Rx
 
 from sernia_mcp.config import INTERNAL_EMAIL_DOMAIN
-from sernia_mcp.core.errors import CoreError, NotFoundError
+from sernia_mcp.core.errors import CoreError, NotFoundError, ValidationError
 from sernia_mcp.core.google.gmail import send_email_core
-from sernia_mcp.core.quo.send_sms import resolve_sms_routing_core, send_sms_core
+from sernia_mcp.core.quo.send_sms import (
+    resolve_group_sms_routing_core,
+    resolve_sms_routing_core,
+    send_group_sms_core,
+    send_sms_core,
+)
 from sernia_mcp.identity import resolve_user_email_for_request
 
 # Pending sends, keyed by short UUID.
@@ -73,26 +78,110 @@ approvals_app = FastMCPApp("sernia_approvals")
 
 
 @approvals_app.ui()
-async def quo_send_sms(to_phone: str, message: str) -> PrefabApp:
-    """Send an SMS to a Quo contact (internal or external).
+async def quo_send_sms(to_phone: str | list[str], message: str) -> PrefabApp:
+    """Send an SMS to one Quo contact, or a GROUP text to 2-10 contacts.
 
     Returns an Approve / Reject card — the SMS is NOT sent until the user
     clicks Approve in the card. Only MCP clients that can render PrefabApps
     (Claude Desktop, Claude app, VS Code Copilot, fastmcp dev apps) can
     complete the flow.
 
+    **Group texts**: pass a list of 2-10 phone numbers to start ONE shared
+    thread — all recipients see the message and each other's replies (and
+    each other's phone numbers). Deterministic gates that approval cannot
+    override: every number must be a Quo contact, and tenants from
+    DIFFERENT units are always blocked from sharing a group thread
+    (roommates in the same unit are fine). A mixed internal+external group
+    exposes internal team numbers to the external recipients — only do
+    this when clearly intended. To message multiple people SEPARATELY
+    (private 1:1 threads), call this tool once per recipient instead.
+
     Args:
-        to_phone: Recipient phone in E.164 format (e.g. "+14155550100").
+        to_phone: Recipient phone in E.164 format (e.g. "+14155550100"),
+            or a list of 2-10 numbers for a group text (one shared thread).
         message: SMS body (max 1000 chars; auto-split above 500).
     """
+    if isinstance(to_phone, list) and len(to_phone) == 1:
+        to_phone = to_phone[0]
+
+    if len(message) > 1000:
+        raise ToolError(f"message is {len(message)} chars, max 1000")
+
+    # ---- Group path ----
+    if isinstance(to_phone, list):
+        try:
+            group = await resolve_group_sms_routing_core(to_phone)
+        except (NotFoundError, ValidationError) as e:
+            raise ToolError(str(e)) from e
+        except CoreError as e:
+            raise ToolError(f"quo_send_sms failed: {e}") from e
+
+        pid = uuid.uuid4().hex[:12]
+        _PENDING[pid] = {
+            "type": "sms",
+            "group": True,
+            "to_phones": group.phones,
+            "message": message,
+            "contact_name": ", ".join(group.recipient_names),
+            "created_at": time.time(),
+        }
+
+        audience = "INTERNAL" if group.all_internal else "EXTERNAL"
+        recipients_label = ", ".join(
+            f"{name} ({phone})"
+            for name, phone in zip(group.recipient_names, group.phones, strict=True)
+        )
+        with Card(css_class="max-w-xl") as view:
+            with CardHeader():
+                CardTitle(f"Send GROUP SMS to {len(group.phones)} recipients?")
+            with CardContent():
+                with Column(gap=3):
+                    Text(f"**To (one shared thread):** {recipients_label}")
+                    Text(f"**Routing:** {audience} line ({group.line_name})")
+                    if group.is_mixed:
+                        Text(
+                            "⚠️ **Mixed group:** internal team numbers will be "
+                            "visible to the external recipients in this thread."
+                        )
+                    Heading("Message", level=4)
+                    Text(message)
+            with CardFooter():
+                with Row(gap=2):
+                    Button(
+                        "Approve & Send",
+                        variant="success",
+                        on_click=[
+                            CallTool(
+                                "_confirm_send_sms",
+                                arguments={"pending_id": pid, "decision": "approve"},
+                            ),
+                            SetState("decided", True),
+                            ShowToast("Group SMS sent", variant="success"),
+                        ],
+                        disabled=Rx("decided"),
+                    )
+                    Button(
+                        "Reject",
+                        variant="destructive",
+                        on_click=[
+                            CallTool(
+                                "_confirm_send_sms",
+                                arguments={"pending_id": pid, "decision": "reject"},
+                            ),
+                            SetState("decided", True),
+                            ShowToast("Cancelled", variant="warning"),
+                        ],
+                        disabled=Rx("decided"),
+                    )
+        return PrefabApp(view=view, state={"decided": False})
+
+    # ---- Single-recipient path ----
     try:
         routing = await resolve_sms_routing_core(to_phone)
     except NotFoundError as e:
         raise ToolError(str(e)) from e
     except CoreError as e:
         raise ToolError(f"quo_send_sms failed: {e}") from e
-    if len(message) > 1000:
-        raise ToolError(f"message is {len(message)} chars, max 1000")
 
     pid = uuid.uuid4().hex[:12]
     _PENDING[pid] = {
@@ -154,17 +243,22 @@ async def _confirm_send_sms(pending_id: str, decision: str) -> str:
     age = time.time() - rec.get("created_at", 0)
     if age > _PENDING_TTL_SECONDS:
         return f"Pending SMS expired ({int(age)}s old, TTL {_PENDING_TTL_SECONDS}s)."
+    is_group = rec.get("group", False)
+    recipient_desc = rec.get("contact_name") or (
+        ", ".join(rec["to_phones"]) if is_group else rec["to_phone"]
+    )
     if decision != "approve":
-        return (
-            f"Cancelled SMS to {rec.get('contact_name') or rec['to_phone']} "
-            f"(decision={decision!r})."
-        )
+        return f"Cancelled SMS to {recipient_desc} (decision={decision!r})."
     try:
-        result = await send_sms_core(rec["to_phone"], rec["message"])
+        if is_group:
+            result = await send_group_sms_core(rec["to_phones"], rec["message"])
+        else:
+            result = await send_sms_core(rec["to_phone"], rec["message"])
     except CoreError as e:
         return f"Send failed: {e}"
+    kind = "Group SMS (one shared thread)" if is_group else "SMS"
     return (
-        f"SMS sent to {result.contact_name or result.to_phone} via {result.line_name} "
+        f"{kind} sent to {result.contact_name or result.to_phone} via {result.line_name} "
         f"({result.parts_sent} part{'s' if result.parts_sent != 1 else ''})."
     )
 

--- a/apps/sernia_mcp/tests/test_quo_group_sms.py
+++ b/apps/sernia_mcp/tests/test_quo_group_sms.py
@@ -1,0 +1,292 @@
+"""Tests for group SMS support (Quo multi-recipient messages).
+
+The Quo API's POST /v1/messages accepts up to GROUP_SMS_MAX_RECIPIENTS (10)
+numbers in ``to``, landing the message in one shared group thread (verified
+live 2026-08-13).
+
+Covers:
+
+  * ``resolve_group_sms_routing_core`` — line selection, mixed-group
+    flagging, size gates, unknown-contact blocking, deterministic
+    cross-unit tenant isolation, dedup.
+  * ``send_group_sms_core`` — payload shape (all recipients in one ``to``),
+    auto-split fan-out.
+  * Approval flow — ``quo_send_sms`` with a list queues a group pending row
+    and returns a PrefabApp; ``_confirm_send_sms`` routes to the group send.
+
+All sends are mocked — no real SMS leaves these tests.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from sernia_mcp.config import (
+    GROUP_SMS_MAX_RECIPIENTS,
+    QUO_INTERNAL_COMPANY,
+    QUO_SERNIA_AI_PHONE_ID,
+    QUO_SHARED_EXTERNAL_PHONE_ID,
+)
+from sernia_mcp.core.errors import NotFoundError, ValidationError
+from sernia_mcp.core.quo import send_sms as send_sms_mod
+from sernia_mcp.core.quo.send_sms import (
+    resolve_group_sms_routing_core,
+    send_group_sms_core,
+)
+from sernia_mcp.core.types import GroupSmsRouting, SmsResult
+from sernia_mcp.tools import approvals
+
+INTERNAL_A = "+14125550001"
+INTERNAL_B = "+14125550002"
+EXTERNAL_A = "+14125550101"
+TENANT_320_02_A = "+14125550201"
+TENANT_320_02_B = "+14125550202"
+TENANT_320_03 = "+14125550203"
+UNKNOWN = "+19999999999"
+
+
+def _contact(name: str, phone: str, company: str | None = None, unit: tuple | None = None) -> dict:
+    c: dict = {
+        "defaultFields": {
+            "firstName": name,
+            "lastName": "Test",
+            "company": company,
+            "phoneNumbers": [{"value": phone}],
+        }
+    }
+    if unit:
+        c["customFields"] = [
+            {"name": "Property", "value": unit[0]},
+            {"name": "Unit #", "value": unit[1]},
+        ]
+    return c
+
+
+_CONTACTS = {
+    INTERNAL_A: _contact("Emilio", INTERNAL_A, company=QUO_INTERNAL_COMPANY),
+    INTERNAL_B: _contact("Anna", INTERNAL_B, company=QUO_INTERNAL_COMPANY),
+    EXTERNAL_A: _contact("Sana", EXTERNAL_A, company="Test2"),
+    TENANT_320_02_A: _contact("Aidan", TENANT_320_02_A, unit=("320", "02")),
+    TENANT_320_02_B: _contact("Adeline", TENANT_320_02_B, unit=("320", "02")),
+    TENANT_320_03: _contact("Hailey", TENANT_320_03, unit=("320", "03")),
+}
+
+
+class _FakeClientCM:
+    """Async-context-manager stand-in for build_quo_client()."""
+
+    def __init__(self, client=None):
+        self._client = client
+
+    async def __aenter__(self):
+        return self._client
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _mock_quo(monkeypatch):
+    async def fake_find(phone: str, client) -> dict | None:
+        return _CONTACTS.get(phone)
+
+    monkeypatch.setattr(send_sms_mod, "find_contact_by_phone", fake_find)
+    monkeypatch.setattr(send_sms_mod, "build_quo_client", lambda: _FakeClientCM())
+
+
+def _capturing_client(captured: list[dict], status_code: int = 202) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(status_code, json={"data": {"id": "ACtest"}})
+
+    return httpx.AsyncClient(
+        base_url="https://api.openphone.com",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+# ------------------------------------------------- resolve_group_sms_routing_core
+
+
+class TestResolveGroupRouting:
+    @pytest.mark.asyncio
+    async def test_all_internal_uses_ai_line(self):
+        routing = await resolve_group_sms_routing_core([INTERNAL_A, INTERNAL_B])
+        assert routing.all_internal is True
+        assert routing.is_mixed is False
+        assert routing.from_phone_id == QUO_SERNIA_AI_PHONE_ID
+        assert routing.line_name == "Sernia AI"
+        assert routing.recipient_names == ["Emilio Test", "Anna Test"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_group_flagged_uses_shared_line(self):
+        routing = await resolve_group_sms_routing_core([INTERNAL_A, EXTERNAL_A])
+        assert routing.all_internal is False
+        assert routing.is_mixed is True
+        assert routing.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+
+    @pytest.mark.asyncio
+    async def test_cross_unit_tenants_blocked(self):
+        """Deterministic unit isolation — tenants from different units can
+        never share a group thread; blocks before any approval card."""
+        with pytest.raises(ValidationError, match="different units"):
+            await resolve_group_sms_routing_core([TENANT_320_02_A, TENANT_320_03])
+
+    @pytest.mark.asyncio
+    async def test_same_unit_roommates_allowed(self):
+        routing = await resolve_group_sms_routing_core([TENANT_320_02_A, TENANT_320_02_B])
+        assert routing.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+
+    @pytest.mark.asyncio
+    async def test_unknown_contact_blocked(self):
+        with pytest.raises(NotFoundError, match="not a Quo contact"):
+            await resolve_group_sms_routing_core([INTERNAL_A, UNKNOWN])
+
+    @pytest.mark.asyncio
+    async def test_size_gates(self):
+        with pytest.raises(ValidationError, match="at least 2"):
+            await resolve_group_sms_routing_core([INTERNAL_A, INTERNAL_A])
+        too_many = [f"+1412555{i:04d}" for i in range(GROUP_SMS_MAX_RECIPIENTS + 1)]
+        with pytest.raises(ValidationError, match="at most"):
+            await resolve_group_sms_routing_core(too_many)
+
+    @pytest.mark.asyncio
+    async def test_dedup_preserves_order(self):
+        routing = await resolve_group_sms_routing_core([INTERNAL_B, INTERNAL_A, INTERNAL_B])
+        assert routing.phones == [INTERNAL_B, INTERNAL_A]
+
+
+# ------------------------------------------------------------ send_group_sms_core
+
+
+class TestSendGroupSms:
+    @pytest.mark.asyncio
+    async def test_all_recipients_in_one_payload(self, monkeypatch):
+        captured: list[dict] = []
+        monkeypatch.setattr(
+            send_sms_mod,
+            "build_quo_client",
+            lambda: _FakeClientCM(_capturing_client(captured)),
+        )
+        result = await send_group_sms_core([INTERNAL_A, INTERNAL_B], "hello group")
+        assert len(captured) == 1
+        assert captured[0]["to"] == [INTERNAL_A, INTERNAL_B]
+        assert captured[0]["from"] == QUO_SERNIA_AI_PHONE_ID
+        assert result.parts_sent == 1
+        assert result.contact_name == "Emilio Test, Anna Test"
+
+    @pytest.mark.asyncio
+    async def test_auto_split_sends_every_chunk_to_full_group(self, monkeypatch):
+        captured: list[dict] = []
+        monkeypatch.setattr(
+            send_sms_mod,
+            "build_quo_client",
+            lambda: _FakeClientCM(_capturing_client(captured)),
+        )
+        long_msg = "A sentence for splitting purposes. " * 20  # > 500 chars
+        result = await send_group_sms_core([INTERNAL_A, INTERNAL_B], long_msg)
+        assert result.parts_sent >= 2
+        for payload in captured:
+            assert payload["to"] == [INTERNAL_A, INTERNAL_B]
+
+
+# ----------------------------------------------------------------- approval flow
+
+
+class TestGroupApprovalFlow:
+    @pytest.fixture(autouse=True)
+    def _clear_pending(self):
+        approvals._PENDING.clear()
+        yield
+        approvals._PENDING.clear()
+
+    @pytest.mark.asyncio
+    async def test_group_send_queues_pending_row(self):
+        fake_routing = GroupSmsRouting(
+            phones=[INTERNAL_A, EXTERNAL_A],
+            recipient_names=["Emilio Test", "Sana Test"],
+            all_internal=False,
+            is_mixed=True,
+            from_phone_id=QUO_SHARED_EXTERNAL_PHONE_ID,
+            line_name="Sernia Capital Team",
+        )
+        with patch(
+            "sernia_mcp.tools.approvals.resolve_group_sms_routing_core",
+            new=AsyncMock(return_value=fake_routing),
+        ):
+            await approvals.quo_send_sms(to_phone=[INTERNAL_A, EXTERNAL_A], message="group hello")
+        assert len(approvals._PENDING) == 1
+        rec = next(iter(approvals._PENDING.values()))
+        assert rec["group"] is True
+        assert rec["to_phones"] == [INTERNAL_A, EXTERNAL_A]
+        assert rec["message"] == "group hello"
+
+    @pytest.mark.asyncio
+    async def test_confirm_approve_routes_to_group_send(self):
+        approvals._PENDING["gid"] = {
+            "type": "sms",
+            "group": True,
+            "to_phones": [INTERNAL_A, EXTERNAL_A],
+            "message": "group hello",
+            "contact_name": "Emilio Test, Sana Test",
+            "created_at": time.time(),
+        }
+        fake = SmsResult(
+            to_phone=f"{INTERNAL_A}, {EXTERNAL_A}",
+            contact_name="Emilio Test, Sana Test",
+            line_name="Sernia Capital Team",
+            parts_sent=1,
+            message_chars=11,
+        )
+        with (
+            patch(
+                "sernia_mcp.tools.approvals.send_group_sms_core",
+                new=AsyncMock(return_value=fake),
+            ) as group_send,
+            patch("sernia_mcp.tools.approvals.send_sms_core", new=AsyncMock()) as single_send,
+        ):
+            out = await approvals._confirm_send_sms(pending_id="gid", decision="approve")
+        group_send.assert_awaited_once_with([INTERNAL_A, EXTERNAL_A], "group hello")
+        single_send.assert_not_called()
+        assert "Group SMS (one shared thread) sent to" in out
+
+    @pytest.mark.asyncio
+    async def test_confirm_reject_group_does_not_send(self):
+        approvals._PENDING["gid"] = {
+            "type": "sms",
+            "group": True,
+            "to_phones": [INTERNAL_A, EXTERNAL_A],
+            "message": "group hello",
+            "contact_name": "Emilio Test, Sana Test",
+            "created_at": time.time(),
+        }
+        with patch("sernia_mcp.tools.approvals.send_group_sms_core", new=AsyncMock()) as group_send:
+            out = await approvals._confirm_send_sms(pending_id="gid", decision="reject")
+        group_send.assert_not_called()
+        assert "Cancelled" in out
+
+    @pytest.mark.asyncio
+    async def test_single_element_list_treated_as_1to1(self):
+        """A 1-element list unwraps to the single-recipient path."""
+        from sernia_mcp.core.types import SmsRouting
+
+        fake_routing = SmsRouting(
+            contact_id="c1",
+            contact_name="Emilio Test",
+            is_internal=True,
+            from_phone_id=QUO_SERNIA_AI_PHONE_ID,
+            line_name="Sernia AI",
+        )
+        with patch(
+            "sernia_mcp.tools.approvals.resolve_sms_routing_core",
+            new=AsyncMock(return_value=fake_routing),
+        ):
+            await approvals.quo_send_sms(to_phone=[INTERNAL_A], message="hi")
+        rec = next(iter(approvals._PENDING.values()))
+        assert "group" not in rec
+        assert rec["to_phone"] == INTERNAL_A


### PR DESCRIPTION
## Description

The new Quo API supports **group texts**: `POST /v1/messages` accepts up to 10 recipients in its `to` array, landing the message in one shared group thread. **Tried out live first with Emilio + Sana** (TestSana test contact) on 2026-08-13: HTTP 202, both recipients in a single `conversationId`, status reached `delivered` — verified both via a raw API probe and again through the new `execute_sms` group code path.

Group support is implemented in **both surfaces** — the Sernia AI agent (`api/src/sernia_ai`) and the standalone MCP server (`apps/sernia_mcp`) — with the **same tool names** (no new tools): `send_sms` (agent) and `quo_send_sms` (MCP) now take a single phone **or a list of 2–10 phones**.

### Routing & deterministic gates (both surfaces)

- All-internal group → AI line, no approval (team group chat). Any external → shared team number + HITL approval.
- Mixed internal+external → allowed but flagged: the approval card warns that internal numbers become visible to external recipients.
- **Unit isolation, deterministic**: tenants from *different* units (per `Property` / `Unit #` custom fields) are hard-blocked from sharing a group thread — the gate runs *before* the approval gate, so approval cannot override it. Roommates in the same unit pass; unit-less contacts (vendors, team) don't trigger it.
- Every recipient must be a Quo contact; 2–10 unique recipients (`GROUP_SMS_MAX_RECIPIENTS`, matching the API spec's `maxItems: 10`).

### Changes

- **Agent** — `send_sms` group path via new `GroupSmsRouting` / `resolve_group_sms_routing`; `execute_sms` generalized to `str | list[str]`; `mass_text_tenants` now sends **one group thread per unit** (solo tenants stay 1:1; >10-phone units fall back to individual sends); `_find_group_conversation` searches both lines so AI-line group threads are readable.
- **MCP server** — `quo_send_sms` accepts `str | list[str]`; group approval card lists all recipients + routing + mixed-group warning; hidden `_confirm_send_sms` routes to new `send_group_sms_core`; `resolve_group_sms_routing_core` carries the same gates.
- **Tests** — 16 mocked unit tests in the monorepo (`test_quo_group_sms.py`), 13 in `apps/sernia_mcp/tests`; live tests for the group send path (opt-in via `QUO_LIVE_GROUP_SMS_TEST=1`) and mixed-group routing. Monorepo suite: 564 passed (one pre-existing `test_contact_service` event-loop flake, reproduced on clean tree); sernia_mcp: 206 passed (4 pre-existing `git_sync_flow` sandbox failures, reproduced on clean tree).
- **Docs** — `tools/README.md` "Group Texts (sending)" section with the gate list; known limitation documented: replies to all-internal groups are currently handled 1:1 by the AI SMS trigger (conversation_id propagation is follow-up work).

Preview: https://react-router-portfolio-pr-296.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.