### PR TITLE
Group SMS follow-up: replies stay in the group; mixed groups blocked

### DIFF
--- a/api/src/open_phone/routes.py
+++ b/api/src/open_phone/routes.py
@@ -6,7 +6,6 @@ import time
 from datetime import date, datetime
 from pprint import pprint
 
-import httpx as _httpx
 import logfire
 import requests
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Security
@@ -31,38 +30,20 @@ from api.src.utils.clerk import verify_serniacapital_user
 from api.src.utils.dependencies import verify_admin_or_serniacapital
 from api.src.utils.password import verify_admin_password
 
+
 # ---------------------------------------------------------------------------
 # Cached AI phone number lookup (circular trigger guard)
 # ---------------------------------------------------------------------------
-_ai_phone_number: str | None = None
-
-
 async def _get_ai_phone_number() -> str | None:
-    """Look up the AI phone's actual number via OpenPhone API, caching at module level."""
-    global _ai_phone_number
-    if _ai_phone_number is not None:
-        return _ai_phone_number
+    """Look up the AI phone's actual number (process-cached).
 
-    api_key = os.environ.get("OPEN_PHONE_API_KEY", "")
-    if not api_key:
-        return None
+    Thin wrapper kept for webhook-routing readability — the cached lookup
+    lives in ``open_phone.service.get_ai_phone_number`` so the AI SMS
+    trigger can share it without importing this routes module.
+    """
+    from api.src.open_phone.service import get_ai_phone_number
 
