### PR TITLE
Fix AI phone number lookup so group SMS detection actually fires

### DIFF
--- a/api/src/open_phone/service.py
+++ b/api/src/open_phone/service.py
@@ -56,11 +56,21 @@ async def get_ai_phone_number() -> str | None:
         ) as client:
             resp = await client.get(f"/v1/phone-numbers/{QUO_SERNIA_AI_PHONE_ID}")
             resp.raise_for_status()
-            phone = resp.json().get("data", {}).get("phoneNumber")
+            data = resp.json().get("data", {})
+            # The API returns the E.164 under ``number`` (NOT ``phoneNumber``
+            # — that wrong key silently broke this lookup and with it group
+            # detection AND the webhook circular-trigger guard until
+            # 2026-08-14). Keep ``phoneNumber`` as a defensive fallback.
+            phone = data.get("number") or data.get("phoneNumber")
             if phone:
                 _ai_phone_number = phone
-                logfire.info("cached AI phone number")
+                logfire.info("cached AI phone number", phone=phone)
                 return _ai_phone_number
+            logfire.warn(
+                "AI phone number lookup returned no number — group SMS "
+                "detection and the circular-trigger guard are degraded",
+                data_keys=sorted(data.keys()),
+            )
     except Exception:
         logfire.exception("failed to look up AI phone number")
     return None

--- a/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
+++ b/api/src/sernia_ai/triggers/ai_sms_event_trigger.py
@@ -906,7 +906,10 @@ async def _handle_group_sms(
             metadata={
                 "trigger_source": "ai_sms_group",
                 "trigger_phone": from_number,
-                "trigger_contact_name": sender_name,
+                # Group label (not the sender's name): the web UI sidebar shows
+                # this as the conversation's participant, and a bare sender
+                # name would make the group thread look like a 1:1.
+                "trigger_contact_name": "Group: " + ", ".join(name_by_phone[p] for p in all_humans),
                 "openphone_conversation_id": quo_conv_id,
                 # Post-approval replies use this to respond into the group
                 # thread instead of 1:1 (see routes.approve_conversation).

--- a/api/src/tests/test_ai_sms_group_trigger.py
+++ b/api/src/tests/test_ai_sms_group_trigger.py
@@ -245,6 +245,81 @@ class TestSendSmsReplyGroup:
 
 
 # ===========================================================================
+# get_ai_phone_number — response parsing + caching
+# ===========================================================================
+
+
+class TestGetAiPhoneNumber:
+    """Regression: the API returns the E.164 under ``data.number`` — the old
+    code read ``data.phoneNumber`` (which doesn't exist), silently returned
+    None on every call, and group detection fell back to 1:1 in production
+    (2026-08-14). Pin the real response shape and the process-level cache."""
+
+    # Trimmed copy of the real GET /v1/phone-numbers/{id} response.
+    REAL_RESPONSE = {
+        "data": {
+            "id": "PNWvNqsFFy",
+            "formattedNumber": "(412) 910-1500",
+            "name": "Sernia AI Intern",
+            "number": "+14129101500",
+            "symbol": "🤖",
+        }
+    }
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self, monkeypatch):
+        from api.src.open_phone import service as op_service
+
+        monkeypatch.setattr(op_service, "_ai_phone_number", None)
+
+    def _patch_httpx(self, monkeypatch, payload: dict, calls: list):
+        import httpx
+
+        from api.src.open_phone import service as op_service
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            return httpx.Response(200, json=payload)
+
+        real_async_client = httpx.AsyncClient
+
+        def fake_async_client(**kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return real_async_client(**kwargs)
+
+        monkeypatch.setattr(op_service.httpx, "AsyncClient", fake_async_client)
+
+    @pytest.mark.asyncio
+    async def test_parses_number_field_from_real_shape(self, monkeypatch):
+        from api.src.open_phone.service import get_ai_phone_number
+
+        calls: list = []
+        self._patch_httpx(monkeypatch, self.REAL_RESPONSE, calls)
+        monkeypatch.setenv("OPEN_PHONE_API_KEY", "test-key")
+        assert await get_ai_phone_number() == "+14129101500"
+
+    @pytest.mark.asyncio
+    async def test_caches_after_first_success(self, monkeypatch):
+        from api.src.open_phone.service import get_ai_phone_number
+
+        calls: list = []
+        self._patch_httpx(monkeypatch, self.REAL_RESPONSE, calls)
+        monkeypatch.setenv("OPEN_PHONE_API_KEY", "test-key")
+        assert await get_ai_phone_number() == "+14129101500"
+        assert await get_ai_phone_number() == "+14129101500"
+        assert len(calls) == 1, "second call must hit the process cache, not the API"
+
+    @pytest.mark.asyncio
+    async def test_missing_number_returns_none_without_caching(self, monkeypatch):
+        from api.src.open_phone.service import get_ai_phone_number
+
+        calls: list = []
+        self._patch_httpx(monkeypatch, {"data": {"id": "PNWvNqsFFy"}}, calls)
+        monkeypatch.setenv("OPEN_PHONE_API_KEY", "test-key")
+        assert await get_ai_phone_number() is None
+
+
+# ===========================================================================
 # send_message — group payload
 # ===========================================================================
 

--- a/apps/web-react-router/app/routes/sernia-chat.tsx
+++ b/apps/web-react-router/app/routes/sernia-chat.tsx
@@ -1888,7 +1888,9 @@ export default function SerniaChatPage() {
         setLoadedMessages(data.messages || []);
         setConversationModality(
           opts?.modality ||
-            (convId.startsWith("ai_sms_from_") ? "sms" : "web_chat"),
+            // ai_sms_from_* = 1:1 AI SMS threads; ai_sms_group_* = group
+            // SMS threads. Both are read-only SMS conversations here.
+            (convId.startsWith("ai_sms_") ? "sms" : "web_chat"),
         );
 
         if (opts?.updateUrl !== false) {


### PR DESCRIPTION
## Description

Follow-up to #297 — production group texts were still being answered in the 1:1 thread. Investigated via prod Logfire traces + the prod `open_phone_events` table:

**Root cause:** `GET /v1/phone-numbers/{id}` returns the E.164 under **`data.number`**, but `get_ai_phone_number()` read `data.phoneNumber` — a key that doesn't exist. The lookup silently returned `None` on every call (traces show it ran on *both* of tonight's test messages at 01:01 and 01:03 UTC, never cached, and logged neither success nor failure), so group detection took its safe unknown-AI-number fallback and handled the group message as a 1:1. The webhook's `to` field itself was fine — the prod event row shows `to_number = "+14128770257,+14129101500"`, exactly what detection needs. The same wrong key predates the group work: the old webhook circular-trigger guard used it too, so that guard has been silently broken all along.

**Fix:**
- Parse `data.number` (keeping `phoneNumber` as a defensive fallback).
- The no-number case now logs a loud warning instead of failing silently, since it degrades both group detection and the circular guard.
- Regression tests pin the real API response shape, the process-level cache (second call must not re-fetch), and the missing-number path.
- **Verified live from this session:** the fixed lookup returns `+14129101500` and caches.

After deploy, a reply in the Emilio + Sana group thread should be answered in-group. Monorepo suite: 588 passed (one pre-existing `test_contact_service` event-loop flake).

Preview: https://react-router-portfolio-pr-298.up.railway.app/

**Required Pre-Merge Check:**
- [x] Synced Railway environment with Dev/Prod as needed.