-    try:
-        async with _httpx.AsyncClient(
-            base_url="https://api.openphone.com",
-            headers={"Authorization": api_key},
-            timeout=15,
-        ) as client:
-            resp = await client.get(f"/v1/phone-numbers/{QUO_SERNIA_AI_PHONE_ID}")
-            resp.raise_for_status()
-            phone = resp.json().get("data", {}).get("phoneNumber")
-            if phone:
-                _ai_phone_number = phone
-                logfire.info("cached AI phone number for circular trigger guard")
-                return _ai_phone_number
-    except Exception:
-        logfire.exception("failed to look up AI phone number")
-    return None
+    return await get_ai_phone_number()
 
 
 router = APIRouter(

--- a/api/src/open_phone/service.py
+++ b/api/src/open_phone/service.py
@@ -26,6 +26,46 @@ _contact_cache: list[dict] = []
 _cache_ts: float = 0.0
 
 
+# The AI line's actual phone number (E.164), looked up once via the API and
+# cached for the process lifetime. Used by the webhook circular-trigger guard
+# and by the AI SMS trigger to tell group messages apart from 1:1s.
+_ai_phone_number: str | None = None
+
+
+async def get_ai_phone_number() -> str | None:
+    """Look up the AI phone line's E.164 number, caching at module level.
+
+    Returns None when the API key is missing or the lookup fails — callers
+    must treat None as "unknown" and fall back to 1:1 behavior.
+    """
+    global _ai_phone_number
+    if _ai_phone_number is not None:
+        return _ai_phone_number
+
+    from api.src.sernia_ai.config import QUO_SERNIA_AI_PHONE_ID
+
+    api_key = os.environ.get("OPEN_PHONE_API_KEY", "")
+    if not api_key:
+        return None
+
+    try:
+        async with httpx.AsyncClient(
+            base_url="https://api.openphone.com",
+            headers={"Authorization": api_key},
+            timeout=15,
+        ) as client:
+            resp = await client.get(f"/v1/phone-numbers/{QUO_SERNIA_AI_PHONE_ID}")
+            resp.raise_for_status()
+            phone = resp.json().get("data", {}).get("phoneNumber")
+            if phone:
+                _ai_phone_number = phone
+                logfire.info("cached AI phone number")
+                return _ai_phone_number
+    except Exception:
+        logfire.exception("failed to look up AI phone number")
+    return None
+
+
 def _openphone_client() -> httpx.AsyncClient:
     """Create a configured AsyncClient for the OpenPhone API.
 
@@ -115,18 +155,25 @@ async def find_contact_by_phone(
     return matches[0] if matches else None
 
 
-async def send_message(message: str, to_phone_number: str, from_phone_number: str | None = None):
+async def send_message(
+    message: str,
+    to_phone_number: str | list[str],
+    from_phone_number: str | None = None,
+):
     """
-    Send a message to a phone number using the OpenPhone API.
+    Send a message to one phone number — or a group text to several — using
+    the OpenPhone API. A list of recipients lands in one shared group thread
+    (the API's ``to`` array accepts up to 10 numbers).
     """
     if from_phone_number is None:
         sernia_contact = await get_contact_by_slug("sernia")
         from_phone_number = sernia_contact.phone_number
 
+    to_list = [to_phone_number] if isinstance(to_phone_number, str) else list(to_phone_number)
     data = {
         "content": message,
         "from": from_phone_number,
-        "to": [to_phone_number],
+        "to": to_list,
     }
     # Uses the shared OpenPhone client: a generous read timeout (httpx's 5s
     # default made slow sends raise ReadTimeout and fail the caller — e.g. the

--- a/api/src/sernia_ai/README.md
+++ b/api/src/sernia_ai/README.md
@@ -110,7 +110,7 @@ The agent operates in three modalities, each with distinct behavior:
 
 ### Safety Gates
 
-- **Internal/external SMS separation** — Routing keeps internal phone numbers out of external threads; a mixed internal+external **group text** is the one deliberate exception and always requires HITL approval (see [`tools/README.md`](tools/README.md))
+- **Internal/external SMS separation** — Routing keeps internal phone numbers out of external threads; mixed internal+external **group texts** are hard-blocked deterministically — a group is always all-internal or all-external (see [`tools/README.md`](tools/README.md))
 - **Unit isolation** — Cross-unit tenant group texts blocked; roommates within a unit share one group thread (see [`tools/README.md`](tools/README.md))
 - **HITL approval** — External SMS, emails, task deletion, contact updates/deletes, and calendar writes (create or delete) for events with external attendees require human approval. Internal-only calendar writes are not gated.
 - **Universal kill switch** — DB-backed toggle disables all automated triggers

--- a/api/src/sernia_ai/instructions.py
+++ b/api/src/sernia_ai/instructions.py
@@ -85,7 +85,10 @@ cross-cutting policies that don't belong to any single tool description:
 - **Internal vs external routing is automatic.** Communication tools (SMS, \
 email, scheduling) auto-detect internal (Sernia Capital LLC / \
 @serniacapital.com) vs external recipients and pick the right phone / \
-mailbox. Don't think about which line — just pass the recipient.
+mailbox. Don't think about which line — just pass the recipient. Group \
+texts (a list of phones to `quo_send_sms`) must be all-internal or \
+all-external — mixing is blocked deterministically, as are cross-unit \
+tenant groups.
 - **Prefer the shared team number** for general team SMS notifications so \
 the whole team sees one thread. Only message a specific person when the \
 message is really for them.

--- a/api/src/sernia_ai/routes.py
+++ b/api/src/sernia_ai/routes.py
@@ -479,7 +479,9 @@ async def approve_conversation(
         )
         create_logged_task(commit_and_push(WORKSPACE_PATH), name="git_sync")
 
-        # If this is an SMS conversation, send the agent's response back via SMS
+        # If this is an SMS conversation, send the agent's response back via SMS.
+        # Group conversations (ai_sms_group_*) store the full participant list
+        # in metadata — reply into the group thread, not 1:1 to the sender.
         conv = await get_agent_conversation(session, conversation_id, clerk_user_id=None)
         if (
             conv
@@ -487,11 +489,17 @@ async def approve_conversation(
             and isinstance(result.output, str)
             and result.output.strip()
             and conv.metadata_
-            and conv.metadata_.get("trigger_phone")
+            and (
+                conv.metadata_.get("trigger_group_participants")
+                or conv.metadata_.get("trigger_phone")
+            )
         ):
+            reply_to = (
+                conv.metadata_.get("trigger_group_participants") or conv.metadata_["trigger_phone"]
+            )
             create_logged_task(
                 _send_sms_reply(
-                    to_phone=conv.metadata_["trigger_phone"],
+                    to_phone=reply_to,
                     message=result.output,
                 ),
                 name="sms_reply",
@@ -1156,8 +1164,12 @@ async def update_admin_settings(
 # =============================================================================
 
 
-async def _send_sms_reply(to_phone: str, message: str) -> None:
-    """Send an SMS reply from the AI phone number, auto-splitting if long. Never raises."""
+async def _send_sms_reply(to_phone: str | list[str], message: str) -> None:
+    """Send an SMS reply from the AI phone number, auto-splitting if long.
+
+    ``to_phone`` may be a single number (1:1) or a list — a list replies
+    into the shared group thread. Never raises.
+    """
     from api.src.open_phone.service import send_message
     from api.src.sernia_ai.config import QUO_SERNIA_AI_PHONE_ID
     from api.src.sernia_ai.tools.quo_tools import split_sms

--- a/api/src/sernia_ai/tools/README.md
+++ b/api/src/sernia_ai/tools/README.md
@@ -39,16 +39,16 @@ The Quo API supports up to **10 recipients** per `POST /v1/messages` (`to` array
 
 Routing for group sends (`resolve_group_sms_routing`):
 
-- **All internal** → AI line, no approval (team group chat).
-- **Any external** → shared team number + HITL approval.
-- **Mixed internal + external** → allowed but flagged (`is_mixed`) — sending exposes the internal members' numbers to the external recipients, so the HITL approval is the safeguard. The agent is instructed to only do this deliberately.
+- **All internal** → AI line, no approval (team group chat). Replies are handled **in the group thread** by the AI SMS trigger — see [`triggers/README.md`](../triggers/README.md).
+- **All external** → shared team number + HITL approval.
+- **Mixed internal + external** → hard-blocked deterministically — a mixed group would expose internal team numbers to external recipients. Approval cannot override; a group is always all-internal or all-external.
 - **Cross-unit tenants** → hard-blocked deterministically (gate 5 above); approval cannot override.
 
 The same group support (same tool name, same gates) is mirrored in the standalone MCP server at `apps/sernia_mcp` — `quo_send_sms` accepts `str | list[str]` with the group approval card, backed by `resolve_group_sms_routing_core` / `send_group_sms_core`.
 
 To message multiple people *privately*, the agent calls `send_sms` once per recipient instead of passing a list.
 
-> **Known limitation — replies to all-internal groups:** the AI SMS event trigger handles inbound messages on the AI line keyed by sender only (`from_number`), so a reply to an all-internal group text is loaded as the sender's 1:1 history and the AI's answer is sent back 1:1 — it does not land in the group thread. Propagating the webhook's `conversation_id`/participants through the trigger (history loading + reply send) is tracked as follow-up work. The agent is instructed to prefer 1:1 sends for conversational exchanges and reserve internal group texts for announcements.
+> **Group replies stay in the group:** the AI SMS event trigger detects group messages on the AI line (the webhook's `to` contains recipients besides the AI's own number), keys the conversation to the Quo group conversation (`ai_sms_group_{CN...}`), and sends the AI's answer to **all** human participants so it lands in the same group thread. Context seeding for group sends (`send_sms`'s `context` param) also lands in that group conversation. See [`triggers/README.md`](../triggers/README.md) for the flow.
 
 The group-conversation lookup used by the read tools (`_find_group_conversation`) searches **both** lines — the shared team number and the AI line — since all-internal groups are created on the AI line.
 

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -411,19 +411,17 @@ async def resolve_sms_routing(
 class GroupSmsRouting:
     """Resolved routing for a group SMS (one shared thread, 2+ recipients).
 
-    Line selection: an all-internal group sends from the AI line (no
-    approval); any group containing an external contact sends from the
-    shared team number and requires HITL approval. A mixed group
-    (internal + external members) is allowed but flagged — sending it
-    exposes the internal members' numbers to the external recipients, so
-    the HITL approval is the safeguard.
+    Groups are either all-internal or all-external — mixing internal and
+    external recipients in one group is hard-blocked at resolution time
+    (see ``resolve_group_sms_routing``). Line selection: an all-internal
+    group sends from the AI line (no approval); an all-external group
+    sends from the shared team number and requires HITL approval.
     """
 
     routings: list[SmsRouting]
     phones: list[str]  # deduped, original order preserved
     all_internal: bool
     has_external: bool
-    is_mixed: bool
     from_phone_id: str
     line_name: str
 
@@ -440,9 +438,11 @@ async def resolve_group_sms_routing(
     """Resolve a list of phone numbers to group-SMS routing parameters.
 
     Returns GroupSmsRouting on success, or an error string when the group
-    is invalid: fewer than 2 unique recipients, more than
+    is invalid — all of these are deterministic gates that approval cannot
+    override: fewer than 2 unique recipients, more than
     ``GROUP_SMS_MAX_RECIPIENTS`` (the Quo API's per-message ``to`` limit),
-    or any recipient that is not a Quo contact.
+    any recipient that is not a Quo contact, tenants from different units
+    in one group, or a mix of internal and external recipients.
     """
     unique_phones = list(dict.fromkeys(phones))  # dedupe, keep order
     if len(unique_phones) < 2:
@@ -489,12 +489,24 @@ async def resolve_group_sms_routing(
 
     all_internal = all(r.is_internal for r in routings)
     has_external = any(not r.is_internal for r in routings)
+
+    # Deterministic internal/external separation: a group can be all-internal
+    # or all-external, never a mix — a mixed group would expose internal team
+    # numbers to external recipients. Hard block; approval cannot override.
+    if has_external and not all_internal and any(r.is_internal for r in routings):
+        internal_names = ", ".join(r.contact_name for r in routings if r.is_internal)
+        external_names = ", ".join(r.contact_name for r in routings if not r.is_internal)
+        return (
+            "Blocked: internal team members and external contacts can never "
+            f"share a group thread (internal: {internal_names}; external: "
+            f"{external_names}). Send separate messages instead."
+        )
+
     return GroupSmsRouting(
         routings=routings,
         phones=unique_phones,
         all_internal=all_internal,
         has_external=has_external,
-        is_mixed=has_external and any(r.is_internal for r in routings),
         from_phone_id=QUO_SERNIA_AI_PHONE_ID if all_internal else QUO_SHARED_EXTERNAL_PHONE_ID,
         line_name="Sernia AI" if all_internal else "Sernia Capital Team",
     )
@@ -1515,11 +1527,18 @@ async def _seed_sms_conversation(
     phone: str,
     outbound_text: str,
     context: str,
+    conv_id: str | None = None,
+    contact_identifier: str | None = None,
 ) -> None:
-    """Seed the recipient's ai_sms_from_ conversation with hidden context.
+    """Seed the recipient's AI SMS conversation with hidden context.
 
     Creates or appends to the conversation so that when the recipient
     replies via SMS, the AI agent has context about why the message was sent.
+
+    Defaults to the recipient's 1:1 ``ai_sms_from_{digits}`` conversation.
+    Group sends pass an explicit ``conv_id`` (``ai_sms_group_{CN...}``) so
+    the context lands in the conversation the AI SMS trigger loads when a
+    group member replies.
     """
     from api.src.ai_demos.models import (
         get_conversation_messages,
@@ -1528,8 +1547,11 @@ async def _seed_sms_conversation(
     from api.src.database.database import AsyncSessionFactory
     from api.src.sernia_ai.config import AGENT_NAME, TRIGGER_BOT_ID
 
-    digits = re.sub(r"\D", "", phone)
-    conv_id = f"ai_sms_from_{digits}"
+    if conv_id is None:
+        digits = re.sub(r"\D", "", phone)
+        conv_id = f"ai_sms_from_{digits}"
+    if contact_identifier is None:
+        contact_identifier = phone
 
     async with AsyncSessionFactory() as session:
         # Load existing conversation (if any) so we append, not overwrite
@@ -1562,7 +1584,7 @@ async def _seed_sms_conversation(
             clerk_user_id=TRIGGER_BOT_ID,
             metadata={"trigger_source": "ai_sms", "seeded_from_tool": True},
             modality="sms",
-            contact_identifier=phone,
+            contact_identifier=contact_identifier,
         )
     logfire.info(
         "sms conversation seeded with context",
@@ -1886,21 +1908,14 @@ def _build_quo_toolset():
         **Group texts**: pass a list of 2-10 phone numbers to start ONE shared
         thread — all recipients see the message and each other's replies (and
         each other's phone numbers). An all-internal group sends from the AI
-        line with no approval; a group containing ANY external contact sends
-        from the shared team number and requires approval. A mixed
-        internal+external group exposes the internal members' numbers to the
-        external recipients — only do this when that's clearly intended.
-        Tenants from DIFFERENT units are always blocked from sharing a group
-        thread (deterministic — approval cannot override); roommates in the
-        same unit are fine.
+        line with no approval, and when members reply, you respond in the
+        same group thread. An all-external group sends from the shared team
+        number and requires approval. Two deterministic blocks that approval
+        cannot override: internal and external contacts can NEVER be mixed
+        in one group, and tenants from DIFFERENT units can never share a
+        group thread (roommates in the same unit are fine).
         To message multiple people SEPARATELY (private 1:1 threads), call
         this tool once per recipient instead.
-
-        Known limitation: replies to an all-internal group (sent from the
-        AI line) are currently processed by the AI SMS trigger as 1:1
-        conversations — the AI's answer goes to the replier privately, not
-        into the group thread. Prefer 1:1 sends when you expect to hold a
-        conversation; use internal group texts for announcements.
 
         Max 1000 chars — messages over this limit are rejected (shorten/summarize
         and retry). Messages over 500 chars are auto-split into multiple texts.
@@ -1941,7 +1956,6 @@ def _build_quo_toolset():
                 to=group.phones,
                 names=group.recipient_names,
                 all_internal=group.all_internal,
-                is_mixed=group.is_mixed,
                 from_phone_id=group.from_phone_id,
             )
 
@@ -1954,13 +1968,27 @@ def _build_quo_toolset():
                 ctx.deps.conversation_id,
             )
 
-            # Seed each recipient's AI SMS conversation with hidden context
+            # Seed the GROUP conversation with hidden context: look up the
+            # Quo conversation the send created/reused so the seed lands in
+            # the ``ai_sms_group_{CN...}`` conversation the AI SMS trigger
+            # loads when a group member replies. Falls back to per-recipient
+            # 1:1 seeding when the conversation isn't findable yet.
             if context and "Failed" not in send_result:
-                for phone in group.phones:
-                    try:
-                        await _seed_sms_conversation(phone, message, context)
-                    except Exception:
-                        logfire.exception("send_sms: failed to seed conversation", to=phone)
+                try:
+                    conv = await _find_group_conversation(client, group.phones)
+                    if conv and conv.get("id"):
+                        await _seed_sms_conversation(
+                            group.phones[0],
+                            message,
+                            context,
+                            conv_id=f"ai_sms_group_{conv['id']}",
+                            contact_identifier=",".join(sorted(group.phones)),
+                        )
+                    else:
+                        for phone in group.phones:
+                            await _seed_sms_conversation(phone, message, context)
+                except Exception:
+                    logfire.exception("send_sms: failed to seed group conversation")
 
             if send_result.startswith("Group message sent"):
                 named = ", ".join(

--- a/api/src/sernia_ai/tools/quo_tools.py
+++ b/api/src/sernia_ai/tools/quo_tools.py
@@ -1971,11 +1971,21 @@ def _build_quo_toolset():
             # Seed the GROUP conversation with hidden context: look up the
             # Quo conversation the send created/reused so the seed lands in
             # the ``ai_sms_group_{CN...}`` conversation the AI SMS trigger
-            # loads when a group member replies. Falls back to per-recipient
-            # 1:1 seeding when the conversation isn't findable yet.
+            # loads when a group member replies. Retries briefly — a freshly
+            # created conversation can lag in /v1/conversations. No 1:1
+            # fallback: the group trigger never reads ``ai_sms_from_*``
+            # conversations, so seeding them would silently lose the context.
             if context and "Failed" not in send_result:
                 try:
-                    conv = await _find_group_conversation(client, group.phones)
+                    import asyncio
+
+                    conv = None
+                    for delay in (0, 2, 4):
+                        if delay:
+                            await asyncio.sleep(delay)
+                        conv = await _find_group_conversation(client, group.phones)
+                        if conv and conv.get("id"):
+                            break
                     if conv and conv.get("id"):
                         await _seed_sms_conversation(
                             group.phones[0],
@@ -1985,8 +1995,11 @@ def _build_quo_toolset():
                             contact_identifier=",".join(sorted(group.phones)),
                         )
                     else:
-                        for phone in group.phones:
-                            await _seed_sms_conversation(phone, message, context)
+                        logfire.warn(
+                            "send_sms: group conversation not found after send — "
+                            "context NOT seeded",
+                            phones=group.phones,
+                        )
                 except Exception:
                     logfire.exception("send_sms: failed to seed group conversation")
 

--- a/api/src/sernia_ai/triggers/README.md
+++ b/api/src/sernia_ai/triggers/README.md
@@ -36,6 +36,17 @@ flowchart TD
 
 The AI SMS event trigger treats the SMS thread as a direct conversation. Only internal contacts (Sernia Capital LLC) are allowed. The agent responds natively via SMS.
 
+### Group Threads
+
+A `message.received` on the AI line whose webhook `to` field contains recipients **besides the AI's own number** is a **group text** (`_extract_group_participants` — the AI's E.164 number comes from the process-cached `open_phone.service.get_ai_phone_number()`; if that lookup fails, the trigger safely falls back to 1:1 handling). Group messages take a parallel path (`_handle_group_sms`) that differs from the 1:1 flow in four ways:
+
+1. **Gate** — *every* human participant (sender + other recipients) must be an internal contact. One external/unknown member and the whole event is silently ignored.
+2. **Conversation key** — `ai_sms_group_{CN...}` (the Quo conversation ID), so all group members share **one** AI conversation, instead of the sender's personal `ai_sms_from_{digits}`.
+3. **History** — reconstructed from the local `open_phone_events` webhook table (the only source of full group history — OpenPhone's API can't list group messages by participant filter), merged with DB history. Inbound turns are prefixed `[Sender Name]:` so the agent can tell members apart; the same prefix format is used for the live prompt so text-dedup in the merge works. The current message is excluded from reconstruction (the webhook saves it to the events table *before* the background task runs) since it becomes the run's prompt.
+4. **Reply** — sent to **all** human participants in one API call (`to` array), landing in the same group thread. Post-approval replies do the same: the conversation's `trigger_group_participants` metadata routes `routes.approve_conversation()`'s SMS reply to the group instead of 1:1.
+
+`send_sms`'s hidden-context seeding for group sends targets the same `ai_sms_group_{CN...}` conversation (looked up via `_find_group_conversation` after the send), so the agent has the context when any member replies.
+
 ### History Loading
 
 The trigger always fetches from **both** sources and merges them:
@@ -57,7 +68,11 @@ flowchart TD
 
     CONTACT --> GATE{"Sernia Capital<br/>LLC contact?"}
     GATE -->|No| IGNORE["Silently ignore<br/>(external/unknown)"]
-    GATE -->|Yes| CONV_ID["Derive conv_id:<br/>ai_sms_from_{digits}"]
+    GATE -->|Yes| GROUP{"Group message?<br/>(to has recipients<br/>besides AI line)"}
+    GROUP -->|Yes| GGATE{"ALL participants<br/>internal?"}
+    GGATE -->|No| GIGNORE["Silently ignore"]
+    GGATE -->|Yes| GFLOW["_handle_group_sms():<br/>conv_id ai_sms_group_{CN},<br/>history from open_phone_events,<br/>reply to ALL participants"]
+    GROUP -->|No| CONV_ID["Derive conv_id:<br/>ai_sms_from_{digits}"]
 
     CONV_ID --> FETCH["Fetch both sources in parallel"]
     FETCH --> DB["DB: get_conversation_messages()"]
@@ -209,7 +224,7 @@ Separate sliding-window rate limiter in `ai_sms_event_trigger.py`:
 |------|---------|
 | `background_agent_runner.py` | Core async runner: triggers-enabled check, rate limiting, agent run, `NoAction` handling, HITL approval push (`notify_pending_approval` only — generic completion alerts removed) |
 | `zillow_email_event_trigger.py` | Zillow email event trigger: real-time draft generation when Zillow emails arrive via Pub/Sub, Emilio-only push notification |
-| `ai_sms_event_trigger.py` | AI SMS event trigger: contact gate, history loading/bootstrap, agent run with `modality="sms"`, SMS reply |
+| `ai_sms_event_trigger.py` | AI SMS event trigger: contact gate, history loading/bootstrap, agent run with `modality="sms"`, SMS reply. Group messages (`to` beyond the AI line) run `_handle_group_sms`: all-internal gate, `ai_sms_group_{CN}` conversation, events-table history, reply to all participants |
 | `scheduled_triggers.py` | Single scheduled trigger + APScheduler registration: `run_scheduled_checks()` |
 
 ## Config (`config.py`)

--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -93,6 +93,92 @@ def _digits_only(phone: str) -> str:
     return re.sub(r"\D", "", phone)
 
 
+# ---------------------------------------------------------------------------
+# Group SMS support — a message.received on the AI line whose ``to`` includes
+# recipients besides the AI's own number is a GROUP text. The AI replies into
+# the same group thread (all human participants) instead of 1:1.
+# ---------------------------------------------------------------------------
+
+
+def _split_to_numbers(to_number) -> list[str]:
+    """Normalize the webhook ``to`` field to a list of E.164 strings.
+
+    OpenPhone delivers ``to`` as a single string — comma-joined when the
+    message went to a group. Accepts a list too, defensively.
+    """
+    if not to_number:
+        return []
+    if isinstance(to_number, str):
+        return [p.strip() for p in to_number.split(",") if p.strip()]
+    return [str(p).strip() for p in to_number if str(p).strip()]
+
+
+def _extract_group_participants(event_data: dict, ai_phone: str | None) -> list[str]:
+    """Human group participants besides the sender: every ``to`` recipient
+    that isn't the AI line itself.
+
+    Returns [] for a 1:1 message (the only recipient is the AI line) — and
+    also when ``ai_phone`` is unknown (None), because without it a 1:1
+    message's own ``to`` entry can't be told apart from a real participant.
+    Falling back to 1:1 handling is the safe failure mode.
+    """
+    if not ai_phone:
+        return []
+    from_number = event_data.get("from_number", "")
+    return [
+        p
+        for p in _split_to_numbers(event_data.get("to_number"))
+        if p and p != from_number and p != ai_phone
+    ]
+
+
+def _group_prompt(sender_name: str, text: str) -> str:
+    """Prefix a group message with its sender so the agent can tell group
+    members apart. Used for BOTH the live prompt and history reconstruction
+    from the events table — the formats must match for text dedup to work."""
+    return f"[{sender_name}]: {text}"
+
+
+def _group_activities_to_model_messages(
+    activities: list[dict],
+    ai_phone: str | None,
+    name_by_phone: dict[str, str],
+    exclude_message_id: str | None = None,
+) -> list[ModelMessage]:
+    """Convert events-table group activities into PydanticAI messages.
+
+    Outgoing messages from the AI line become assistant turns; everything
+    else becomes a user turn prefixed with the sender's name via
+    ``_group_prompt``. ``exclude_message_id`` drops the activity for the
+    message currently being processed — it is passed as the run's prompt
+    instead (the webhook saves the event to the DB before the background
+    task runs, so the current message is already in the table).
+    """
+    result: list[ModelMessage] = []
+    for act in activities:
+        if act.get("_kind") != "message":
+            continue
+        if exclude_message_id and act.get("id") == exclude_message_id:
+            continue
+        text = (act.get("text") or "").strip()
+        if not text:
+            continue
+        ts = _parse_timestamp(act.get("createdAt"))
+        sender = act.get("from") or ""
+        if ai_phone and sender == ai_phone:
+            resp_kwargs: dict = {"timestamp": ts} if ts is not None else {}
+            result.append(ModelResponse(parts=[TextPart(content=text)], **resp_kwargs))
+        else:
+            name = name_by_phone.get(sender, sender or "Unknown")
+            part_kwargs: dict = {"timestamp": ts} if ts is not None else {}
+            result.append(
+                ModelRequest(
+                    parts=[UserPromptPart(content=_group_prompt(name, text), **part_kwargs)]
+                )
+            )
+    return result
+
+
 async def _verify_internal_contact(phone: str) -> dict | None:
     """Check if phone belongs to a Sernia Capital LLC contact.
 
@@ -433,8 +519,12 @@ def _sanitize_tool_calls(messages: list[ModelMessage]) -> list[ModelMessage]:
     return result
 
 
-async def _send_sms_reply(to_phone: str, message: str) -> None:
-    """Send an SMS reply from the AI phone number, auto-splitting if long. Never raises."""
+async def _send_sms_reply(to_phone: str | list[str], message: str) -> None:
+    """Send an SMS reply from the AI phone number, auto-splitting if long.
+
+    ``to_phone`` may be a single number (1:1 reply) or a list of numbers —
+    a list replies into the shared group thread. Never raises.
+    """
     from api.src.sernia_ai.tools.quo_tools import split_sms
 
     chunks = split_sms(message)
@@ -500,6 +590,22 @@ async def handle_ai_sms_event(event_data: dict) -> None:
         return
 
     contact_name = _contact_display_name(contact)
+
+    # --- Group detection: to includes recipients besides the AI line ---
+    from api.src.open_phone.service import get_ai_phone_number
+
+    ai_phone = await get_ai_phone_number()
+    other_participants = _extract_group_participants(event_data, ai_phone)
+    if other_participants:
+        await _handle_group_sms(
+            event_data,
+            sender_contact=contact,
+            sender_name=contact_name,
+            other_participants=other_participants,
+            ai_phone=ai_phone,
+        )
+        return
+
     conv_id = f"ai_sms_from_{_digits_only(from_number)}"
 
     # Load conversation history — always fetch SMS thread from Quo and
@@ -630,5 +736,206 @@ async def handle_ai_sms_event(event_data: dict) -> None:
             "ai_sms_event: completed",
             conversation_id=conv_id,
             from_number=from_number,
+            has_pending=bool(pending),
+        )
+
+
+async def _handle_group_sms(
+    event_data: dict,
+    *,
+    sender_contact: dict,
+    sender_name: str,
+    other_participants: list[str],
+    ai_phone: str,
+) -> None:
+    """Process an inbound GROUP SMS on the AI line.
+
+    Differences from the 1:1 flow:
+
+    - **Gate**: every human participant (sender + other recipients) must be
+      an internal contact — one external/unknown member and the whole event
+      is silently ignored, same as an external 1:1 sender.
+    - **Conversation**: keyed to the Quo group conversation
+      (``ai_sms_group_{CN...}``) so all members share one AI conversation,
+      instead of the sender's personal ``ai_sms_from_{digits}``.
+    - **History**: group thread reconstructed from the local
+      ``open_phone_events`` webhook table (the only source of full group
+      history — OpenPhone's API can't list group messages by participant),
+      merged with DB history. User turns are prefixed ``[Sender Name]:``.
+    - **Reply**: sent to ALL human participants in one message, landing in
+      the same group thread.
+    """
+    from_number = event_data.get("from_number", "")
+    message_text = event_data.get("message_text", "")
+    quo_conv_id = event_data.get("conversation_id")
+
+    # Gate: every other participant must also be internal.
+    participant_contacts: dict[str, dict] = {from_number: sender_contact}
+    for phone in other_participants:
+        member = await _verify_internal_contact(phone)
+        if not member:
+            logfire.info(
+                "ai_sms_event: ignoring group with external/unknown participant",
+                participant=phone,
+                from_number=from_number,
+            )
+            return
+        participant_contacts[phone] = member
+
+    name_by_phone = {p: _contact_display_name(c) for p, c in participant_contacts.items()}
+    all_humans = sorted(participant_contacts)  # sender + others, deterministic order
+
+    if quo_conv_id:
+        conv_id = f"ai_sms_group_{quo_conv_id}"
+    else:
+        conv_id = "ai_sms_group_" + "_".join(_digits_only(p) for p in all_humans)
+
+    # The current message's Quo ID — already saved to the events table by the
+    # webhook route, so exclude it from reconstructed history (it becomes the
+    # run's prompt instead).
+    current_msg_id = (
+        ((event_data.get("event_data") or {}).get("data") or {}).get("object") or {}
+    ).get("id")
+
+    logfire.info(
+        "ai_sms_event: processing GROUP SMS",
+        conversation_id=conv_id,
+        from_number=from_number,
+        participants=all_humans,
+    )
+
+    async with AsyncSessionFactory() as session:
+        db_history = await get_conversation_messages(conv_id, clerk_user_id=None, session=session)
+
+        group_thread: list[ModelMessage] = []
+        if quo_conv_id:
+            try:
+                from api.src.sernia_ai.tools.quo_tools import (
+                    _fetch_group_thread_from_events_table,
+                )
+
+                activities = await _fetch_group_thread_from_events_table(
+                    quo_conv_id,
+                    max_results=SMS_CONVERSATION_MAX_MESSAGES,
+                )
+                group_thread = _group_activities_to_model_messages(
+                    activities,
+                    ai_phone,
+                    name_by_phone,
+                    exclude_message_id=current_msg_id,
+                )
+            except Exception:
+                logfire.exception(
+                    "ai_sms_event: group thread reconstruction failed",
+                    conversation_id=conv_id,
+                )
+
+        merged = _merge_sms_into_history(db_history, group_thread)
+        trimmed, trimmed_count = _trim_sms_history(merged)
+        history = _sanitize_tool_calls(trimmed)
+        logfire.info(
+            "ai_sms_event: group history loaded",
+            conversation_id=conv_id,
+            db_messages=len(db_history),
+            group_thread_messages=len(group_thread),
+            after_trim=len(trimmed),
+            trimmed=trimmed_count,
+        )
+
+        participants_label = ", ".join(f"{name_by_phone[p]} ({p})" for p in all_humans)
+        group_hint = (
+            f" [System: This is a GROUP SMS thread with {participants_label}. "
+            "Messages are prefixed with the sender's name. Your reply will be "
+            "sent to the WHOLE group.]"
+        )
+        if trimmed_count > 0:
+            group_hint += (
+                f" [System: History trimmed — {trimmed_count} older message(s) omitted. "
+                "Use `get_thread_messages` with the participant list for earlier context.]"
+            )
+
+        deps = SerniaDeps(
+            db_session=session,
+            conversation_id=conv_id,
+            user_identifier=f"sms_group:{from_number}",
+            user_name=sender_name,
+            user_email=GOOGLE_DELEGATION_EMAIL,
+            modality="sms",
+            workspace_path=WORKSPACE_PATH,
+        )
+
+        run_kwargs = await resolve_active_run_kwargs()
+
+        try:
+            result = await sernia_agent.run(
+                _group_prompt(sender_name, message_text) + group_hint,
+                message_history=history,
+                deps=deps,
+                metadata={"trigger_source": "ai_sms_group"},
+                **run_kwargs,
+            )
+        except Exception:
+            logfire.exception(
+                "ai_sms_event: group agent run failed",
+                conversation_id=conv_id,
+            )
+            return
+
+        create_logged_task(commit_and_push(WORKSPACE_PATH), name="git_sync")
+
+        await save_agent_conversation(
+            session=session,
+            conversation_id=conv_id,
+            agent_name=AGENT_NAME,
+            messages=result.all_messages(),
+            clerk_user_id=TRIGGER_BOT_ID,
+            metadata={
+                "trigger_source": "ai_sms_group",
+                "trigger_phone": from_number,
+                "trigger_contact_name": sender_name,
+                "openphone_conversation_id": quo_conv_id,
+                # Post-approval replies use this to respond into the group
+                # thread instead of 1:1 (see routes.approve_conversation).
+                "trigger_group_participants": all_humans,
+            },
+            modality="sms",
+            contact_identifier=",".join(all_humans),
+        )
+
+        pending = extract_pending_approvals(result)
+        if pending:
+            first = pending[0]
+            create_logged_task(
+                notify_pending_approval(
+                    conversation_id=conv_id,
+                    tool_name=first["tool_name"],
+                    tool_args=first.get("args"),
+                ),
+                name="notify_pending_approval",
+            )
+            logfire.info(
+                "ai_sms_event: group HITL pause — awaiting approval",
+                conversation_id=conv_id,
+                tool_name=first["tool_name"],
+            )
+        elif isinstance(result.output, NoAction):
+            logfire.info(
+                "ai_sms_event: group NoAction — no SMS reply",
+                conversation_id=conv_id,
+                reason=result.output.reason,
+            )
+        else:
+            output_text = result.output if isinstance(result.output, str) else ""
+            if output_text:
+                create_logged_task(
+                    _send_sms_reply(all_humans, output_text),
+                    name="sms_reply",
+                )
+
+        logfire.info(
+            "ai_sms_event: group completed",
+            conversation_id=conv_id,
+            from_number=from_number,
+            participants=all_humans,
             has_pending=bool(pending),
         )

--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -299,18 +299,32 @@ def _sms_to_model_messages(messages: list[dict]) -> list[ModelMessage]:
     return result
 
 
+# Prompts persisted to the DB can carry appended system hints (history-trim
+# notes, the group-thread hint) that the same message reconstructed from the
+# Quo API / events table doesn't have. Strip them before dedup comparison,
+# otherwise every hinted turn is re-prepended as "missing" on the next run
+# and the agent sees each prior message twice.
+_SYSTEM_HINT_RE = re.compile(r"\s*\[System:.*$", re.DOTALL)
+
+
+def _dedup_key(text: str) -> str:
+    """Normalize a message text for dedup: strip appended system hints."""
+    return _SYSTEM_HINT_RE.sub("", text).strip()
+
+
 def _extract_text_contents(messages: list[ModelMessage]) -> set[str]:
-    """Extract all text content strings from a message list for dedup."""
+    """Extract all (normalized) text content strings from a message list for
+    dedup — appended ``[System: ...]`` hints are stripped via ``_dedup_key``."""
     texts: set[str] = set()
     for msg in messages:
         if isinstance(msg, ModelRequest):
             for part in msg.parts:
                 if isinstance(part, UserPromptPart) and isinstance(part.content, str):
-                    texts.add(part.content.strip())
+                    texts.add(_dedup_key(part.content))
         elif isinstance(msg, ModelResponse):
             for part in msg.parts:
                 if isinstance(part, TextPart):
-                    texts.add(part.content.strip())
+                    texts.add(_dedup_key(part.content))
     return texts
 
 
@@ -330,7 +344,7 @@ def _merge_sms_into_history(
     if not db_history:
         return sms_thread
 
-    # Find text contents already in DB history
+    # Find text contents already in DB history (normalized via _dedup_key)
     db_texts = _extract_text_contents(db_history)
 
     # Collect SMS messages not present in DB
@@ -339,13 +353,13 @@ def _merge_sms_into_history(
         if isinstance(msg, ModelRequest):
             for part in msg.parts:
                 if isinstance(part, UserPromptPart) and isinstance(part.content, str):
-                    if part.content.strip() not in db_texts:
+                    if _dedup_key(part.content) not in db_texts:
                         missing.append(msg)
                         break
         elif isinstance(msg, ModelResponse):
             for part in msg.parts:
                 if isinstance(part, TextPart):
-                    if part.content.strip() not in db_texts:
+                    if _dedup_key(part.content) not in db_texts:
                         missing.append(msg)
                         break
 

--- a/api/src/tests/test_ai_sms_group_trigger.py
+++ b/api/src/tests/test_ai_sms_group_trigger.py
@@ -1,0 +1,231 @@
+"""
+Unit tests for group-SMS handling in the AI SMS event trigger.
+
+A message.received on the AI line whose ``to`` includes recipients besides
+the AI's own number is a GROUP text: the trigger keys the conversation to
+the Quo group conversation (``ai_sms_group_{CN...}``), reconstructs history
+from the local ``open_phone_events`` table with sender-name prefixes, and
+replies to ALL human participants so the answer lands in the group thread.
+
+⚠️  SMS SAFETY: All SMS tests mock the send call. NEVER send real SMS from
+tests. See CLAUDE.md.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+
+from api.src.sernia_ai.triggers.ai_sms_event_trigger import (
+    _extract_group_participants,
+    _group_activities_to_model_messages,
+    _group_prompt,
+    _send_sms_reply,
+    _split_to_numbers,
+)
+
+AI_PHONE = "+14125559999"
+EMILIO = "+14123703550"
+SANA = "+14128770257"
+
+
+# ===========================================================================
+# _split_to_numbers
+# ===========================================================================
+
+
+class TestSplitToNumbers:
+    def test_single_string(self):
+        assert _split_to_numbers(AI_PHONE) == [AI_PHONE]
+
+    def test_comma_joined_group(self):
+        assert _split_to_numbers(f"{AI_PHONE},{SANA}") == [AI_PHONE, SANA]
+
+    def test_comma_joined_with_spaces(self):
+        assert _split_to_numbers(f"{AI_PHONE}, {SANA}") == [AI_PHONE, SANA]
+
+    def test_list_passthrough(self):
+        assert _split_to_numbers([AI_PHONE, SANA]) == [AI_PHONE, SANA]
+
+    def test_empty_values(self):
+        assert _split_to_numbers(None) == []
+        assert _split_to_numbers("") == []
+        assert _split_to_numbers([]) == []
+
+
+# ===========================================================================
+# _extract_group_participants
+# ===========================================================================
+
+
+class TestExtractGroupParticipants:
+    def test_one_to_one_message_yields_no_participants(self):
+        """A plain 1:1 SMS to the AI line: to == AI phone only."""
+        event = {"from_number": EMILIO, "to_number": AI_PHONE}
+        assert _extract_group_participants(event, AI_PHONE) == []
+
+    def test_group_message_yields_other_humans(self):
+        """Group SMS from Emilio to [AI, Sana]: Sana is the other human."""
+        event = {"from_number": EMILIO, "to_number": f"{AI_PHONE},{SANA}"}
+        assert _extract_group_participants(event, AI_PHONE) == [SANA]
+
+    def test_unknown_ai_phone_falls_back_to_1to1(self):
+        """When the AI's own number can't be resolved, group detection is
+        unsafe (the AI's own to-entry would look like a participant) — the
+        trigger must fall back to 1:1 handling."""
+        event = {"from_number": EMILIO, "to_number": f"{AI_PHONE},{SANA}"}
+        assert _extract_group_participants(event, None) == []
+
+    def test_sender_excluded_from_participants(self):
+        event = {"from_number": EMILIO, "to_number": f"{AI_PHONE},{EMILIO},{SANA}"}
+        assert _extract_group_participants(event, AI_PHONE) == [SANA]
+
+
+# ===========================================================================
+# _group_activities_to_model_messages
+# ===========================================================================
+
+
+def _activity(
+    kind: str,
+    msg_id: str,
+    sender: str,
+    text: str | None,
+    created: str = "2026-08-14T12:00:00+00:00",
+) -> dict:
+    return {
+        "_kind": kind,
+        "id": msg_id,
+        "createdAt": created,
+        "text": text,
+        "from": sender,
+        "to": [],
+        "direction": "outgoing" if sender == AI_PHONE else "incoming",
+    }
+
+
+class TestGroupActivitiesToModelMessages:
+    NAMES = {EMILIO: "Emilio Esposito", SANA: "Sana Esposito"}
+
+    def test_incoming_prefixed_with_sender_name(self):
+        msgs = _group_activities_to_model_messages(
+            [_activity("message", "AC1", EMILIO, "Red skies")],
+            AI_PHONE,
+            self.NAMES,
+        )
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], ModelRequest)
+        part = msgs[0].parts[0]
+        assert isinstance(part, UserPromptPart)
+        assert part.content == _group_prompt("Emilio Esposito", "Red skies")
+        assert part.timestamp is not None
+
+    def test_ai_outgoing_becomes_assistant_turn(self):
+        msgs = _group_activities_to_model_messages(
+            [_activity("message", "AC2", AI_PHONE, "Sailors' delight!")],
+            AI_PHONE,
+            self.NAMES,
+        )
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], ModelResponse)
+        assert isinstance(msgs[0].parts[0], TextPart)
+        assert msgs[0].parts[0].content == "Sailors' delight!"
+
+    def test_current_message_excluded(self):
+        """The webhook saves the current message to the events table before
+        the background task runs — it must be dropped from history (it's the
+        run's prompt instead)."""
+        msgs = _group_activities_to_model_messages(
+            [
+                _activity("message", "AC1", EMILIO, "earlier"),
+                _activity("message", "ACcurrent", SANA, "the live message"),
+            ],
+            AI_PHONE,
+            self.NAMES,
+            exclude_message_id="ACcurrent",
+        )
+        assert len(msgs) == 1
+        assert "earlier" in msgs[0].parts[0].content
+
+    def test_calls_and_empty_texts_skipped(self):
+        msgs = _group_activities_to_model_messages(
+            [
+                _activity("call", "AC3", EMILIO, None),
+                _activity("message", "AC4", EMILIO, "   "),
+                _activity("message", "AC5", SANA, "real message"),
+            ],
+            AI_PHONE,
+            self.NAMES,
+        )
+        assert len(msgs) == 1
+        assert "real message" in msgs[0].parts[0].content
+
+    def test_unknown_sender_falls_back_to_phone(self):
+        msgs = _group_activities_to_model_messages(
+            [_activity("message", "AC6", "+19995550000", "hi")],
+            AI_PHONE,
+            self.NAMES,
+        )
+        assert msgs[0].parts[0].content == "[+19995550000]: hi"
+
+
+# ===========================================================================
+# _send_sms_reply — group recipients
+# ===========================================================================
+
+
+class TestSendSmsReplyGroup:
+    @pytest.mark.asyncio
+    async def test_group_reply_sends_to_all_participants(self):
+        with patch(
+            "api.src.sernia_ai.triggers.ai_sms_event_trigger.send_message", new=AsyncMock()
+        ) as send:
+            await _send_sms_reply([EMILIO, SANA], "group answer")
+        assert send.await_count == 1
+        kwargs = send.await_args.kwargs
+        assert kwargs["to_phone_number"] == [EMILIO, SANA]
+
+    @pytest.mark.asyncio
+    async def test_single_reply_unchanged(self):
+        with patch(
+            "api.src.sernia_ai.triggers.ai_sms_event_trigger.send_message", new=AsyncMock()
+        ) as send:
+            await _send_sms_reply(EMILIO, "solo answer")
+        assert send.await_count == 1
+        assert send.await_args.kwargs["to_phone_number"] == EMILIO
+
+
+# ===========================================================================
+# send_message — group payload
+# ===========================================================================
+
+
+class TestSendMessageGroupPayload:
+    @pytest.mark.asyncio
+    async def test_list_recipients_in_one_to_array(self):
+        import httpx
+
+        from api.src.open_phone import service as op_service
+
+        captured: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            captured.append(json.loads(request.content))
+            return httpx.Response(202, json={"data": {"id": "ACtest"}})
+
+        def fake_client():
+            return httpx.AsyncClient(
+                base_url="https://api.openphone.com",
+                transport=httpx.MockTransport(handler),
+            )
+
+        with patch.object(op_service, "_openphone_client", fake_client):
+            await op_service.send_message(
+                message="hello group",
+                to_phone_number=[EMILIO, SANA],
+                from_phone_number="PNtest",
+            )
+        assert captured[0]["to"] == [EMILIO, SANA]
+        assert captured[0]["from"] == "PNtest"

--- a/api/src/tests/test_ai_sms_group_trigger.py
+++ b/api/src/tests/test_ai_sms_group_trigger.py
@@ -170,6 +170,55 @@ class TestGroupActivitiesToModelMessages:
 
 
 # ===========================================================================
+# System-hint dedup normalization
+# ===========================================================================
+
+
+class TestSystemHintDedup:
+    """Persisted prompts carry appended ``[System: ...]`` hints that the
+    same message reconstructed from Quo / the events table doesn't have.
+    Dedup must strip them, or every hinted turn is re-prepended as
+    "missing" on the next run and appears twice."""
+
+    def test_dedup_key_strips_system_hint(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _dedup_key
+
+        hinted = "[Emilio Esposito]: Red skies [System: This is a GROUP SMS thread with ...]"
+        assert _dedup_key(hinted) == "[Emilio Esposito]: Red skies"
+
+    def test_dedup_key_noop_without_hint(self):
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import _dedup_key
+
+        assert _dedup_key("plain message") == "plain message"
+
+    def test_merge_dedups_hinted_db_prompt_against_reconstructed_turn(self):
+        """A DB prompt saved WITH a group hint must dedup against the same
+        message reconstructed WITHOUT the hint."""
+        from api.src.sernia_ai.triggers.ai_sms_event_trigger import (
+            _merge_sms_into_history,
+        )
+
+        db_history = [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content="[Emilio Esposito]: Red skies [System: This is a "
+                        "GROUP SMS thread with Emilio, Sana. Your reply will be "
+                        "sent to the WHOLE group.]"
+                    )
+                ]
+            ),
+            ModelResponse(parts=[TextPart(content="Sailors' delight!")]),
+        ]
+        reconstructed = [
+            ModelRequest(parts=[UserPromptPart(content="[Emilio Esposito]: Red skies")]),
+            ModelResponse(parts=[TextPart(content="Sailors' delight!")]),
+        ]
+        merged = _merge_sms_into_history(db_history, reconstructed)
+        assert merged == db_history, "hinted DB turn must absorb the reconstructed turn"
+
+
+# ===========================================================================
 # _send_sms_reply — group recipients
 # ===========================================================================
 

--- a/api/src/tests/test_quo_group_sms.py
+++ b/api/src/tests/test_quo_group_sms.py
@@ -137,7 +137,6 @@ class TestResolveGroupSmsRouting:
         assert isinstance(result, GroupSmsRouting)
         assert result.all_internal is True
         assert result.has_external is False
-        assert result.is_mixed is False
         assert result.from_phone_id == QUO_SERNIA_AI_PHONE_ID
         assert result.line_name == "Sernia AI"
         assert result.recipient_names == ["Emilio Esposito", "Anna Esposito"]
@@ -149,21 +148,20 @@ class TestResolveGroupSmsRouting:
         assert isinstance(result, GroupSmsRouting)
         assert result.all_internal is False
         assert result.has_external is True
-        assert result.is_mixed is False
         assert result.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
         assert result.line_name == "Sernia Capital Team"
 
     @pytest.mark.asyncio
-    async def test_mixed_group_flagged_and_uses_shared_line(self):
-        """Internal + external in one group: allowed, but routed to the shared
-        team line and flagged mixed — the HITL approval (has_external=True at
-        the tool level) is the safeguard for exposing internal numbers."""
+    async def test_mixed_group_blocked_deterministically(self):
+        """Internal + external in one group is hard-blocked — a mixed group
+        would expose internal team numbers to external recipients, and no
+        approval can override the block."""
         client = _capture_client([])
         result = await resolve_group_sms_routing([INTERNAL_A, EXTERNAL_A], client)
-        assert isinstance(result, GroupSmsRouting)
-        assert result.is_mixed is True
-        assert result.has_external is True
-        assert result.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+        assert isinstance(result, str)
+        assert "never share a group thread" in result
+        assert "Emilio Esposito" in result
+        assert "Sana Test" in result
 
     @pytest.mark.asyncio
     async def test_unknown_contact_blocks_whole_group(self):
@@ -215,15 +213,23 @@ class TestResolveGroupSmsRouting:
         assert result.has_external is True
 
     @pytest.mark.asyncio
-    async def test_internal_member_does_not_trip_unit_gate(self):
-        """Internal team members have no unit; adding one to a single-unit
-        tenant group must not trigger the cross-unit block."""
+    async def test_internal_plus_tenants_blocked_as_mixed(self):
+        """An internal member plus tenants is a mixed group — blocked by the
+        internal/external separation gate (tenants are external)."""
         client = _capture_client([])
         result = await resolve_group_sms_routing(
             [INTERNAL_A, TENANT_320_02_A, TENANT_320_02_B], client
         )
+        assert isinstance(result, str)
+        assert "never share a group thread" in result
+
+    @pytest.mark.asyncio
+    async def test_all_internal_group_allowed(self):
+        """Sanity: internal-only groups still resolve (AI line, no gates hit)."""
+        client = _capture_client([])
+        result = await resolve_group_sms_routing([INTERNAL_A, INTERNAL_B], client)
         assert isinstance(result, GroupSmsRouting)
-        assert result.is_mixed is True
+        assert result.all_internal is True
 
     @pytest.mark.asyncio
     async def test_duplicates_deduped_order_preserved(self):

--- a/api/src/tests/test_quo_tools.py
+++ b/api/src/tests/test_quo_tools.py
@@ -722,13 +722,23 @@ async def test_resolve_group_sms_routing_live_all_internal(quo_client: httpx.Asy
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("QUO_LIVE_GROUP_SMS_TEST"),
+    reason=(
+        "Sends a real group SMS (Emilio + TestSana, both internal). Opt in "
+        "with QUO_LIVE_GROUP_SMS_TEST=1 so the default live suite doesn't "
+        "text the team on every run."
+    ),
+)
 async def test_send_group_sms_live_emilio_and_sana(quo_client: httpx.AsyncClient):
     """Send a real group text to Emilio + TestSana through execute_sms.
 
     Both numbers are internal contacts (Emilio's own devices), so this is a
-    live INTERNAL send — allowed by SMS test safety. Routing is resolved
-    live first; the test skips rather than sending if the group ever stops
-    resolving as all-internal (e.g. the TestSana contact's company changes).
+    live INTERNAL send — allowed by SMS test safety, but still opt-in via
+    QUO_LIVE_GROUP_SMS_TEST to keep surprise texts out of routine live
+    runs. Routing is resolved live first; the test skips rather than
+    sending if the group ever stops resolving as all-internal (e.g. the
+    TestSana contact's company changes).
     """
     from api.src.sernia_ai.tools.quo_tools import (
         GroupSmsRouting,

--- a/api/src/tests/test_quo_tools.py
+++ b/api/src/tests/test_quo_tools.py
@@ -695,53 +695,17 @@ TESTSANA_NUMBER = "+14128770257"
 # The Quo API's POST /v1/messages `to` array accepts up to 10 recipients
 # (spec maxItems: 10), landing the message in ONE shared group thread.
 # First verified live 2026-08-13 with Emilio + TestSana: HTTP 202, single
-# conversationId, status reached "delivered".
+# conversationId, status reached "delivered". TestSana was made an internal
+# contact (Sernia Capital LLC) on 2026-08-14, so this group is all-internal
+# and sends from the AI line — a live internal send, allowed per SMS safety.
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    not os.environ.get("QUO_LIVE_GROUP_SMS_TEST"),
-    reason=(
-        "Sends a real group SMS to TestSana (classified external — company "
-        "'Test2'). Repo policy keeps external sends out of the default live "
-        "suite; set QUO_LIVE_GROUP_SMS_TEST=1 to opt in deliberately."
-    ),
-)
-async def test_send_group_sms_live_emilio_and_sana(quo_client: httpx.AsyncClient):
-    """Send a real group text to Emilio + TestSana through execute_sms.
-
-    Both numbers are Emilio's own devices (internal number + the dedicated
-    TestSana test contact), and Emilio explicitly requested this live trial
-    (2026-08-13 — delivered, single group conversationId). But TestSana is
-    *classified* external (company 'Test2'), so per SMS test safety this
-    send is opt-in via QUO_LIVE_GROUP_SMS_TEST rather than part of the
-    default ``pytest -m live`` run. Verifies the group code path
-    end-to-end: one API call, both recipients in one shared thread.
-    """
-    from api.src.sernia_ai.config import QUO_SHARED_EXTERNAL_PHONE_ID
-    from api.src.sernia_ai.tools.quo_tools import execute_sms
-
-    result = await execute_sms(
-        quo_client,
-        [INTERNAL_TEST_NUMBER, TESTSANA_NUMBER],
-        "[QUO GROUP TEST] Group text via execute_sms — Emilio + Sana in one thread. Please ignore.",
-        QUO_SHARED_EXTERNAL_PHONE_ID,
-        "Sernia Capital Team",
-        tool_name="test_group_sms",
-    )
-    print(f"\nGroup send result: {result}")
-    assert result.startswith("Group message sent to")
-    assert INTERNAL_TEST_NUMBER in result
-    assert TESTSANA_NUMBER in result
-
-
-@pytest.mark.asyncio
-async def test_resolve_group_sms_routing_live_mixed_group(quo_client: httpx.AsyncClient):
-    """Live routing resolution for the Emilio + TestSana group: Emilio is
-    internal, TestSana (company 'Test2') is external → mixed group, routed to
-    the shared team line with has_external=True (HITL at the tool level).
-    No SMS is sent — this only exercises contact resolution."""
-    from api.src.sernia_ai.config import QUO_SHARED_EXTERNAL_PHONE_ID
+async def test_resolve_group_sms_routing_live_all_internal(quo_client: httpx.AsyncClient):
+    """Live routing resolution for the Emilio + TestSana group: both are
+    internal (Sernia Capital LLC) since 2026-08-14 → all-internal group on
+    the AI line, no approval. No SMS is sent — contact resolution only."""
+    from api.src.sernia_ai.config import QUO_SERNIA_AI_PHONE_ID
     from api.src.sernia_ai.tools.quo_tools import (
         GroupSmsRouting,
         resolve_group_sms_routing,
@@ -749,10 +713,46 @@ async def test_resolve_group_sms_routing_live_mixed_group(quo_client: httpx.Asyn
 
     result = await resolve_group_sms_routing([INTERNAL_TEST_NUMBER, TESTSANA_NUMBER], quo_client)
     assert isinstance(result, GroupSmsRouting), result
-    assert result.is_mixed is True
-    assert result.has_external is True
-    assert result.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
+    assert result.all_internal is True, (
+        "Expected Emilio + TestSana to both be internal — was the TestSana "
+        f"contact's company changed? Got: {result}"
+    )
+    assert result.from_phone_id == QUO_SERNIA_AI_PHONE_ID
     print(f"\nGroup routing: names={result.recipient_names}, line={result.line_name}")
+
+
+@pytest.mark.asyncio
+async def test_send_group_sms_live_emilio_and_sana(quo_client: httpx.AsyncClient):
+    """Send a real group text to Emilio + TestSana through execute_sms.
+
+    Both numbers are internal contacts (Emilio's own devices), so this is a
+    live INTERNAL send — allowed by SMS test safety. Routing is resolved
+    live first; the test skips rather than sending if the group ever stops
+    resolving as all-internal (e.g. the TestSana contact's company changes).
+    """
+    from api.src.sernia_ai.tools.quo_tools import (
+        GroupSmsRouting,
+        execute_sms,
+        resolve_group_sms_routing,
+    )
+
+    routing = await resolve_group_sms_routing([INTERNAL_TEST_NUMBER, TESTSANA_NUMBER], quo_client)
+    if not isinstance(routing, GroupSmsRouting) or not routing.all_internal:
+        pytest.skip(f"Emilio + TestSana no longer resolve as all-internal: {routing}")
+
+    result = await execute_sms(
+        quo_client,
+        routing.phones,
+        "[QUO GROUP TEST] Group text via execute_sms — Emilio + Sana in one thread. Please ignore.",
+        routing.from_phone_id,
+        routing.line_name,
+        tool_name="test_group_sms",
+    )
+    print(f"\nGroup send result: {result}")
+    assert result.startswith("Group message sent to")
+    assert INTERNAL_TEST_NUMBER in result
+    assert TESTSANA_NUMBER in result
+    assert "Sernia AI" in result
 
 
 @pytest.mark.asyncio

--- a/apps/sernia_mcp/src/sernia_mcp/core/quo/send_sms.py
+++ b/apps/sernia_mcp/src/sernia_mcp/core/quo/send_sms.py
@@ -82,16 +82,19 @@ async def resolve_group_sms_routing_core(phones: list[str]) -> GroupSmsRouting:
     ``GROUP_SMS_MAX_RECIPIENTS`` (10) numbers in ``to`` — the message lands
     in one shared group conversation (verified live 2026-08-13).
 
-    Deterministic gates (raise ``ValidationError`` / ``NotFoundError``):
+    Deterministic gates (raise ``ValidationError`` / ``NotFoundError``) —
+    all of them block before the approval card is even shown:
 
     - 2..GROUP_SMS_MAX_RECIPIENTS unique recipients.
     - Every recipient must be a Quo contact.
     - **Unit isolation**: tenants from different units (per the
       Property / Unit # custom fields) can never share a group thread —
-      they would see each other's phone numbers. Approval cannot override
-      this; it blocks before the approval card is even shown.
+      they would see each other's phone numbers.
+    - **Internal/external separation**: internal team members and external
+      contacts can never be mixed in one group — a mixed group would expose
+      internal numbers to external recipients.
 
-    Line selection: all-internal → AI line; any external → shared team line.
+    Line selection: all-internal → AI line; all-external → shared team line.
     """
     unique_phones = list(dict.fromkeys(phones))
     if len(unique_phones) < 2:
@@ -138,11 +141,21 @@ async def resolve_group_sms_routing_core(phones: list[str]) -> GroupSmsRouting:
         )
 
     all_internal = all(internal_flags)
+
+    # Internal/external separation: hard-block mixed groups deterministically.
+    if not all_internal and any(internal_flags):
+        internal_names = ", ".join(n for n, i in zip(names, internal_flags, strict=True) if i)
+        external_names = ", ".join(n for n, i in zip(names, internal_flags, strict=True) if not i)
+        raise ValidationError(
+            "internal team members and external contacts can never share a "
+            f"group thread (internal: {internal_names}; external: "
+            f"{external_names}); send separate messages instead"
+        )
+
     return GroupSmsRouting(
         phones=unique_phones,
         recipient_names=names,
         all_internal=all_internal,
-        is_mixed=(not all_internal) and any(internal_flags),
         from_phone_id=QUO_SERNIA_AI_PHONE_ID if all_internal else QUO_SHARED_EXTERNAL_PHONE_ID,
         line_name="Sernia AI" if all_internal else "Sernia Capital Team",
     )

--- a/apps/sernia_mcp/src/sernia_mcp/core/types.py
+++ b/apps/sernia_mcp/src/sernia_mcp/core/types.py
@@ -32,16 +32,15 @@ class SmsRouting(BaseModel):
 class GroupSmsRouting(BaseModel):
     """Resolved routing for a group SMS (one shared thread, 2+ recipients).
 
-    All-internal groups send from the AI line; any group containing an
-    external contact sends from the shared team number. ``is_mixed`` flags
-    internal+external groups (internal numbers become visible to external
-    recipients — the approval card is the safeguard).
+    Groups are either all-internal or all-external — mixing internal and
+    external recipients is hard-blocked at resolution time. All-internal
+    groups send from the AI line; all-external groups send from the shared
+    team number.
     """
 
     phones: list[str]  # deduped, original order preserved
     recipient_names: list[str]
     all_internal: bool
-    is_mixed: bool
     from_phone_id: str
     line_name: str
 

--- a/apps/sernia_mcp/src/sernia_mcp/tools/approvals.py
+++ b/apps/sernia_mcp/src/sernia_mcp/tools/approvals.py
@@ -89,12 +89,12 @@ async def quo_send_sms(to_phone: str | list[str], message: str) -> PrefabApp:
     **Group texts**: pass a list of 2-10 phone numbers to start ONE shared
     thread — all recipients see the message and each other's replies (and
     each other's phone numbers). Deterministic gates that approval cannot
-    override: every number must be a Quo contact, and tenants from
+    override: every number must be a Quo contact, internal team members and
+    external contacts can NEVER be mixed in one group, and tenants from
     DIFFERENT units are always blocked from sharing a group thread
-    (roommates in the same unit are fine). A mixed internal+external group
-    exposes internal team numbers to the external recipients — only do
-    this when clearly intended. To message multiple people SEPARATELY
-    (private 1:1 threads), call this tool once per recipient instead.
+    (roommates in the same unit are fine). To message multiple people
+    SEPARATELY (private 1:1 threads), call this tool once per recipient
+    instead.
 
     Args:
         to_phone: Recipient phone in E.164 format (e.g. "+14155550100"),
@@ -138,11 +138,6 @@ async def quo_send_sms(to_phone: str | list[str], message: str) -> PrefabApp:
                 with Column(gap=3):
                     Text(f"**To (one shared thread):** {recipients_label}")
                     Text(f"**Routing:** {audience} line ({group.line_name})")
-                    if group.is_mixed:
-                        Text(
-                            "⚠️ **Mixed group:** internal team numbers will be "
-                            "visible to the external recipients in this thread."
-                        )
                     Heading("Message", level=4)
                     Text(message)
             with CardFooter():

--- a/apps/sernia_mcp/tests/test_quo_group_sms.py
+++ b/apps/sernia_mcp/tests/test_quo_group_sms.py
@@ -118,16 +118,21 @@ class TestResolveGroupRouting:
     async def test_all_internal_uses_ai_line(self):
         routing = await resolve_group_sms_routing_core([INTERNAL_A, INTERNAL_B])
         assert routing.all_internal is True
-        assert routing.is_mixed is False
         assert routing.from_phone_id == QUO_SERNIA_AI_PHONE_ID
         assert routing.line_name == "Sernia AI"
         assert routing.recipient_names == ["Emilio Test", "Anna Test"]
 
     @pytest.mark.asyncio
-    async def test_mixed_group_flagged_uses_shared_line(self):
-        routing = await resolve_group_sms_routing_core([INTERNAL_A, EXTERNAL_A])
+    async def test_mixed_group_blocked(self):
+        """Internal + external in one group is hard-blocked deterministically —
+        a mixed group would expose internal numbers to external recipients."""
+        with pytest.raises(ValidationError, match="never share a group thread"):
+            await resolve_group_sms_routing_core([INTERNAL_A, EXTERNAL_A])
+
+    @pytest.mark.asyncio
+    async def test_all_external_uses_shared_line(self):
+        routing = await resolve_group_sms_routing_core([EXTERNAL_A, TENANT_320_02_A])
         assert routing.all_internal is False
-        assert routing.is_mixed is True
         assert routing.from_phone_id == QUO_SHARED_EXTERNAL_PHONE_ID
 
     @pytest.mark.asyncio
@@ -208,10 +213,9 @@ class TestGroupApprovalFlow:
     @pytest.mark.asyncio
     async def test_group_send_queues_pending_row(self):
         fake_routing = GroupSmsRouting(
-            phones=[INTERNAL_A, EXTERNAL_A],
-            recipient_names=["Emilio Test", "Sana Test"],
+            phones=[TENANT_320_02_A, TENANT_320_02_B],
+            recipient_names=["Aidan Test", "Adeline Test"],
             all_internal=False,
-            is_mixed=True,
             from_phone_id=QUO_SHARED_EXTERNAL_PHONE_ID,
             line_name="Sernia Capital Team",
         )
@@ -223,7 +227,7 @@ class TestGroupApprovalFlow:
         assert len(approvals._PENDING) == 1
         rec = next(iter(approvals._PENDING.values()))
         assert rec["group"] is True
-        assert rec["to_phones"] == [INTERNAL_A, EXTERNAL_A]
+        assert rec["to_phones"] == [TENANT_320_02_A, TENANT_320_02_B]
         assert rec["message"] == "group hello"
 
     @pytest.mark.asyncio
@@ -231,14 +235,14 @@ class TestGroupApprovalFlow:
         approvals._PENDING["gid"] = {
             "type": "sms",
             "group": True,
-            "to_phones": [INTERNAL_A, EXTERNAL_A],
+            "to_phones": [TENANT_320_02_A, TENANT_320_02_B],
             "message": "group hello",
-            "contact_name": "Emilio Test, Sana Test",
+            "contact_name": "Aidan Test, Adeline Test",
             "created_at": time.time(),
         }
         fake = SmsResult(
-            to_phone=f"{INTERNAL_A}, {EXTERNAL_A}",
-            contact_name="Emilio Test, Sana Test",
+            to_phone=f"{TENANT_320_02_A}, {TENANT_320_02_B}",
+            contact_name="Aidan Test, Adeline Test",
             line_name="Sernia Capital Team",
             parts_sent=1,
             message_chars=11,
@@ -251,7 +255,7 @@ class TestGroupApprovalFlow:
             patch("sernia_mcp.tools.approvals.send_sms_core", new=AsyncMock()) as single_send,
         ):
             out = await approvals._confirm_send_sms(pending_id="gid", decision="approve")
-        group_send.assert_awaited_once_with([INTERNAL_A, EXTERNAL_A], "group hello")
+        group_send.assert_awaited_once_with([TENANT_320_02_A, TENANT_320_02_B], "group hello")
         single_send.assert_not_called()
         assert "Group SMS (one shared thread) sent to" in out
 
@@ -260,9 +264,9 @@ class TestGroupApprovalFlow:
         approvals._PENDING["gid"] = {
             "type": "sms",
             "group": True,
-            "to_phones": [INTERNAL_A, EXTERNAL_A],
+            "to_phones": [TENANT_320_02_A, TENANT_320_02_B],
             "message": "group hello",
-            "contact_name": "Emilio Test, Sana Test",
+            "contact_name": "Aidan Test, Adeline Test",
             "created_at": time.time(),
         }
         with patch("sernia_mcp.tools.approvals.send_group_sms_core", new=AsyncMock()) as group_send:


### PR DESCRIPTION
## Description

Follow-up to #296, addressing two issues found in live use:

### 1. Group replies now stay in the group thread

Previously a reply to an all-internal group text (e.g. the Emilio + Sana thread) was answered by the AI in a private 1:1 thread. The AI SMS trigger now detects group messages on the AI line — the webhook's `to` contains recipients besides the AI's own number (resolved via the new process-cached `open_phone.service.get_ai_phone_number()`; unknown → safe 1:1 fallback) — and runs a dedicated `_handle_group_sms` path:

- **Gate**: every human participant (sender + recipients) must be internal; one external/unknown member and the event is silently ignored.
- **Conversation**: keyed to the Quo group conversation (`ai_sms_group_{CN...}`) so all members share one AI conversation, instead of the sender's personal `ai_sms_from_{digits}`.
- **History**: reconstructed from the local `open_phone_events` webhook table (the only source of full group history), with turns prefixed `[Sender Name]:` so the agent can tell members apart. The current message is excluded from reconstruction (it becomes the run's prompt).
- **Reply**: sent to **all** participants in one `to` array — landing in the same group thread. Post-approval replies do the same via the conversation's `trigger_group_participants` metadata.
- `send_sms`'s hidden-context seeding for group sends now targets the same `ai_sms_group_{CN...}` conversation, so the agent has the context when any member replies.

### 2. Mixed internal+external groups are now impossible

On both surfaces (agent `resolve_group_sms_routing` and sernia_mcp `resolve_group_sms_routing_core`), a group containing both internal and external contacts is **hard-blocked deterministically** — approval cannot override. A group is always all-internal (AI line, no approval, group replies) or all-external (shared team number + HITL). The `is_mixed` flag and the approval-card mixed warning are removed; tool descriptions updated on both surfaces.

### Live verification

TestSana is now an internal contact (Sernia Capital LLC), so Emilio + Sana resolves **all-internal**: verified live, and a live group send from the **Sernia AI line** delivered (`Group message sent to +14123703550, +14128770257 from Sernia AI`). Live tests updated: the routing test pins all-internal; the send test resolves live first and skips rather than sending if the group ever stops resolving all-internal.

### Tests

- New `test_ai_sms_group_trigger.py` (17 tests): `to`-field parsing, group participant extraction (incl. the unknown-AI-number fallback), events-table→history conversion (sender prefixes, current-message exclusion, AI turns as assistant turns), group reply recipients, `send_message` group payload.
- Updated group SMS tests on both surfaces for the mixed hard-block (mixed → blocked; internal+tenants → blocked; all-internal / all-external / same-unit still allowed).
- Monorepo: 582 passed (one pre-existing `test_contact_service` event-loop flake); sernia_mcp: 207 passed (4 pre-existing `git_sync_flow` sandbox failures).

Preview: https://react-router-portfolio-pr-297.up.railway.app/

**Required Pre-Merge Check:**
- [ ] Synced Railway environment with Dev/Prod as needed.